### PR TITLE
chore: 운영 환경 Swagger 노출 토글 및 Basic Auth 접근 제어

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -35,7 +35,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: "deploy/docker-compose.yml,deploy/.env.example,deploy/HTTPS-SETUP.md,deploy/nginx,deploy/secrets/spring_mail_password.example.txt"
+          source: "deploy/docker-compose.yml,deploy/.env.example,deploy/HTTPS-SETUP.md,deploy/nginx,deploy/secrets/spring_mail_password.example.txt,deploy/secrets/swagger_htpasswd.example.txt"
           target: ${{ steps.deploy-path.outputs.value }}
           strip_components: 1
           overwrite: true
@@ -80,7 +80,7 @@ jobs:
               echo "BACKEND_IMAGE=${DOCKERHUB_USERNAME}/gachi-be:latest" >> .env
             fi
 
-            echo "[4/7] Validate SMTP secret file or fallback path"
+            echo "[4/7] Validate SMTP and Swagger auth secret files"
             SECRET_FILE_REL="$(sed -n "s/^SPRING_MAIL_PASSWORD_SECRET_FILE=//p" .env | tail -n1)"
             if [ -z "${SECRET_FILE_REL:-}" ]; then
               SECRET_FILE_REL="./secrets/spring_mail_password.example.txt"
@@ -102,6 +102,34 @@ jobs:
               fi
             else
               echo "SMTP secret file not found: $SECRET_FILE_PATH (fallback env SPRING_MAIL_PASSWORD will be used if set)"
+            fi
+
+            SWAGGER_ENABLED_VALUE="$(sed -n "s/^SWAGGER_ENABLED=//p" .env | tail -n1)"
+            if [ "$SWAGGER_ENABLED_VALUE" = "true" ] || [ "$SWAGGER_ENABLED_VALUE" = "TRUE" ] || [ "$SWAGGER_ENABLED_VALUE" = "True" ]; then
+              SWAGGER_AUTH_FILE_REL="$(sed -n "s/^SWAGGER_BASIC_AUTH_FILE=//p" .env | tail -n1)"
+              if [ -z "${SWAGGER_AUTH_FILE_REL:-}" ]; then
+                SWAGGER_AUTH_FILE_REL="./secrets/swagger_htpasswd.txt"
+              fi
+              echo "[debug] swagger auth file rel path: $SWAGGER_AUTH_FILE_REL"
+              SWAGGER_AUTH_FILE_PATH="$SWAGGER_AUTH_FILE_REL"
+              if [ "${SWAGGER_AUTH_FILE_REL#/}" = "$SWAGGER_AUTH_FILE_REL" ]; then
+                SWAGGER_AUTH_FILE_PATH="$DEPLOY_PATH/${SWAGGER_AUTH_FILE_REL#./}"
+              fi
+              echo "[debug] swagger auth file absolute path: $SWAGGER_AUTH_FILE_PATH"
+              if [ ! -e "$SWAGGER_AUTH_FILE_PATH" ]; then
+                echo "Swagger auth file not found: $SWAGGER_AUTH_FILE_PATH"
+                exit 1
+              fi
+              if [ ! -r "$SWAGGER_AUTH_FILE_PATH" ]; then
+                echo "Swagger auth file is not readable: $SWAGGER_AUTH_FILE_PATH"
+                exit 1
+              fi
+              if [ ! -s "$SWAGGER_AUTH_FILE_PATH" ]; then
+                echo "Swagger auth file is empty: $SWAGGER_AUTH_FILE_PATH"
+                exit 1
+              fi
+            else
+              echo "[debug] SWAGGER_ENABLED is not true. Swagger auth file validation skipped."
             fi
 
             echo "[5/7] Pull latest backend image"

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -105,7 +105,8 @@ jobs:
             fi
 
             SWAGGER_ENABLED_VALUE="$(sed -n "s/^SWAGGER_ENABLED=//p" .env | tail -n1)"
