### PR TITLE
feat: 인증 중복체크 API 3종과 비밀번호 정책 검증 추가

### DIFF
--- a/docs/error-code.md
+++ b/docs/error-code.md
@@ -8,5 +8,5 @@
 
 1. 코드 추가/수정은 시트에서 먼저 반영합니다.
 2. 코드 반영 시 `src/main/java/com/gachi/be/global/code/ErrorCode.java`와 동기화합니다.
-3. PR에는 변경된 코드와 설명(의도/상태코드/메시지), 그리고 반영한 시트 탭(vN/gid)을 함께 남깁니다.
-4. PR 시점의 에러코드 스냅샷은 Error Code Single Source의 버전 탭(vN)에 보관하고, PR 본문에 해당 탭 링크(gid)와 커밋 해시를 기록합니다.
+3. PR에는 변경된 에러코드의 핵심 정보(코드/HTTP 상태코드/의도)를 남기고, 시트 참조는 `에러코드 스냅샷 탭(vN): error-code-vN(gid=<숫자>)` 형식의 링크로 기록합니다.
+4. PR 시점의 에러코드 스냅샷은 버전 탭(`error-code-vN`)에 보관하며, PR 본문에 해당 탭 링크(gid 포함)와 커밋 해시를 기록합니다.

--- a/docs/error-code.md
+++ b/docs/error-code.md
@@ -2,11 +2,11 @@
 
 상세 에러 코드는 아래 Google Sheets를 단일 원본으로 관리합니다.
 