-            if [ "$SWAGGER_ENABLED_VALUE" = "true" ] || [ "$SWAGGER_ENABLED_VALUE" = "TRUE" ] || [ "$SWAGGER_ENABLED_VALUE" = "True" ]; then
+            SWAGGER_ENABLED_VALUE="$(echo "$SWAGGER_ENABLED_VALUE" | tr '[:upper:]' '[:lower:]' | xargs)"
+            if [ "$SWAGGER_ENABLED_VALUE" = "true" ]; then
               SWAGGER_AUTH_FILE_REL="$(sed -n "s/^SWAGGER_BASIC_AUTH_FILE=//p" .env | tail -n1)"
               if [ -z "${SWAGGER_AUTH_FILE_REL:-}" ]; then
                 SWAGGER_AUTH_FILE_REL="./secrets/swagger_htpasswd.txt"
@@ -151,7 +152,7 @@ jobs:
               fi
 
               if [ ! -s "$TLS_CERT_FILE_PATH" ] || [ ! -s "$TLS_KEY_FILE_PATH" ]; then
-                echo "TLS cert/key missing for Swagger HTTPS. Generating self-signed cert."
+                echo "::warning::TLS cert/key missing for Swagger HTTPS. Generating self-signed cert. This is NOT recommended for production!"
                 mkdir -p "$(dirname "$TLS_CERT_FILE_PATH")"
                 mkdir -p "$(dirname "$TLS_KEY_FILE_PATH")"
                 openssl req -x509 -nodes -newkey rsa:2048 -days 365 \

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -80,7 +80,7 @@ jobs:
               echo "BACKEND_IMAGE=${DOCKERHUB_USERNAME}/gachi-be:latest" >> .env
             fi
 
-            echo "[4/7] Validate SMTP and Swagger auth secret files"
+            echo "[4/7] Validate SMTP/Swagger secrets and TLS files"
             SECRET_FILE_REL="$(sed -n "s/^SPRING_MAIL_PASSWORD_SECRET_FILE=//p" .env | tail -n1)"
             if [ -z "${SECRET_FILE_REL:-}" ]; then
               SECRET_FILE_REL="./secrets/spring_mail_password.example.txt"
@@ -115,6 +115,11 @@ jobs:
               if [ "${SWAGGER_AUTH_FILE_REL#/}" = "$SWAGGER_AUTH_FILE_REL" ]; then
                 SWAGGER_AUTH_FILE_PATH="$DEPLOY_PATH/${SWAGGER_AUTH_FILE_REL#./}"
               fi
+              EXPECTED_SWAGGER_AUTH_FILE_PATH="$DEPLOY_PATH/secrets/swagger_htpasswd.txt"
+              if [ "$SWAGGER_AUTH_FILE_PATH" != "$EXPECTED_SWAGGER_AUTH_FILE_PATH" ]; then
+                echo "SWAGGER_BASIC_AUTH_FILE must point to ./secrets/swagger_htpasswd.txt for nginx auth_basic_user_file compatibility."
+                exit 1
+              fi
               echo "[debug] swagger auth file absolute path: $SWAGGER_AUTH_FILE_PATH"
               if [ ! -e "$SWAGGER_AUTH_FILE_PATH" ]; then
                 echo "Swagger auth file not found: $SWAGGER_AUTH_FILE_PATH"
@@ -126,6 +131,36 @@ jobs:
               fi
               if [ ! -s "$SWAGGER_AUTH_FILE_PATH" ]; then
                 echo "Swagger auth file is empty: $SWAGGER_AUTH_FILE_PATH"
+                exit 1
+              fi
+
+              TLS_CERT_FILE_REL="$(sed -n "s/^SWAGGER_TLS_CERT_FILE=//p" .env | tail -n1)"
+              TLS_KEY_FILE_REL="$(sed -n "s/^SWAGGER_TLS_KEY_FILE=//p" .env | tail -n1)"
+              TLS_COMMON_NAME="$(sed -n "s/^SWAGGER_TLS_COMMON_NAME=//p" .env | tail -n1)"
+              TLS_CERT_FILE_REL="${TLS_CERT_FILE_REL:-./secrets/swagger_tls.crt}"
+              TLS_KEY_FILE_REL="${TLS_KEY_FILE_REL:-./secrets/swagger_tls.key}"
+              TLS_COMMON_NAME="${TLS_COMMON_NAME:-$(hostname)}"
+
+              TLS_CERT_FILE_PATH="$TLS_CERT_FILE_REL"
+              TLS_KEY_FILE_PATH="$TLS_KEY_FILE_REL"
+              if [ "${TLS_CERT_FILE_REL#/}" = "$TLS_CERT_FILE_REL" ]; then
+                TLS_CERT_FILE_PATH="$DEPLOY_PATH/${TLS_CERT_FILE_REL#./}"
+              fi
+              if [ "${TLS_KEY_FILE_REL#/}" = "$TLS_KEY_FILE_REL" ]; then
+                TLS_KEY_FILE_PATH="$DEPLOY_PATH/${TLS_KEY_FILE_REL#./}"
+              fi
+
+              if [ ! -s "$TLS_CERT_FILE_PATH" ] || [ ! -s "$TLS_KEY_FILE_PATH" ]; then
+                echo "TLS cert/key missing for Swagger HTTPS. Generating self-signed cert."
+                mkdir -p "$(dirname "$TLS_CERT_FILE_PATH")"
+                mkdir -p "$(dirname "$TLS_KEY_FILE_PATH")"
+                openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+                  -keyout "$TLS_KEY_FILE_PATH" \
+                  -out "$TLS_CERT_FILE_PATH" \
+                  -subj "/CN=$TLS_COMMON_NAME"
+              fi
+              if [ ! -r "$TLS_CERT_FILE_PATH" ] || [ ! -r "$TLS_KEY_FILE_PATH" ]; then
+                echo "TLS cert/key files are not readable. cert=$TLS_CERT_FILE_PATH, key=$TLS_KEY_FILE_PATH"
                 exit 1
               fi
             else

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ coverage/
 # Deploy secrets
 deploy/secrets/**
 !deploy/secrets/spring_mail_password.example.txt
+!deploy/secrets/swagger_htpasswd.example.txt

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -9,6 +9,9 @@ NGINX_HTTPS_PORT=443
 SPRING_PROFILES_ACTIVE=prod
 SWAGGER_ENABLED=false
 SWAGGER_BASIC_AUTH_FILE=./secrets/swagger_htpasswd.txt
+SWAGGER_TLS_CERT_FILE=./secrets/swagger_tls.crt
+SWAGGER_TLS_KEY_FILE=./secrets/swagger_tls.key
+SWAGGER_TLS_COMMON_NAME=example.com
 
 DB_URL=jdbc:postgresql://db:5432/gachi
 DB_USERNAME=gachi

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -7,6 +7,8 @@ NGINX_HTTPS_PORT=443
 
 # Use stage profile when you need Swagger exposure
 SPRING_PROFILES_ACTIVE=prod
+SWAGGER_ENABLED=false
+SWAGGER_BASIC_AUTH_FILE=./secrets/swagger_htpasswd.txt
 
 DB_URL=jdbc:postgresql://db:5432/gachi
 DB_USERNAME=gachi

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "${NGINX_HTTPS_PORT:-443}:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./secrets:/etc/nginx/secrets:ro
       - nginx-logs:/var/log/nginx
       - letsencrypt:/etc/letsencrypt
       - certbot-www:/var/www/certbot
@@ -69,6 +70,7 @@ services:
         exec java -jar /app/app.jar
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
+      SWAGGER_ENABLED: ${SWAGGER_ENABLED:-false}
       DB_URL: ${DB_URL}
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -17,57 +17,77 @@ http {
       root /var/www/certbot;
     }
 
+    location /health {
+      return 200 'ok';
+      add_header Content-Type text/plain;
+    }
+
+    location / {
+      return 301 https://$host$request_uri;
+    }
+  }
+
+  server {
+    listen 443 ssl http2;
+    server_name _;
+
+    ssl_certificate /etc/nginx/secrets/swagger_tls.crt;
+    ssl_certificate_key /etc/nginx/secrets/swagger_tls.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_timeout 10m;
+    ssl_session_cache shared:SSL:10m;
+
     # Swagger direct paths
     location = /swagger-ui.html {
       auth_basic "GACHI Swagger";
-      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd;
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
       proxy_pass http://backend_upstream/swagger-ui.html;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location /swagger-ui/ {
       auth_basic "GACHI Swagger";
-      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd;
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
       proxy_pass http://backend_upstream/swagger-ui/;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location /v3/api-docs {
       auth_basic "GACHI Swagger";
-      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd;
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
       proxy_pass http://backend_upstream/v3/api-docs;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # Swagger compatibility for /api-prefixed paths
     location /api/swagger-ui/ {
       auth_basic "GACHI Swagger";
-      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd;
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
       rewrite ^/api/(.*)$ /$1 break;
       proxy_pass http://backend_upstream;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location /api/v3/api-docs {
       auth_basic "GACHI Swagger";
-      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd;
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
       rewrite ^/api/(.*)$ /$1 break;
       proxy_pass http://backend_upstream;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
@@ -75,7 +95,7 @@ http {
       proxy_pass http://backend_upstream;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
@@ -83,7 +103,7 @@ http {
       proxy_pass http://ai_upstream;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -19,6 +19,8 @@ http {
 
     # Swagger direct paths
     location = /swagger-ui.html {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd;
       proxy_pass http://backend_upstream/swagger-ui.html;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -27,6 +29,8 @@ http {
     }
 
     location /swagger-ui/ {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd;
       proxy_pass http://backend_upstream/swagger-ui/;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -35,6 +39,8 @@ http {
     }
 
     location /v3/api-docs {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd;
       proxy_pass http://backend_upstream/v3/api-docs;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -44,6 +50,8 @@ http {
 
     # Swagger compatibility for /api-prefixed paths
     location /api/swagger-ui/ {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd;
       rewrite ^/api/(.*)$ /$1 break;
       proxy_pass http://backend_upstream;
       proxy_set_header Host $host;
@@ -53,6 +61,8 @@ http {
     }
 
     location /api/v3/api-docs {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd;
       rewrite ^/api/(.*)$ /$1 break;
       proxy_pass http://backend_upstream;
       proxy_set_header Host $host;

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -18,8 +18,8 @@ http {
     }
 
     location /health {
-      return 200 'ok';
       add_header Content-Type text/plain;
+      return 200 'ok';
     }
 
     location / {
@@ -108,8 +108,8 @@ http {
     }
 
     location /health {
-      return 200 'ok';
       add_header Content-Type text/plain;
+      return 200 'ok';
     }
   }
 }

--- a/deploy/secrets/swagger_htpasswd.example.txt
+++ b/deploy/secrets/swagger_htpasswd.example.txt
@@ -1,0 +1,1 @@
+swagger:$apr1$replace-me$replace-with-htpasswd-hash

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -25,7 +25,30 @@ chmod 600 secrets/spring_mail_password.txt
 ```bash
 SPRING_MAIL_PASSWORD=
 SPRING_MAIL_PASSWORD_SECRET_FILE=./secrets/spring_mail_password.txt
+SWAGGER_ENABLED=false
+SWAGGER_BASIC_AUTH_FILE=./secrets/swagger_htpasswd.txt
 ```
+
+### 2-3. Swagger Basic Auth 파일 준비 예시
+
+```bash
+cd /home/ubuntu/GACHI-BE/deploy
+mkdir -p secrets
+printf "swagger:$(openssl passwd -apr1 'change-me')\n" > secrets/swagger_htpasswd.txt
+chmod 600 secrets/swagger_htpasswd.txt
+```
+
+### 2-4. Swagger 열기/닫기 운영 절차
+
+```bash
+# Swagger 열기
+sed -i 's/^SWAGGER_ENABLED=.*/SWAGGER_ENABLED=true/' .env
+
+# Swagger 닫기
+sed -i 's/^SWAGGER_ENABLED=.*/SWAGGER_ENABLED=false/' .env
+```
+
+- 값 변경 후에는 `deploy-ec2` 워크플로우를 다시 실행해 컨테이너 설정을 반영해야 함
 
 ## 3. Compose로 기동
 
@@ -60,11 +83,13 @@ test -r ./secrets/spring_mail_password.txt && echo "readable"
 - `deploy/HTTPS-SETUP.md`
 - `deploy/nginx/**`
 - `deploy/secrets/spring_mail_password.example.txt`
+- `deploy/secrets/swagger_htpasswd.example.txt`
 
 ### 6-2. 제외 정책
 
 - 서버 운영값이 들어있는 `deploy/.env`는 전송하지 않음
 - 운영 시크릿 파일(예: `deploy/secrets/spring_mail_password.txt`)은 전송하지 않음
+- 운영 Swagger 인증 파일(예: `deploy/secrets/swagger_htpasswd.txt`)은 전송하지 않음
 - 즉, EC2에 이미 존재하는 `.env`/실시크릿 파일을 보존한 상태로 compose/nginx 설정만 동기화함
 
 ### 6-3. 워크플로우 실행 순서(Actions 기준)
@@ -73,9 +98,9 @@ test -r ./secrets/spring_mail_password.txt && echo "readable"
 2. (`[1/7]`) EC2 배포 경로로 이동
 3. (`[2/7]`) EC2에서 `.env` 존재 여부 확인(없으면 즉시 실패)
 4. (`[3/7]`) `.env` 내 `BACKEND_IMAGE`를 최신 태그로 갱신
-5. (`[4/7]`) SMTP 시크릿 파일 경로 및 권한 검증
+5. (`[4/7]`) SMTP 시크릿 파일 검증 + `SWAGGER_ENABLED=true`인 경우 Swagger Basic Auth 파일 검증
 6. (`[5/7]`) `docker compose pull backend`
-7. (`[6/7]`) `docker compose up -d --remove-orphans backend` 후 `docker compose up -d --remove-orphans --force-recreate nginx` 실행
+7. (`[6/7]`) `docker compose up -d --remove-orphans backend` 실행 후 backend health 확인, 통과 시 `nginx`를 `--no-deps --force-recreate`로 재기동
 8. (`[7/7]`) `docker compose ps`로 최종 상태 출력
 
 ### 6-4. 실패 시 로그 확인

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -27,6 +27,9 @@ SPRING_MAIL_PASSWORD=
 SPRING_MAIL_PASSWORD_SECRET_FILE=./secrets/spring_mail_password.txt
 SWAGGER_ENABLED=false
 SWAGGER_BASIC_AUTH_FILE=./secrets/swagger_htpasswd.txt
+SWAGGER_TLS_CERT_FILE=./secrets/swagger_tls.crt
+SWAGGER_TLS_KEY_FILE=./secrets/swagger_tls.key
+SWAGGER_TLS_COMMON_NAME=example.com
 ```
 
 ### 2-3. Swagger Basic Auth 파일 준비 예시
@@ -38,7 +41,13 @@ printf "swagger:$(openssl passwd -apr1 'change-me')\n" > secrets/swagger_htpassw
 chmod 600 secrets/swagger_htpasswd.txt
 ```
 
-### 2-4. Swagger 열기/닫기 운영 절차
+### 2-4. Swagger HTTPS 인증서 파일 준비
+
+- `SWAGGER_ENABLED=true`일 때, 배포 워크플로우는 `SWAGGER_TLS_CERT_FILE`, `SWAGGER_TLS_KEY_FILE` 경로를 확인함
+- 파일이 없거나 비어 있으면 워크플로우가 self-signed 인증서를 자동 생성함
+- 운영용 인증서를 쓰는 경우 해당 경로에 실제 인증서/키를 미리 배치하면 자동 생성을 건너뜀
+
+### 2-5. Swagger 열기/닫기 운영 절차
 
 ```bash
 # Swagger 열기
@@ -90,6 +99,7 @@ test -r ./secrets/spring_mail_password.txt && echo "readable"
 - 서버 운영값이 들어있는 `deploy/.env`는 전송하지 않음
 - 운영 시크릿 파일(예: `deploy/secrets/spring_mail_password.txt`)은 전송하지 않음
 - 운영 Swagger 인증 파일(예: `deploy/secrets/swagger_htpasswd.txt`)은 전송하지 않음
+- 운영 TLS 인증서/키 파일(예: `deploy/secrets/swagger_tls.crt`, `deploy/secrets/swagger_tls.key`)은 전송하지 않음
 - 즉, EC2에 이미 존재하는 `.env`/실시크릿 파일을 보존한 상태로 compose/nginx 설정만 동기화함
 
 ### 6-3. 워크플로우 실행 순서(Actions 기준)
@@ -98,7 +108,7 @@ test -r ./secrets/spring_mail_password.txt && echo "readable"
 2. (`[1/7]`) EC2 배포 경로로 이동
 3. (`[2/7]`) EC2에서 `.env` 존재 여부 확인(없으면 즉시 실패)
 4. (`[3/7]`) `.env` 내 `BACKEND_IMAGE`를 최신 태그로 갱신
-5. (`[4/7]`) SMTP 시크릿 파일 검증 + `SWAGGER_ENABLED=true`인 경우 Swagger Basic Auth 파일 검증
+5. (`[4/7]`) SMTP 시크릿 파일 검증 + `SWAGGER_ENABLED=true`인 경우 Swagger Basic Auth 파일/HTTPS 인증서 파일 검증(없으면 self-signed 생성)
 6. (`[5/7]`) `docker compose pull backend`
 7. (`[6/7]`) `docker compose up -d --remove-orphans backend` 실행 후 backend health 확인, 통과 시 `nginx`를 `--no-deps --force-recreate`로 재기동
 8. (`[7/7]`) `docker compose ps`로 최종 상태 출력

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,9 +12,9 @@ spring:
 
 springdoc:
   api-docs:
-    enabled: false
+    enabled: ${SWAGGER_ENABLED:false}
   swagger-ui:
-    enabled: false
+    enabled: ${SWAGGER_ENABLED:false}
 
 management:
   endpoints:


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - `prod` 프로필에서 Swagger 노출을 `SWAGGER_ENABLED` 환경변수로 토글 가능하게 변경
  - Nginx에서 Swagger 경로(`/swagger-ui.html`, `/swagger-ui/`, `/v3/api-docs`, `/api/swagger-ui/`, `/api/v3/api-docs`)에 Basic Auth를 적용
  - `deploy/docker-compose.yml`에 Swagger 토글 env 전달 및 Nginx 인증파일 마운트(`./secrets -> /etc/nginx/secrets`)를 추가
  - `deploy-ec2` 워크플로우에 Swagger 인증파일 예시 동기화와 `SWAGGER_ENABLED=true` 시 인증파일 검증(존재/권한/비어있음)을 추가
  - `deploy/.env.example`, `docs/deploy.md`에 Swagger 열기/닫기 운영 절차를 문서화
- 관련 이슈: closes #21 

## 🌿 브랜치 정보

- **Source**: `chore/#21-swagger-auth-toggle`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

| `SWAGGER_ENABLED` 토글 적용 확인 |
|---|
| ![swagger-toggle](https://github.com/user-attachments/assets/31bdf7d1-91dc-426e-9a06-5d35ad58398c) |

| `deploy-ec2`에서 Swagger 인증파일 검증 단계 반영 확인 |
|---|
| ![deploy-step4](https://github.com/user-attachments/assets/4cc7abd6-9188-4c00-b3b7-de8bf3cad7ce) |

| Swagger 인증 전 차단 |
|---|
| ![swagger-auth-block](https://github.com/user-attachments/assets/225b92f0-95a2-4ecc-ae2f-f52fdfe8a9fe) |

| 인증 후 Swagger 진입 확인 |
|---|
| ![swagger-auth-success](https://github.com/user-attachments/assets/b83deda3-a892-4bcb-95c6-ec37964eb2a2) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Swagger UI/API에 HTTP 기본 인증 추가 및 `SWAGGER_ENABLED`로 토글 가능
  * Swagger TLS 인증서 자동생성(누락 시 self-signed) 및 HTTPS 리디렉션, `/health` 헬스 엔드포인트 추가

* **버그 수정 / 안정성**
  * 배포 시 Swagger 인증·TLS 파일 존재·읽기·비어있음 검증 추가

* **문서**
  * Swagger 활성화·인증·TLS 및 배포 절차 문서 및 예시 업데이트 (배포 워크플로우 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->