-- Google Sheets: [Error Code Single Source](https://docs.google.com/spreadsheets/d/1sUG_JJsVl6a8nR6k8jO_b7UrIEZzuvQdPB6S2S6fqgo/edit?usp=sharing)
+- Google Sheets: [Error Code Single Source](https://docs.google.com/spreadsheets/d/1sUG_JJsVl6a8nR6k8jO_b7UrIEZzuvQdPB6S2S6fqgo/edit?gid=657937#gid=657937)
 
 ## 운영 원칙
 
 1. 코드 추가/수정은 시트에서 먼저 반영합니다.
 2. 코드 반영 시 `src/main/java/com/gachi/be/global/code/ErrorCode.java`와 동기화합니다.
-3. PR에는 변경된 코드와 설명(의도/상태코드/메시지)을 함께 남깁니다.
-4. PR 시점의 에러코드 스냅샷은 팀 비공개 문서에 보관하고, PR 본문에 커밋 해시를 기록합니다.
+3. PR에는 변경된 코드와 설명(의도/상태코드/메시지), 그리고 반영한 시트 탭(vN/gid)을 함께 남깁니다.
+4. PR 시점의 에러코드 스냅샷은 Error Code Single Source의 버전 탭(vN)에 보관하고, PR 본문에 해당 탭 링크(gid)와 커밋 해시를 기록합니다.

--- a/src/main/java/com/gachi/be/domain/auth/api/controller/AuthController.java
+++ b/src/main/java/com/gachi/be/domain/auth/api/controller/AuthController.java
@@ -1,11 +1,15 @@
 package com.gachi.be.domain.auth.api.controller;
 
+import com.gachi.be.domain.auth.dto.request.CheckEmailRequest;
+import com.gachi.be.domain.auth.dto.request.CheckLoginIdRequest;
+import com.gachi.be.domain.auth.dto.request.CheckPhoneNumberRequest;
 import com.gachi.be.domain.auth.dto.request.EmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.EmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.LoginRequest;
 import com.gachi.be.domain.auth.dto.request.ReissueRequest;
 import com.gachi.be.domain.auth.dto.request.SignupRequest;
 import com.gachi.be.domain.auth.dto.response.AuthTokenResponse;
+import com.gachi.be.domain.auth.dto.response.DuplicateCheckResponse;
 import com.gachi.be.domain.auth.dto.response.EmailSendResponse;
 import com.gachi.be.domain.auth.dto.response.SignupResponse;
 import com.gachi.be.domain.auth.service.AuthService;
@@ -28,6 +32,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/auth")
 public class AuthController {
   private final AuthService authService;
+
+  @PostMapping("/check-login-id")
+  public ApiResponse<DuplicateCheckResponse> checkLoginId(
+      @Valid @RequestBody CheckLoginIdRequest request) {
+    return ApiResponse.success(
+        SuccessCode.AUTH_CHECK_LOGIN_ID_AVAILABLE, authService.checkLoginId(request));
+  }
+
+  @PostMapping("/check-email")
+  public ApiResponse<DuplicateCheckResponse> checkEmail(
+      @Valid @RequestBody CheckEmailRequest request) {
+    return ApiResponse.success(
+        SuccessCode.AUTH_CHECK_EMAIL_AVAILABLE, authService.checkEmail(request));
+  }
+
+  @PostMapping("/check-phone-number")
+  public ApiResponse<DuplicateCheckResponse> checkPhoneNumber(
+      @Valid @RequestBody CheckPhoneNumberRequest request) {
+    return ApiResponse.success(
+        SuccessCode.AUTH_CHECK_PHONE_NUMBER_AVAILABLE, authService.checkPhoneNumber(request));
+  }
 
   @PostMapping("/signup")
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/CheckEmailRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/CheckEmailRequest.java
@@ -1,0 +1,6 @@
+package com.gachi.be.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record CheckEmailRequest(@NotBlank @Email String email) {}

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/CheckLoginIdRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/CheckLoginIdRequest.java
@@ -1,0 +1,9 @@
+package com.gachi.be.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record CheckLoginIdRequest(
+    @NotBlank
+        @Pattern(regexp = "^[a-zA-Z0-9._-]{4,50}$", message = "loginId는 4~50자의 영문/숫자/._-만 허용합니다.")
+        String loginId) {}

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/CheckPhoneNumberRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/CheckPhoneNumberRequest.java
@@ -1,0 +1,8 @@
+package com.gachi.be.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record CheckPhoneNumberRequest(
+    @NotBlank @Pattern(regexp = "^[0-9]{10,11}$", message = "전화번호는 숫자 10~11자리여야 합니다.")
+        String phoneNumber) {}

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/CheckPhoneNumberRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/CheckPhoneNumberRequest.java
@@ -5,7 +5,5 @@ import jakarta.validation.constraints.Pattern;
 
 public record CheckPhoneNumberRequest(
     @NotBlank
-        @Pattern(
-            regexp = "^[0-9]{3}-?[0-9]{3,4}-?[0-9]{4}$",
-            message = "전화번호는 숫자만 입력하거나 하이픈(-)을 포함해 주세요.")
+        @Pattern(regexp = PhoneNumberValidation.REGEXP, message = PhoneNumberValidation.MESSAGE)
         String phoneNumber) {}

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/CheckPhoneNumberRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/CheckPhoneNumberRequest.java
@@ -4,5 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record CheckPhoneNumberRequest(
-    @NotBlank @Pattern(regexp = "^[0-9]{10,11}$", message = "전화번호는 숫자 10~11자리여야 합니다.")
+    @NotBlank
+        @Pattern(
+            regexp = "^[0-9]{3}-?[0-9]{3,4}-?[0-9]{4}$",
+            message = "전화번호는 숫자만 입력하거나 하이픈(-)을 포함해 주세요.")
         String phoneNumber) {}

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/PhoneNumberValidation.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/PhoneNumberValidation.java
@@ -1,0 +1,8 @@
+package com.gachi.be.domain.auth.dto.request;
+
+public final class PhoneNumberValidation {
+  public static final String REGEXP = "^[0-9]{3}-?[0-9]{3,4}-?[0-9]{4}$";
+  public static final String MESSAGE = "전화번호는 숫자만 입력하거나 하이픈(-)을 포함해 주세요.";
+
+  private PhoneNumberValidation() {}
+}

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/SignupRequest.java
@@ -10,7 +10,7 @@ public record SignupRequest(
     @NotBlank @Size(max = 50) String name,
     @NotBlank @Email String email,
     @NotBlank
-        @Pattern(regexp = "^[a-zA-Z0-9._-]{4,50}$", message = "loginId는 4~50자 영문/숫자/._-만 허용됩니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9._-]{4,50}$", message = "loginId는 4~50자의 영문/숫자/._-만 허용합니다.")
         String loginId,
     @NotBlank @Size(min = 8, max = 100) String password,
     @NotBlank String passwordConfirm,

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/SignupRequest.java
@@ -15,8 +15,6 @@ public record SignupRequest(
     @NotBlank @Size(max = 100) String password,
     @NotBlank String passwordConfirm,
     @NotBlank
-        @Pattern(
-            regexp = "^[0-9]{3}-?[0-9]{3,4}-?[0-9]{4}$",
-            message = "전화번호는 숫자만 입력하거나 하이픈(-)을 포함해 주세요.")
+        @Pattern(regexp = PhoneNumberValidation.REGEXP, message = PhoneNumberValidation.MESSAGE)
         String phoneNumber,
     @NotNull Boolean consentAgreed) {}

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/SignupRequest.java
@@ -12,7 +12,7 @@ public record SignupRequest(
     @NotBlank
         @Pattern(regexp = "^[a-zA-Z0-9._-]{4,50}$", message = "loginId는 4~50자의 영문/숫자/._-만 허용합니다.")
         String loginId,
-    @NotBlank @Size(min = 8, max = 100) String password,
+    @NotBlank @Size(max = 100) String password,
     @NotBlank String passwordConfirm,
     @NotBlank @Pattern(regexp = "^[0-9]{10,11}$", message = "전화번호는 숫자 10~11자리여야 합니다.")
         String phoneNumber,

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/SignupRequest.java
@@ -14,6 +14,9 @@ public record SignupRequest(
         String loginId,
     @NotBlank @Size(max = 100) String password,
     @NotBlank String passwordConfirm,
-    @NotBlank @Pattern(regexp = "^[0-9]{10,11}$", message = "전화번호는 숫자 10~11자리여야 합니다.")
+    @NotBlank
+        @Pattern(
+            regexp = "^[0-9]{3}-?[0-9]{3,4}-?[0-9]{4}$",
+            message = "전화번호는 숫자만 입력하거나 하이픈(-)을 포함해 주세요.")
         String phoneNumber,
     @NotNull Boolean consentAgreed) {}

--- a/src/main/java/com/gachi/be/domain/auth/dto/response/DuplicateCheckResponse.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/response/DuplicateCheckResponse.java
@@ -1,0 +1,3 @@
+package com.gachi.be.domain.auth.dto.response;
+
+public record DuplicateCheckResponse(boolean available) {}

--- a/src/main/java/com/gachi/be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/AuthService.java
@@ -1,16 +1,26 @@
 package com.gachi.be.domain.auth.service;
 
+import com.gachi.be.domain.auth.dto.request.CheckEmailRequest;
+import com.gachi.be.domain.auth.dto.request.CheckLoginIdRequest;
+import com.gachi.be.domain.auth.dto.request.CheckPhoneNumberRequest;
 import com.gachi.be.domain.auth.dto.request.EmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.EmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.LoginRequest;
 import com.gachi.be.domain.auth.dto.request.ReissueRequest;
 import com.gachi.be.domain.auth.dto.request.SignupRequest;
 import com.gachi.be.domain.auth.dto.response.AuthTokenResponse;
+import com.gachi.be.domain.auth.dto.response.DuplicateCheckResponse;
 import com.gachi.be.domain.auth.dto.response.EmailSendResponse;
 import com.gachi.be.domain.auth.dto.response.SignupResponse;
 
 /** 인증 유스케이스 진입점. */
 public interface AuthService {
+  DuplicateCheckResponse checkLoginId(CheckLoginIdRequest request);
+
+  DuplicateCheckResponse checkEmail(CheckEmailRequest request);
+
+  DuplicateCheckResponse checkPhoneNumber(CheckPhoneNumberRequest request);
+
   SignupResponse signup(SignupRequest request);
 
   AuthTokenResponse login(LoginRequest request, String deviceInfo, String ipAddress);

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -356,15 +356,16 @@ public class AuthServiceImpl implements AuthService {
   }
 
   private boolean containsIgnoreCase(String password, String token) {
+    String normalizedPassword = normalizeText(password).toLowerCase(Locale.ROOT);
     String normalizedToken = normalizeText(token).toLowerCase(Locale.ROOT);
     if (normalizedToken.length() >= PASSWORD_IDENTIFIER_MIN_LENGTH
-        && password.contains(normalizedToken)) {
+        && normalizedPassword.contains(normalizedToken)) {
       return true;
     }
 
     // '_' '.' '-' 같은 구분자를 제거한 정규형도 비교해서 식별자 우회를 막는다.
     String canonicalToken = canonicalizePasswordToken(normalizedToken);
-    String canonicalPassword = canonicalizePasswordToken(password);
+    String canonicalPassword = canonicalizePasswordToken(normalizedPassword);
     return canonicalToken.length() >= PASSWORD_IDENTIFIER_MIN_LENGTH
         && canonicalPassword.contains(canonicalToken);
   }

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -57,6 +57,7 @@ public class AuthServiceImpl implements AuthService {
   private static final Pattern PASSWORD_SPECIAL_PATTERN = Pattern.compile("[\\p{P}\\p{S}]");
   private static final Pattern PASSWORD_REPEAT_PATTERN = Pattern.compile("(.)\\1{2,}");
   private static final Pattern PASSWORD_CANONICAL_PATTERN = Pattern.compile("[^a-z0-9]");
+  private static final Pattern PASSWORD_NON_DIGIT_PATTERN = Pattern.compile("[^0-9]");
 
   private final UserRepository userRepository;
   private final AuthRefreshTokenRepository authRefreshTokenRepository;
@@ -374,6 +375,8 @@ public class AuthServiceImpl implements AuthService {
 
   private boolean containsPhoneChunk(String password, String phoneNumber) {
     String normalizedPhone = normalizePhone(phoneNumber);
+    // 원문 비밀번호는 구분자 삽입으로 우회 가능하므로 숫자만 추출해서 비교한다.
+    String digitOnlyPassword = extractDigits(password);
     if (normalizedPhone.length() < PASSWORD_MIN_PHONE_CHUNK_LENGTH) {
       return false;
     }
@@ -381,11 +384,15 @@ public class AuthServiceImpl implements AuthService {
         start <= normalizedPhone.length() - PASSWORD_MIN_PHONE_CHUNK_LENGTH;
         start++) {
       String chunk = normalizedPhone.substring(start, start + PASSWORD_MIN_PHONE_CHUNK_LENGTH);
-      if (password.contains(chunk)) {
+      if (digitOnlyPassword.contains(chunk)) {
         return true;
       }
     }
     return false;
+  }
+
+  private String extractDigits(String value) {
+    return PASSWORD_NON_DIGIT_PATTERN.matcher(value).replaceAll("");
   }
 
   private boolean containsSequentialPattern(String password) {

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -49,12 +49,14 @@ public class AuthServiceImpl implements AuthService {
   private static final int PASSWORD_MIN_LENGTH = 8;
   private static final int PASSWORD_MAX_LENGTH = 20;
   private static final int PASSWORD_MIN_COMPOSITION = 2;
+  private static final int PASSWORD_IDENTIFIER_MIN_LENGTH = 3;
   private static final int PASSWORD_MIN_PHONE_CHUNK_LENGTH = 4;
   private static final int PASSWORD_SEQUENCE_LIMIT = 4;
   private static final Pattern PASSWORD_LETTER_PATTERN = Pattern.compile("[A-Za-z]");
   private static final Pattern PASSWORD_DIGIT_PATTERN = Pattern.compile("[0-9]");
-  private static final Pattern PASSWORD_SPECIAL_PATTERN = Pattern.compile("[^A-Za-z0-9]");
+  private static final Pattern PASSWORD_SPECIAL_PATTERN = Pattern.compile("[\\p{P}\\p{S}]");
   private static final Pattern PASSWORD_REPEAT_PATTERN = Pattern.compile("(.)\\1{2,}");
+  private static final Pattern PASSWORD_CANONICAL_PATTERN = Pattern.compile("[^a-z0-9]");
 
   private final UserRepository userRepository;
   private final AuthRefreshTokenRepository authRefreshTokenRepository;
@@ -354,7 +356,20 @@ public class AuthServiceImpl implements AuthService {
 
   private boolean containsIgnoreCase(String password, String token) {
     String normalizedToken = normalizeText(token).toLowerCase(Locale.ROOT);
-    return normalizedToken.length() >= 3 && password.contains(normalizedToken);
+    if (normalizedToken.length() >= PASSWORD_IDENTIFIER_MIN_LENGTH
+        && password.contains(normalizedToken)) {
+      return true;
+    }
+
+    // '_' '.' '-' 같은 구분자를 제거한 정규형도 비교해서 식별자 우회를 막는다.
+    String canonicalToken = canonicalizePasswordToken(normalizedToken);
+    String canonicalPassword = canonicalizePasswordToken(password);
+    return canonicalToken.length() >= PASSWORD_IDENTIFIER_MIN_LENGTH
+        && canonicalPassword.contains(canonicalToken);
+  }
+
+  private String canonicalizePasswordToken(String value) {
+    return PASSWORD_CANONICAL_PATTERN.matcher(value).replaceAll("");
   }
 
   private boolean containsPhoneChunk(String password, String phoneNumber) {

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -1,12 +1,16 @@
 package com.gachi.be.domain.auth.service.impl;
 
 import com.gachi.be.domain.auth.config.AuthProperties;
+import com.gachi.be.domain.auth.dto.request.CheckEmailRequest;
+import com.gachi.be.domain.auth.dto.request.CheckLoginIdRequest;
+import com.gachi.be.domain.auth.dto.request.CheckPhoneNumberRequest;
 import com.gachi.be.domain.auth.dto.request.EmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.EmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.LoginRequest;
 import com.gachi.be.domain.auth.dto.request.ReissueRequest;
 import com.gachi.be.domain.auth.dto.request.SignupRequest;
 import com.gachi.be.domain.auth.dto.response.AuthTokenResponse;
+import com.gachi.be.domain.auth.dto.response.DuplicateCheckResponse;
 import com.gachi.be.domain.auth.dto.response.EmailSendResponse;
 import com.gachi.be.domain.auth.dto.response.SignupResponse;
 import com.gachi.be.domain.auth.entity.AuthRefreshToken;
@@ -26,6 +30,7 @@ import com.gachi.be.global.exception.ExternalApiException;
 import java.time.OffsetDateTime;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -41,6 +46,16 @@ import org.springframework.util.StringUtils;
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
+  private static final int PASSWORD_MIN_LENGTH = 8;
+  private static final int PASSWORD_MAX_LENGTH = 20;
+  private static final int PASSWORD_MIN_COMPOSITION = 2;
+  private static final int PASSWORD_MIN_PHONE_CHUNK_LENGTH = 4;
+  private static final int PASSWORD_SEQUENCE_LIMIT = 4;
+  private static final Pattern PASSWORD_LETTER_PATTERN = Pattern.compile("[A-Za-z]");
+  private static final Pattern PASSWORD_DIGIT_PATTERN = Pattern.compile("[0-9]");
+  private static final Pattern PASSWORD_SPECIAL_PATTERN = Pattern.compile("[^A-Za-z0-9]");
+  private static final Pattern PASSWORD_REPEAT_PATTERN = Pattern.compile("(.)\\1{2,}");
+
   private final UserRepository userRepository;
   private final AuthRefreshTokenRepository authRefreshTokenRepository;
   private final PasswordEncoder passwordEncoder;
@@ -49,6 +64,36 @@ public class AuthServiceImpl implements AuthService {
   private final EmailVerificationStore emailVerificationStore;
   private final AuthMailService authMailService;
   private final AuthProperties authProperties;
+
+  @Override
+  @Transactional(readOnly = true)
+  public DuplicateCheckResponse checkLoginId(CheckLoginIdRequest request) {
+    String loginId = normalizeText(request.loginId());
+    if (userRepository.existsByLoginId(loginId)) {
+      throw new BusinessException(ErrorCode.AUTH_DUPLICATE_LOGIN_ID);
+    }
+    return new DuplicateCheckResponse(true);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public DuplicateCheckResponse checkEmail(CheckEmailRequest request) {
+    String email = normalizeEmail(request.email());
+    if (userRepository.existsByEmail(email)) {
+      throw new BusinessException(ErrorCode.AUTH_DUPLICATE_EMAIL);
+    }
+    return new DuplicateCheckResponse(true);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public DuplicateCheckResponse checkPhoneNumber(CheckPhoneNumberRequest request) {
+    String phoneNumber = normalizePhone(request.phoneNumber());
+    if (userRepository.existsByPhoneNumber(phoneNumber)) {
+      throw new BusinessException(ErrorCode.AUTH_DUPLICATE_PHONE_NUMBER);
+    }
+    return new DuplicateCheckResponse(true);
+  }
 
   @Override
   @Transactional
@@ -61,6 +106,8 @@ public class AuthServiceImpl implements AuthService {
     if (!request.password().equals(request.passwordConfirm())) {
       throw new BusinessException(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
     }
+    // 프론트 실시간 검증을 우회한 요청도 차단하기 위해 서버에서 정책을 강제한다.
+    validatePasswordPolicy(request.password(), loginId, email, phoneNumber);
     if (!Boolean.TRUE.equals(request.consentAgreed())) {
       throw new BusinessException(ErrorCode.AUTH_CONSENT_REQUIRED);
     }
@@ -248,6 +295,110 @@ public class AuthServiceImpl implements AuthService {
   private String mergeNullable(String latest, String fallback) {
     String normalizedLatest = normalizeNullable(latest);
     return StringUtils.hasText(normalizedLatest) ? normalizedLatest : normalizeNullable(fallback);
+  }
+
+  private void validatePasswordPolicy(
+      String password, String loginId, String email, String phoneNumber) {
+    if (password.length() < PASSWORD_MIN_LENGTH || password.length() > PASSWORD_MAX_LENGTH) {
+      throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_LENGTH_INVALID);
+    }
+
+    int compositionCount = 0;
+    if (PASSWORD_LETTER_PATTERN.matcher(password).find()) {
+      compositionCount++;
+    }
+    if (PASSWORD_DIGIT_PATTERN.matcher(password).find()) {
+      compositionCount++;
+    }
+    if (PASSWORD_SPECIAL_PATTERN.matcher(password).find()) {
+      compositionCount++;
+    }
+    if (compositionCount < PASSWORD_MIN_COMPOSITION) {
+      throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_COMPOSITION_INVALID);
+    }
+
+    if (containsForbiddenPattern(password, loginId, email, phoneNumber)) {
+      throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_FORBIDDEN_PATTERN);
+    }
+  }
+
+  private boolean containsForbiddenPattern(
+      String password, String loginId, String email, String phoneNumber) {
+    // 계정 식별자/예측 가능한 문자열이 비밀번호에 포함되는 케이스를 묶어서 차단한다.
+    String normalizedPassword = password.toLowerCase(Locale.ROOT);
+    if (password.chars().anyMatch(Character::isWhitespace)) {
+      return true;
+    }
+    if (PASSWORD_REPEAT_PATTERN.matcher(normalizedPassword).find()) {
+      return true;
+    }
+    if (containsIgnoreCase(normalizedPassword, loginId)) {
+      return true;
+    }
+
+    String emailLocalPart = email;
+    int emailAtIndex = email.indexOf('@');
+    if (emailAtIndex > 0) {
+      emailLocalPart = email.substring(0, emailAtIndex);
+    }
+    if (emailLocalPart.length() >= 3 && containsIgnoreCase(normalizedPassword, emailLocalPart)) {
+      return true;
+    }
+
+    if (containsPhoneChunk(normalizedPassword, phoneNumber)) {
+      return true;
+    }
+
+    return containsSequentialPattern(normalizedPassword);
+  }
+
+  private boolean containsIgnoreCase(String password, String token) {
+    String normalizedToken = normalizeText(token).toLowerCase(Locale.ROOT);
+    return normalizedToken.length() >= 3 && password.contains(normalizedToken);
+  }
+
+  private boolean containsPhoneChunk(String password, String phoneNumber) {
+    String normalizedPhone = normalizePhone(phoneNumber);
+    if (normalizedPhone.length() < PASSWORD_MIN_PHONE_CHUNK_LENGTH) {
+      return false;
+    }
+    for (int start = 0;
+        start <= normalizedPhone.length() - PASSWORD_MIN_PHONE_CHUNK_LENGTH;
+        start++) {
+      String chunk = normalizedPhone.substring(start, start + PASSWORD_MIN_PHONE_CHUNK_LENGTH);
+      if (password.contains(chunk)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean containsSequentialPattern(String password) {
+    int ascending = 1;
+    int descending = 1;
+
+    for (int i = 1; i < password.length(); i++) {
+      char previous = password.charAt(i - 1);
+      char current = password.charAt(i);
+      if (!isSameSequentialGroup(previous, current)) {
+        ascending = 1;
+        descending = 1;
+        continue;
+      }
+
+      int diff = current - previous;
+      ascending = diff == 1 ? ascending + 1 : 1;
+      descending = diff == -1 ? descending + 1 : 1;
+      if (ascending >= PASSWORD_SEQUENCE_LIMIT || descending >= PASSWORD_SEQUENCE_LIMIT) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isSameSequentialGroup(char previous, char current) {
+    return (Character.isDigit(previous) && Character.isDigit(current))
+        || (Character.isLetter(previous) && Character.isLetter(current));
   }
 
   private void consumeVerifiedEmailAfterCommit(String email) {

--- a/src/main/java/com/gachi/be/global/code/ErrorCode.java
+++ b/src/main/java/com/gachi/be/global/code/ErrorCode.java
@@ -77,6 +77,24 @@ public enum ErrorCode {
       "약관 및 개인정보 처리방침 동의가 필요합니다.",
       "회원가입 동의 미체크",
       ErrorLogLevel.WARN),
+  AUTH_PASSWORD_POLICY_LENGTH_INVALID(
+      HttpStatus.BAD_REQUEST,
+      "AUTH4006",
+      "비밀번호 길이 정책을 만족하지 않습니다.",
+      "비밀번호 길이 정책 위반",
+      ErrorLogLevel.WARN),
+  AUTH_PASSWORD_POLICY_COMPOSITION_INVALID(
+      HttpStatus.BAD_REQUEST,
+      "AUTH4007",
+      "비밀번호 문자 조합 정책을 만족하지 않습니다.",
+      "비밀번호 문자 조합 정책 위반",
+      ErrorLogLevel.WARN),
+  AUTH_PASSWORD_POLICY_FORBIDDEN_PATTERN(
+      HttpStatus.BAD_REQUEST,
+      "AUTH4008",
+      "비밀번호 금지 패턴에 해당합니다.",
+      "비밀번호 금지 패턴 정책 위반",
+      ErrorLogLevel.WARN),
   AUTH_REFRESH_TOKEN_INVALID(
       HttpStatus.UNAUTHORIZED,
       "AUTH4012",

--- a/src/main/java/com/gachi/be/global/code/SuccessCode.java
+++ b/src/main/java/com/gachi/be/global/code/SuccessCode.java
@@ -13,7 +13,10 @@ public enum SuccessCode {
   AUTH_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "로그인에 성공하였습니다."),
   AUTH_REISSUE_SUCCESS(HttpStatus.OK, "AUTH2002", "토큰 재발급에 성공하였습니다."),
   AUTH_EMAIL_CODE_SENT(HttpStatus.OK, "AUTH2003", "이메일 인증 코드가 발송되었습니다."),
-  AUTH_EMAIL_VERIFIED(HttpStatus.OK, "AUTH2004", "이메일 인증이 완료되었습니다.");
+  AUTH_EMAIL_VERIFIED(HttpStatus.OK, "AUTH2004", "이메일 인증이 완료되었습니다."),
+  AUTH_CHECK_LOGIN_ID_AVAILABLE(HttpStatus.OK, "AUTH2005", "사용 가능한 아이디입니다."),
+  AUTH_CHECK_EMAIL_AVAILABLE(HttpStatus.OK, "AUTH2006", "사용 가능한 이메일입니다."),
+  AUTH_CHECK_PHONE_NUMBER_AVAILABLE(HttpStatus.OK, "AUTH2007", "사용 가능한 전화번호입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
@@ -269,6 +269,9 @@ class AuthControllerIntegrationTest {
     checkEmail(email)
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value("AUTH4091"));
+    checkEmail("DUP-CHECK@GACHI.COM")
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("AUTH4091"));
     checkPhoneNumber(phoneNumber)
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value("AUTH4093"));
@@ -317,6 +320,27 @@ class AuthControllerIntegrationTest {
   }
 
   @Test
+  void signupRejectsPasswordCompositionPolicyViolationWithOnlyNonAsciiAndDigits() throws Exception {
+    String email = "policy-composition-unicode@gachi.com";
+    sendEmail(email).andExpect(status().isOk());
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+    verifyEmail(email, code).andExpect(status().isOk());
+
+    signup(
+            signupPayload(
+                "policy-composition-unicode",
+                email,
+                "policy_unicode_user",
+                "한글비밀번호2580",
+                "한글비밀번호2580",
+                "01044556677",
+                true))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4007"));
+  }
+
+  @Test
   void signupRejectsPasswordForbiddenPatternPolicyViolation() throws Exception {
     String email = "policy-forbidden@gachi.com";
     sendEmail(email).andExpect(status().isOk());
@@ -329,8 +353,8 @@ class AuthControllerIntegrationTest {
                 "policy-forbidden",
                 email,
                 "forbidden_user",
-                "forbidden_user1!",
-                "forbidden_user1!",
+                "ForbiddenUser1!",
+                "ForbiddenUser1!",
                 "01093456789",
                 true))
         .andExpect(status().isBadRequest())

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
@@ -181,10 +181,7 @@ class AuthControllerIntegrationTest {
     String registeredLoginId = "priority_login";
     String registeredPhoneNumber = "01099998888";
 
-    sendEmail(registeredEmail).andExpect(status().isOk());
-    String code = capturingAuthMailService.getCode(registeredEmail);
-    assertThat(code).isNotBlank();
-    verifyEmail(registeredEmail, code).andExpect(status().isOk());
+    verifyEmailForSignup(registeredEmail);
 
     signup(
             signupPayload(
@@ -257,10 +254,7 @@ class AuthControllerIntegrationTest {
         .andExpect(jsonPath("$.code").value("AUTH2007"))
         .andExpect(jsonPath("$.result.available").value(true));
 
-    sendEmail(email).andExpect(status().isOk());
-    String code = capturingAuthMailService.getCode(email);
-    assertThat(code).isNotBlank();
-    verifyEmail(email, code).andExpect(status().isOk());
+    verifyEmailForSignup(email);
 
     signup(
             signupPayload(
@@ -287,10 +281,7 @@ class AuthControllerIntegrationTest {
   @Test
   void signupRejectsPasswordLengthPolicyViolation() throws Exception {
     String email = "policy-length@gachi.com";
-    sendEmail(email).andExpect(status().isOk());
-    String code = capturingAuthMailService.getCode(email);
-    assertThat(code).isNotBlank();
-    verifyEmail(email, code).andExpect(status().isOk());
+    verifyEmailForSignup(email);
 
     signup(
             signupPayload(
@@ -308,10 +299,7 @@ class AuthControllerIntegrationTest {
   @Test
   void signupRejectsPasswordLengthPolicyViolationWhenTooShort() throws Exception {
     String email = "policy-length-short@gachi.com";
-    sendEmail(email).andExpect(status().isOk());
-    String code = capturingAuthMailService.getCode(email);
-    assertThat(code).isNotBlank();
-    verifyEmail(email, code).andExpect(status().isOk());
+    verifyEmailForSignup(email);
 
     signup(
             signupPayload(
@@ -329,10 +317,7 @@ class AuthControllerIntegrationTest {
   @Test
   void signupRejectsPasswordCompositionPolicyViolation() throws Exception {
     String email = "policy-composition@gachi.com";
-    sendEmail(email).andExpect(status().isOk());
-    String code = capturingAuthMailService.getCode(email);
-    assertThat(code).isNotBlank();
-    verifyEmail(email, code).andExpect(status().isOk());
+    verifyEmailForSignup(email);
 
     signup(
             signupPayload(
@@ -350,10 +335,7 @@ class AuthControllerIntegrationTest {
   @Test
   void signupRejectsPasswordCompositionPolicyViolationWithOnlyNonAsciiAndDigits() throws Exception {
     String email = "policy-composition-unicode@gachi.com";
-    sendEmail(email).andExpect(status().isOk());
-    String code = capturingAuthMailService.getCode(email);
-    assertThat(code).isNotBlank();
-    verifyEmail(email, code).andExpect(status().isOk());
+    verifyEmailForSignup(email);
 
     signup(
             signupPayload(
@@ -371,10 +353,7 @@ class AuthControllerIntegrationTest {
   @Test
   void signupRejectsPasswordForbiddenPatternPolicyViolation() throws Exception {
     String email = "policy-forbidden@gachi.com";
-    sendEmail(email).andExpect(status().isOk());
-    String code = capturingAuthMailService.getCode(email);
-    assertThat(code).isNotBlank();
-    verifyEmail(email, code).andExpect(status().isOk());
+    verifyEmailForSignup(email);
 
     signup(
             signupPayload(
@@ -393,10 +372,7 @@ class AuthControllerIntegrationTest {
   void signupRejectsPasswordForbiddenPatternPolicyViolationByPhoneChunkWithSeparators()
       throws Exception {
     String email = "policy-forbidden-phone@gachi.com";
-    sendEmail(email).andExpect(status().isOk());
-    String code = capturingAuthMailService.getCode(email);
-    assertThat(code).isNotBlank();
-    verifyEmail(email, code).andExpect(status().isOk());
+    verifyEmailForSignup(email);
 
     signup(
             signupPayload(
@@ -414,10 +390,7 @@ class AuthControllerIntegrationTest {
   @Test
   void signupRejectsPasswordForbiddenPatternPolicyViolationByRepeatedCharacters() throws Exception {
     String email = "policy-forbidden-repeat@gachi.com";
-    sendEmail(email).andExpect(status().isOk());
-    String code = capturingAuthMailService.getCode(email);
-    assertThat(code).isNotBlank();
-    verifyEmail(email, code).andExpect(status().isOk());
+    verifyEmailForSignup(email);
 
     signup(
             signupPayload(
@@ -436,10 +409,7 @@ class AuthControllerIntegrationTest {
   void signupRejectsPasswordForbiddenPatternPolicyViolationBySequentialCharacters()
       throws Exception {
     String email = "policy-forbidden-sequence@gachi.com";
-    sendEmail(email).andExpect(status().isOk());
-    String code = capturingAuthMailService.getCode(email);
-    assertThat(code).isNotBlank();
-    verifyEmail(email, code).andExpect(status().isOk());
+    verifyEmailForSignup(email);
 
     signup(
             signupPayload(
@@ -474,6 +444,13 @@ class AuthControllerIntegrationTest {
       throws Exception {
     return mockMvc.perform(
         post("/api/v1/auth/signup").contentType(MediaType.APPLICATION_JSON).content(payload));
+  }
+
+  private void verifyEmailForSignup(String email) throws Exception {
+    sendEmail(email).andExpect(status().isOk());
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+    verifyEmail(email, code).andExpect(status().isOk());
   }
 
   private org.springframework.test.web.servlet.ResultActions checkLoginId(String loginId)

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
@@ -361,6 +361,71 @@ class AuthControllerIntegrationTest {
         .andExpect(jsonPath("$.code").value("AUTH4008"));
   }
 
+  @Test
+  void signupRejectsPasswordForbiddenPatternPolicyViolationByPhoneChunkWithSeparators()
+      throws Exception {
+    String email = "policy-forbidden-phone@gachi.com";
+    sendEmail(email).andExpect(status().isOk());
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+    verifyEmail(email, code).andExpect(status().isOk());
+
+    signup(
+            signupPayload(
+                "policy-forbidden-phone",
+                email,
+                "phone_guard_user",
+                "Aa!010-9345-z",
+                "Aa!010-9345-z",
+                "01093456789",
+                true))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4008"));
+  }
+
+  @Test
+  void signupRejectsPasswordForbiddenPatternPolicyViolationByRepeatedCharacters() throws Exception {
+    String email = "policy-forbidden-repeat@gachi.com";
+    sendEmail(email).andExpect(status().isOk());
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+    verifyEmail(email, code).andExpect(status().isOk());
+
+    signup(
+            signupPayload(
+                "policy-forbidden-repeat",
+                email,
+                "repeat_guard_user",
+                "Aaa!2580",
+                "Aaa!2580",
+                "01055667788",
+                true))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4008"));
+  }
+
+  @Test
+  void signupRejectsPasswordForbiddenPatternPolicyViolationBySequentialCharacters()
+      throws Exception {
+    String email = "policy-forbidden-sequence@gachi.com";
+    sendEmail(email).andExpect(status().isOk());
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+    verifyEmail(email, code).andExpect(status().isOk());
+
+    signup(
+            signupPayload(
+                "policy-forbidden-sequence",
+                email,
+                "sequence_guard_user",
+                "Abcd!258",
+                "Abcd!258",
+                "01099887766",
+                true))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4008"));
+  }
+
   private org.springframework.test.web.servlet.ResultActions sendEmail(String email)
       throws Exception {
     return mockMvc.perform(

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
@@ -299,6 +299,27 @@ class AuthControllerIntegrationTest {
   }
 
   @Test
+  void signupRejectsPasswordLengthPolicyViolationWhenTooShort() throws Exception {
+    String email = "policy-length-short@gachi.com";
+    sendEmail(email).andExpect(status().isOk());
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+    verifyEmail(email, code).andExpect(status().isOk());
+
+    signup(
+            signupPayload(
+                "policy-length-short",
+                email,
+                "policy_length_short_user",
+                "Aa1!234",
+                "Aa1!234",
+                "01071231111",
+                true))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4006"));
+  }
+
+  @Test
   void signupRejectsPasswordCompositionPolicyViolation() throws Exception {
     String email = "policy-composition@gachi.com";
     sendEmail(email).andExpect(status().isOk());

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
@@ -252,6 +252,10 @@ class AuthControllerIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.code").value("AUTH2007"))
         .andExpect(jsonPath("$.result.available").value(true));
+    checkPhoneNumber("010-6666-7777")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("AUTH2007"))
+        .andExpect(jsonPath("$.result.available").value(true));
 
     sendEmail(email).andExpect(status().isOk());
     String code = capturingAuthMailService.getCode(email);
@@ -273,6 +277,9 @@ class AuthControllerIntegrationTest {
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value("AUTH4091"));
     checkPhoneNumber(phoneNumber)
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("AUTH4093"));
+    checkPhoneNumber("010-6666-7777")
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value("AUTH4093"));
   }

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
@@ -234,6 +234,109 @@ class AuthControllerIntegrationTest {
         .andExpect(jsonPath("$.code").value("AUTH4093"));
   }
 
+  @Test
+  void duplicateCheckApisAvailableAndDuplicate() throws Exception {
+    String email = "dup-check@gachi.com";
+    String loginId = "dup_check_user";
+    String phoneNumber = "01066667777";
+
+    checkLoginId(loginId)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("AUTH2005"))
+        .andExpect(jsonPath("$.result.available").value(true));
+    checkEmail(email)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("AUTH2006"))
+        .andExpect(jsonPath("$.result.available").value(true));
+    checkPhoneNumber(phoneNumber)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("AUTH2007"))
+        .andExpect(jsonPath("$.result.available").value(true));
+
+    sendEmail(email).andExpect(status().isOk());
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+    verifyEmail(email, code).andExpect(status().isOk());
+
+    signup(
+            signupPayload(
+                "dup-check-user", email, loginId, "Policy12!", "Policy12!", phoneNumber, true))
+        .andExpect(status().isCreated());
+
+    checkLoginId(loginId)
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("AUTH4092"));
+    checkEmail(email)
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("AUTH4091"));
+    checkPhoneNumber(phoneNumber)
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("AUTH4093"));
+  }
+
+  @Test
+  void signupRejectsPasswordLengthPolicyViolation() throws Exception {
+    String email = "policy-length@gachi.com";
+    sendEmail(email).andExpect(status().isOk());
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+    verifyEmail(email, code).andExpect(status().isOk());
+
+    signup(
+            signupPayload(
+                "policy-length",
+                email,
+                "policy_length_user",
+                "TooLongPassword1234567!",
+                "TooLongPassword1234567!",
+                "01071234567",
+                true))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4006"));
+  }
+
+  @Test
+  void signupRejectsPasswordCompositionPolicyViolation() throws Exception {
+    String email = "policy-composition@gachi.com";
+    sendEmail(email).andExpect(status().isOk());
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+    verifyEmail(email, code).andExpect(status().isOk());
+
+    signup(
+            signupPayload(
+                "policy-composition",
+                email,
+                "policy_composition_user",
+                "onlyletters",
+                "onlyletters",
+                "01082345678",
+                true))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4007"));
+  }
+
+  @Test
+  void signupRejectsPasswordForbiddenPatternPolicyViolation() throws Exception {
+    String email = "policy-forbidden@gachi.com";
+    sendEmail(email).andExpect(status().isOk());
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+    verifyEmail(email, code).andExpect(status().isOk());
+
+    signup(
+            signupPayload(
+                "policy-forbidden",
+                email,
+                "forbidden_user",
+                "forbidden_user1!",
+                "forbidden_user1!",
+                "01093456789",
+                true))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4008"));
+  }
+
   private org.springframework.test.web.servlet.ResultActions sendEmail(String email)
       throws Exception {
     return mockMvc.perform(
@@ -254,6 +357,30 @@ class AuthControllerIntegrationTest {
       throws Exception {
     return mockMvc.perform(
         post("/api/v1/auth/signup").contentType(MediaType.APPLICATION_JSON).content(payload));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions checkLoginId(String loginId)
+      throws Exception {
+    return mockMvc.perform(
+        post("/api/v1/auth/check-login-id")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(Map.of("loginId", loginId))));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions checkEmail(String email)
+      throws Exception {
+    return mockMvc.perform(
+        post("/api/v1/auth/check-email")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(Map.of("email", email))));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions checkPhoneNumber(String phoneNumber)
+      throws Exception {
+    return mockMvc.perform(
+        post("/api/v1/auth/check-phone-number")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(Map.of("phoneNumber", phoneNumber))));
   }
 
   private String signupPayload(


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 회원가입 중복체크 API 3종 추가
    - `POST /api/v1/auth/check-login-id`
    - `POST /api/v1/auth/check-email`
    - `POST /api/v1/auth/check-phone-number`
  - 회원가입 비밀번호 정책 서버 강제 검증 추가
    - 길이(8~20), 문자조합(영문/숫자/특수 중 2종 이상), 금지패턴(식별자 포함/반복/연속문자 등)
  - 통합 테스트 추가
    - 중복체크 정상/중복 케이스
    - 비밀번호 정책 위반 케이스(길이/조합/금지패턴)
  - `docs/error-code.md` 운영 원칙(3, 4번) 수정
    - 시트 탭(vN/gid) 기준 기록 방식으로 정리 
  - ErrorCode 동기화
    - `AUTH4006` (HTTP 400 Bad Request): 비밀번호 길이 정책 위반
    - `AUTH4007` (HTTP 400 Bad Request): 비밀번호 문자 조합 정책 위반
    - `AUTH4008` (HTTP 400 Bad Request): 비밀번호 금지 패턴 위반
  - 에러코드 스냅샷 탭(v2): [error-code-v2(gid=657937)](https://docs.google.com/spreadsheets/d/1sUG_JJsVl6a8nR6k8jO_b7UrIEZzuvQdPB6S2S6fqgo/edit?gid=657937#gid=657937)
  - 커밋 해시: 2bf3102
- 관련 이슈: closes #4 

## 🌿 브랜치 정보

- **Source**: `feat/#4-auth-duplicate-check-password-policy`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

- `./gradlew --no-daemon spotlessCheck` 통과
- `./gradlew --no-daemon test --tests com.gachi.be.domain.auth.api.controller.AuthControllerIntegrationTest` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원가입 전 아이디/이메일/전화번호 중복 확인 API(세 엔드포인트) 추가
  * 중복 가능 여부 반환용 응답 형태 추가

* **기능 개선**
  * 회원가입 비밀번호 정책 강화 — 길이·문자 조합·금지 패턴 검사 및 관련 오류 코드 추가
  * 일부 가입 폼 검증 메시지 문구 수정

* **문서**
  * 에러 코드 문서 버전 관리 방식 및 시트 링크 표기 방식 변경

* **테스트**
  * 중복 확인 및 비밀번호 정책 관련 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->