### PR TITLE
chore: deploy-ec2 워크플로우를 SSM 기반으로 전환

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -29,4 +29,4 @@ develop 브랜치에 누적된 변경사항을 main으로 릴리즈 배포합니
 - [ ] 리뷰/체크 통과
 - [ ] main 머지
 - [ ] deploy-ec2 수동 실행 (workflow_dispatch, ref: main)
-- [ ] 배포 검증 완료 (scp-step, ssh-order, compose-ps)
+- [ ] 배포 검증 완료 (ssm-send-step, ssm-order, compose-ps)

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -20,11 +20,11 @@
 
 - GitHub Actions `deploy-ec2` 실행 확인 (`workflow_dispatch`, ref: `main`)
   - 결과:
-  - 스크린샷: ![scp-step]()
+  - 스크린샷: ![ssm-send-step]()
 
 - 원격 배포 순서/재기동 확인
   - 결과:
-  - 스크린샷: ![ssh-order]()
+  - 스크린샷: ![ssm-order]()
 
 - 배포 후 컨테이너 상태 확인
   - 결과:

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -7,10 +7,14 @@ name: Deploy to EC2
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      SSM_EXECUTION_TIMEOUT_SECONDS: "3600"
+      SSM_POLL_INTERVAL_SECONDS: "10"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -29,256 +33,242 @@ jobs:
             echo "value=/home/ubuntu/GACHI-BE/deploy" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Sync deploy folder via SCP
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: "deploy/docker-compose.yml,deploy/.env.example,deploy/HTTPS-SETUP.md,deploy/nginx,deploy/secrets/spring_mail_password.example.txt,deploy/secrets/swagger_htpasswd.example.txt"
-          target: ${{ steps.deploy-path.outputs.value }}
-          strip_components: 1
-          overwrite: true
-
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.2.0
+      - name: Resolve AWS region
+        id: aws-region
         env:
+          AWS_REGION_SECRET: ${{ secrets.AWS_REGION }}
+        run: |
+          RESOLVED_REGION="${AWS_REGION_SECRET:-}"
+          RESOLVED_REGION="${RESOLVED_REGION%$'\r'}"
+          RESOLVED_REGION="$(printf '%s' "$RESOLVED_REGION" | sed 's/[[:space:]]*$//')"
+          if [ -n "$RESOLVED_REGION" ]; then
+            echo "value=$RESOLVED_REGION" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=ap-northeast-2" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve EC2 host fallback
+        id: ec2-host
+        env:
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+        run: |
+          RESOLVED_HOST="${EC2_HOST:-}"
+          RESOLVED_HOST="${RESOLVED_HOST%$'\r'}"
+          RESOLVED_HOST="$(printf '%s' "$RESOLVED_HOST" | sed 's/[[:space:]]*$//')"
+          echo "value=$RESOLVED_HOST" >> "$GITHUB_OUTPUT"
+
+      - name: Validate SSM inputs
+        id: auth-check
+        env:
+          EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
+          AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          EC2_DEPLOY_PATH: ${{ steps.deploy-path.outputs.value }}
-          EC2_HOST: ${{ secrets.EC2_HOST }}
+        run: |
+          set -Eeuo pipefail
+          if [ -z "${EC2_INSTANCE_ID:-}" ]; then
+            echo "::error::EC2_INSTANCE_ID secret is required."
+            exit 1
+          fi
+          if [ -z "${DOCKERHUB_USERNAME:-}" ] || [ -z "${DOCKERHUB_TOKEN:-}" ]; then
+            echo "::error::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN is required."
+            exit 1
+          fi
+          if [ -n "${AWS_OIDC_ROLE_ARN:-}" ]; then
+            echo "auth_mode=oidc" >> "$GITHUB_OUTPUT"
+            echo "has_session_token=false" >> "$GITHUB_OUTPUT"
+          else
+            if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+              echo "::error::Set AWS_OIDC_ROLE_ARN or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY."
+              exit 1
+            fi
+            echo "auth_mode=access_key" >> "$GITHUB_OUTPUT"
+            if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+              echo "has_session_token=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_session_token=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        if: ${{ steps.auth-check.outputs.auth_mode == 'oidc' }}
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          envs: DOCKERHUB_USERNAME,DOCKERHUB_TOKEN,EC2_DEPLOY_PATH,EC2_HOST
-          script_stop: false
-          script: |
-            set -Eeuo pipefail
+          aws-region: ${{ steps.aws-region.outputs.value }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          role-session-name: gachi-be-deploy-ssm
 
-            read_env_value() {
-              local key="$1"
-              local raw
-              raw="$(sed -n "s/^${key}=//p" .env | tail -n1 || true)"
-              printf "%s" "$raw" \
-                | tr -d '\r' \
-                | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/^"//; s/"$//'
-            }
+      - name: Configure AWS credentials (Access key fallback)
+        if: ${{ steps.auth-check.outputs.auth_mode == 'access_key' && steps.auth-check.outputs.has_session_token == 'true' }}
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ steps.aws-region.outputs.value }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
 
-            to_lower() {
-              local value="$1"
-              printf "%s" "$value" | tr '[:upper:]' '[:lower:]'
-            }
+      - name: Configure AWS credentials (Access key fallback without session token)
+        if: ${{ steps.auth-check.outputs.auth_mode == 'access_key' && steps.auth-check.outputs.has_session_token != 'true' }}
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ steps.aws-region.outputs.value }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-            to_abs_path() {
-              local rel_or_abs="$1"
-              local candidate
-              if [ "${rel_or_abs#/}" = "$rel_or_abs" ]; then
-                candidate="$DEPLOY_PATH/${rel_or_abs#./}"
-              else
-                candidate="$rel_or_abs"
-              fi
-              realpath -m "$candidate"
-            }
+      - name: Build SSM command payload
+        id: ssm-payload
+        env:
+          EC2_DEPLOY_PATH: ${{ steps.deploy-path.outputs.value }}
+          EC2_HOST: ${{ steps.ec2-host.outputs.value }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          SCRIPT_PATH="scripts/deploy-ec2.sh"
+          if [ ! -f "$SCRIPT_PATH" ]; then
+            echo "::error::$SCRIPT_PATH not found."
+            exit 1
+          fi
 
-            DEPLOY_PATH="${EC2_DEPLOY_PATH:-/home/ubuntu/GACHI-BE/deploy}"
-            DEPLOY_PATH="$(echo "$DEPLOY_PATH" | xargs)"
+          DEPLOY_BUNDLE_PATH="$RUNNER_TEMP/deploy-sync.tgz"
+          tar -czf "$DEPLOY_BUNDLE_PATH" \
+            deploy/docker-compose.yml \
+            deploy/.env.example \
+            deploy/HTTPS-SETUP.md \
+            deploy/nginx \
+            deploy/secrets/spring_mail_password.example.txt \
+            deploy/secrets/swagger_htpasswd.example.txt
 
-            echo "[1/7] Move to deploy path: $DEPLOY_PATH"
-            if [ ! -d "$DEPLOY_PATH" ]; then
-              echo "Deploy path not found: $DEPLOY_PATH"
-              exit 1
-            fi
-            cd "$DEPLOY_PATH"
-            echo "[debug] host=$(hostname) user=$(whoami) pwd=$(pwd)"
-            ls -al
+          SCRIPT_BASE64="$(base64 -w 0 "$SCRIPT_PATH")"
+          BUNDLE_BASE64="$(base64 -w 0 "$DEPLOY_BUNDLE_PATH")"
+          CHUNK_SIZE=3000
+          COMMANDS_JSON="$(jq -cn '[
+            "rm -f /tmp/deploy-ec2.sh.b64 /tmp/deploy-sync.tgz.b64 /tmp/deploy-ec2.sh /tmp/deploy-sync.tgz"
+          ]')"
 
-            echo "[2/7] Validate server-side .env preservation"
-            if [ ! -f .env ]; then
-              echo ".env not found in $DEPLOY_PATH. Create .env on EC2 before deploy."
-              exit 1
-            fi
+          for ((i=0; i<${#SCRIPT_BASE64}; i+=CHUNK_SIZE)); do
+            CHUNK="${SCRIPT_BASE64:i:CHUNK_SIZE}"
+            COMMANDS_JSON="$(printf '%s' "$COMMANDS_JSON" | jq -c --arg chunk "$CHUNK" '. + [("printf %s " + ($chunk | @sh) + " >> /tmp/deploy-ec2.sh.b64")]')"
+          done
 
-            echo "[3/7] Pin latest backend image tag in .env"
-            if grep -q "^BACKEND_IMAGE=" .env; then
-              sed -i "s|^BACKEND_IMAGE=.*|BACKEND_IMAGE=${DOCKERHUB_USERNAME}/gachi-be:latest|" .env
+          for ((i=0; i<${#BUNDLE_BASE64}; i+=CHUNK_SIZE)); do
+            CHUNK="${BUNDLE_BASE64:i:CHUNK_SIZE}"
+            COMMANDS_JSON="$(printf '%s' "$COMMANDS_JSON" | jq -c --arg chunk "$CHUNK" '. + [("printf %s " + ($chunk | @sh) + " >> /tmp/deploy-sync.tgz.b64")]')"
+          done
+
+          COMMANDS_JSON="$(printf '%s' "$COMMANDS_JSON" | jq -c \
+            --arg deployPath "$EC2_DEPLOY_PATH" \
+            --arg ec2Host "$EC2_HOST" \
+            --arg dockerhubUsername "$DOCKERHUB_USERNAME" \
+            --arg dockerhubToken "$DOCKERHUB_TOKEN" \
+            '. + [
+              (
+                "base64 -d /tmp/deploy-ec2.sh.b64 > /tmp/deploy-ec2.sh" +
+                " && chmod 700 /tmp/deploy-ec2.sh" +
+                " && base64 -d /tmp/deploy-sync.tgz.b64 > /tmp/deploy-sync.tgz" +
+                " && mkdir -p " + ($deployPath | @sh) +
+                " && tar -xzf /tmp/deploy-sync.tgz -C " + ($deployPath | @sh) + " --strip-components=1" +
+                " && bash /tmp/deploy-ec2.sh " + ($deployPath | @sh) + " " + ($ec2Host | @sh) + " " + ($dockerhubUsername | @sh) + " " + ($dockerhubToken | @sh) +
+                "; status=$?; rm -f /tmp/deploy-ec2.sh.b64 /tmp/deploy-sync.tgz.b64 /tmp/deploy-ec2.sh /tmp/deploy-sync.tgz; exit $status"
+              )
+            ]')"
+
+          SSM_PARAMETERS="$(jq -cn \
+            --argjson commands "$COMMANDS_JSON" \
+            --arg executionTimeout "$SSM_EXECUTION_TIMEOUT_SECONDS" \
+            '{commands: $commands, executionTimeout: [$executionTimeout]}')"
+
+          {
+            echo "parameters<<EOF"
+            echo "$SSM_PARAMETERS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send deploy command via SSM
+        id: ssm-send
+        env:
+          AWS_REGION: ${{ steps.aws-region.outputs.value }}
+          EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
+          SSM_PARAMETERS: ${{ steps.ssm-payload.outputs.parameters }}
+        run: |
+          set -Eeuo pipefail
+          COMMAND_ID="$(aws ssm send-command \
+            --region "$AWS_REGION" \
+            --document-name "AWS-RunShellScript" \
+            --instance-ids "$EC2_INSTANCE_ID" \
+            --comment "deploy-ec2 (run=${GITHUB_RUN_ID})" \
+            --max-concurrency "1" \
+            --max-errors "0" \
+            --parameters "$SSM_PARAMETERS" \
+            --query "Command.CommandId" \
+            --output text)"
+
+          if [ -z "$COMMAND_ID" ] || [ "$COMMAND_ID" = "None" ]; then
+            echo "::error::Failed to create SSM command."
+            exit 1
+          fi
+
+          echo "command_id=$COMMAND_ID" >> "$GITHUB_OUTPUT"
+          echo "SSM command created: $COMMAND_ID"
+
+      - name: Wait for SSM command completion
+        env:
+          AWS_REGION: ${{ steps.aws-region.outputs.value }}
+          EC2_INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
+          COMMAND_ID: ${{ steps.ssm-send.outputs.command_id }}
+        run: |
+          set -Eeuo pipefail
+
+          MAX_ATTEMPTS=$(( (SSM_EXECUTION_TIMEOUT_SECONDS + SSM_POLL_INTERVAL_SECONDS - 1) / SSM_POLL_INTERVAL_SECONDS ))
+          STATUS=""
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            STATUS="$(aws ssm get-command-invocation \
+              --region "$AWS_REGION" \
+              --command-id "$COMMAND_ID" \
+              --instance-id "$EC2_INSTANCE_ID" \
+              --query "Status" \
+              --output text 2>/dev/null || true)"
+            if [ -z "$STATUS" ]; then
+              echo "[$attempt/$MAX_ATTEMPTS] status: not-ready"
             else
-              echo "BACKEND_IMAGE=${DOCKERHUB_USERNAME}/gachi-be:latest" >> .env
+              echo "[$attempt/$MAX_ATTEMPTS] status: $STATUS"
             fi
 
-            echo "[4/7] Validate SMTP/Swagger secrets and TLS files"
-            SECRET_FILE_REL="$(read_env_value SPRING_MAIL_PASSWORD_SECRET_FILE)"
-            SECRET_FILE_REL="${SECRET_FILE_REL:-./secrets/spring_mail_password.example.txt}"
-            SECRET_FILE_PATH="$(to_abs_path "$SECRET_FILE_REL")"
-            echo "[debug] secret file rel path: $SECRET_FILE_REL"
-            echo "[debug] secret file absolute path: $SECRET_FILE_PATH"
-            if [ -e "$SECRET_FILE_PATH" ]; then
-              if [ ! -r "$SECRET_FILE_PATH" ]; then
-                echo "SMTP secret file exists but is not readable: $SECRET_FILE_PATH"
-                exit 1
-              fi
-              if [ ! -s "$SECRET_FILE_PATH" ]; then
-                echo "SMTP secret file is empty: $SECRET_FILE_PATH (fallback env SPRING_MAIL_PASSWORD will be used if set)"
-              fi
-            else
-              echo "SMTP secret file not found: $SECRET_FILE_PATH (fallback env SPRING_MAIL_PASSWORD will be used if set)"
-            fi
-
-            SWAGGER_ENABLED_VALUE="$(to_lower "$(read_env_value SWAGGER_ENABLED)")"
-            echo "[debug] SWAGGER_ENABLED normalized value: ${SWAGGER_ENABLED_VALUE:-<empty>}"
-            if [ "$SWAGGER_ENABLED_VALUE" = "true" ]; then
-              SWAGGER_AUTH_FILE_REL="$(read_env_value SWAGGER_BASIC_AUTH_FILE)"
-              SWAGGER_AUTH_FILE_REL="${SWAGGER_AUTH_FILE_REL:-./secrets/swagger_htpasswd.txt}"
-              SWAGGER_AUTH_FILE_PATH="$(to_abs_path "$SWAGGER_AUTH_FILE_REL")"
-              EXPECTED_SWAGGER_AUTH_FILE_PATH="$(realpath -m "$DEPLOY_PATH/secrets/swagger_htpasswd.txt")"
-              if [ "$SWAGGER_AUTH_FILE_PATH" != "$EXPECTED_SWAGGER_AUTH_FILE_PATH" ]; then
-                echo "SWAGGER_BASIC_AUTH_FILE must point to ./secrets/swagger_htpasswd.txt for nginx auth_basic_user_file compatibility."
-                exit 1
-              fi
-              echo "[debug] swagger auth file absolute path: $SWAGGER_AUTH_FILE_PATH"
-              if [ ! -s "$SWAGGER_AUTH_FILE_PATH" ]; then
-                echo "Swagger auth file missing or empty: $SWAGGER_AUTH_FILE_PATH"
-                exit 1
-              fi
-              if [ ! -r "$SWAGGER_AUTH_FILE_PATH" ]; then
-                echo "Swagger auth file is not readable: $SWAGGER_AUTH_FILE_PATH"
-                exit 1
-              fi
-
-              TLS_CERT_FILE_REL="$(read_env_value SWAGGER_TLS_CERT_FILE)"
-              TLS_KEY_FILE_REL="$(read_env_value SWAGGER_TLS_KEY_FILE)"
-              TLS_CERT_FILE_REL="${TLS_CERT_FILE_REL:-./secrets/swagger_tls.crt}"
-              TLS_KEY_FILE_REL="${TLS_KEY_FILE_REL:-./secrets/swagger_tls.key}"
-              TLS_CERT_FILE_PATH="$(to_abs_path "$TLS_CERT_FILE_REL")"
-              TLS_KEY_FILE_PATH="$(to_abs_path "$TLS_KEY_FILE_REL")"
-              EXPECTED_TLS_CERT_FILE_PATH="$(realpath -m "$DEPLOY_PATH/secrets/swagger_tls.crt")"
-              EXPECTED_TLS_KEY_FILE_PATH="$(realpath -m "$DEPLOY_PATH/secrets/swagger_tls.key")"
-              if [ "$TLS_CERT_FILE_PATH" != "$EXPECTED_TLS_CERT_FILE_PATH" ] || [ "$TLS_KEY_FILE_PATH" != "$EXPECTED_TLS_KEY_FILE_PATH" ]; then
-                echo "SWAGGER_TLS_CERT_FILE and SWAGGER_TLS_KEY_FILE must point to ./secrets/swagger_tls.crt and ./secrets/swagger_tls.key."
-                exit 1
-              fi
-
-              SWAGGER_TLS_MODE="$(to_lower "$(read_env_value SWAGGER_TLS_MODE)")"
-              SWAGGER_TLS_MODE="${SWAGGER_TLS_MODE:-letsencrypt_ip}"
-              SWAGGER_TLS_COMMON_NAME="$(read_env_value SWAGGER_TLS_COMMON_NAME)"
-              if [ "$SWAGGER_TLS_MODE" = "letsencrypt_ip" ]; then
-                SWAGGER_TLS_IP="$(read_env_value SWAGGER_TLS_IP)"
-                SWAGGER_TLS_IP="${SWAGGER_TLS_IP:-$EC2_HOST}"
-                SWAGGER_TLS_IP="$(echo "$SWAGGER_TLS_IP" | xargs)"
-                if [ -z "$SWAGGER_TLS_IP" ]; then
-                  echo "SWAGGER_TLS_IP is empty. Set SWAGGER_TLS_IP in .env or EC2_HOST secret."
-                  exit 1
-                fi
-
-                CERTBOT_EMAIL_VALUE="$(read_env_value CERTBOT_EMAIL)"
-
-                if [ ! -s "$TLS_CERT_FILE_PATH" ] || [ ! -s "$TLS_KEY_FILE_PATH" ]; then
-                  BOOTSTRAP_CN="${SWAGGER_TLS_COMMON_NAME:-$SWAGGER_TLS_IP}"
-                  BOOTSTRAP_CN="${BOOTSTRAP_CN:-$(hostname)}"
-                  echo "::warning::Bootstrap self-signed TLS cert is generated to make nginx available for ACME challenge."
-                  mkdir -p "$(dirname "$TLS_CERT_FILE_PATH")"
-                  mkdir -p "$(dirname "$TLS_KEY_FILE_PATH")"
-                  openssl req -x509 -nodes -newkey rsa:2048 -days 7 \
-                    -keyout "$TLS_KEY_FILE_PATH" \
-                    -out "$TLS_CERT_FILE_PATH" \
-                    -subj "/CN=$BOOTSTRAP_CN"
-                  chmod 644 "$TLS_CERT_FILE_PATH"
-                  chmod 600 "$TLS_KEY_FILE_PATH"
-                fi
-
-                echo "[debug] issue/renew Let's Encrypt IP cert for $SWAGGER_TLS_IP"
-                set +e
-                docker compose --env-file .env up -d --no-deps nginx
-                NGINX_UP_EXIT_CODE=$?
-                set -e
-                echo "[debug] nginx up exit code: $NGINX_UP_EXIT_CODE"
-                if [ "$NGINX_UP_EXIT_CODE" -ne 0 ]; then
-                  echo "[error] failed to ensure nginx is running for ACME challenge."
-                  docker compose --env-file .env logs --tail=120 nginx || true
-                  exit "$NGINX_UP_EXIT_CODE"
-                fi
-
-                set +e
-                docker compose --env-file .env --profile tls rm -f certbot >/dev/null 2>&1
-                CERTBOT_RM_EXIT_CODE=$?
-                set -e
-                echo "[debug] certbot rm exit code: $CERTBOT_RM_EXIT_CODE"
-
-                CERTBOT_EXIT_CODE=0
-                if [ -n "${CERTBOT_EMAIL_VALUE:-}" ]; then
-                  set +e
-                  echo "[debug] running certbot certonly with email mode"
-                  docker compose --env-file .env --profile tls run --rm --entrypoint certbot certbot certonly --non-interactive --agree-tos --keep-until-expiring --preferred-profile shortlived --webroot -w /var/www/certbot --cert-name swagger-ip --ip-address "$SWAGGER_TLS_IP" --email "$CERTBOT_EMAIL_VALUE" -v
-                  CERTBOT_EXIT_CODE=$?
-                  set -e
-                else
-                  echo "::warning::CERTBOT_EMAIL is empty. Certificate account will be registered without email."
-                  set +e
-                  echo "[debug] running certbot certonly without email mode"
-                  docker compose --env-file .env --profile tls run --rm --entrypoint certbot certbot certonly --non-interactive --agree-tos --keep-until-expiring --preferred-profile shortlived --webroot -w /var/www/certbot --cert-name swagger-ip --ip-address "$SWAGGER_TLS_IP" --register-unsafely-without-email -v
-                  CERTBOT_EXIT_CODE=$?
-                  set -e
-                fi
-                echo "[debug] certbot certonly exit code: $CERTBOT_EXIT_CODE"
-
-                if [ "$CERTBOT_EXIT_CODE" -ne 0 ]; then
-                  echo "[error] certbot certonly failed (exit=$CERTBOT_EXIT_CODE)."
-                  docker compose --env-file .env logs --tail=120 nginx || true
-                  exit "$CERTBOT_EXIT_CODE"
-                fi
-
-                docker compose --env-file .env --profile tls run --rm --entrypoint /bin/sh certbot -c \
-                  "set -eu; \
-                  cp /etc/letsencrypt/live/swagger-ip/fullchain.pem /workspace/secrets/swagger_tls.crt; \
-                  cp /etc/letsencrypt/live/swagger-ip/privkey.pem /workspace/secrets/swagger_tls.key; \
-                  chmod 644 /workspace/secrets/swagger_tls.crt; \
-                  chmod 600 /workspace/secrets/swagger_tls.key"
-              fi
-
-              if [ ! -s "$TLS_CERT_FILE_PATH" ] || [ ! -s "$TLS_KEY_FILE_PATH" ]; then
-                echo "::warning::TLS cert/key missing for Swagger HTTPS. Generating self-signed cert. This is NOT recommended for production!"
-                mkdir -p "$(dirname "$TLS_CERT_FILE_PATH")"
-                mkdir -p "$(dirname "$TLS_KEY_FILE_PATH")"
-                openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
-                  -keyout "$TLS_KEY_FILE_PATH" \
-                  -out "$TLS_CERT_FILE_PATH" \
-                  -subj "/CN=${SWAGGER_TLS_IP:-$(hostname)}"
-                chmod 644 "$TLS_CERT_FILE_PATH"
-                chmod 600 "$TLS_KEY_FILE_PATH"
-              fi
-
-              if ! docker compose --env-file .env exec -T nginx sh -c "test -r /etc/nginx/secrets/swagger_tls.crt && test -r /etc/nginx/secrets/swagger_tls.key"; then
-                echo "TLS cert/key are not readable from nginx container path."
-                ls -l "$TLS_CERT_FILE_PATH" "$TLS_KEY_FILE_PATH" || true
-                exit 1
-              fi
-            else
-              echo "[debug] SWAGGER_ENABLED is not true. Swagger auth/tls validation skipped."
-            fi
-
-            echo "[5/7] Pull latest backend image"
-            echo "${DOCKERHUB_TOKEN}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
-            docker compose --env-file .env pull backend
-
-            echo "[6/7] Recreate services with synced compose/nginx settings"
-            docker compose --env-file .env up -d --remove-orphans backend
-            BACKEND_HEALTH="starting"
-            for _ in $(seq 1 36); do
-              BACKEND_HEALTH="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' gachi-backend 2>/dev/null || echo "missing")"
-              echo "[debug] backend health: $BACKEND_HEALTH"
-              if [ "$BACKEND_HEALTH" = "healthy" ]; then
+            case "$STATUS" in
+              Success|Failed|TimedOut|Cancelled|Cancelling)
                 break
-              fi
-              sleep 5
-            done
-            if [ "$BACKEND_HEALTH" != "healthy" ]; then
-              echo "backend health check timed out. Check backend logs."
-              docker compose --env-file .env logs --tail=120 backend || true
-              exit 1
-            fi
-            docker compose --env-file .env up -d --remove-orphans --force-recreate --no-deps nginx
+                ;;
+              *)
+                sleep "$SSM_POLL_INTERVAL_SECONDS"
+                ;;
+            esac
+          done
 
-            echo "[7/7] Print deploy status"
-            docker image prune -f
-            docker compose --env-file .env ps
-            docker compose --env-file .env logs --tail=80 backend nginx || true
+          INVOCATION_JSON="$(aws ssm get-command-invocation \
+            --region "$AWS_REGION" \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$EC2_INSTANCE_ID" \
+            --output json)"
+
+          FINAL_STATUS="$(printf '%s' "$INVOCATION_JSON" | jq -r '.Status // "Unknown"')"
+          RESPONSE_CODE="$(printf '%s' "$INVOCATION_JSON" | jq -r '.ResponseCode // -1')"
+          STDERR_CONTENT="$(printf '%s' "$INVOCATION_JSON" | jq -r '.StandardErrorContent // ""')"
+          STDOUT_CONTENT="$(printf '%s' "$INVOCATION_JSON" | jq -r '.StandardOutputContent // ""')"
+
+          echo "::group::SSM stdout"
+          printf '%s\n' "$STDOUT_CONTENT"
+          echo "::endgroup::"
+
+          if [ -n "$STDERR_CONTENT" ]; then
+            echo "::group::SSM stderr"
+            printf '%s\n' "$STDERR_CONTENT"
+            echo "::endgroup::"
+          fi
+
+          if [ "$FINAL_STATUS" != "Success" ]; then
+            echo "::error::SSM command failed. status=$FINAL_STATUS responseCode=$RESPONSE_CODE"
+            exit 1
+          fi

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -66,15 +66,14 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -Eeuo pipefail
           if [ -z "${EC2_INSTANCE_ID:-}" ]; then
             echo "::error::EC2_INSTANCE_ID secret is required."
             exit 1
           fi
-          if [ -z "${DOCKERHUB_USERNAME:-}" ] || [ -z "${DOCKERHUB_TOKEN:-}" ]; then
-            echo "::error::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN is required."
+          if [ -z "${DOCKERHUB_USERNAME:-}" ]; then
+            echo "::error::DOCKERHUB_USERNAME is required."
             exit 1
           fi
           if [ -n "${AWS_OIDC_ROLE_ARN:-}" ]; then
@@ -124,7 +123,6 @@ jobs:
           EC2_DEPLOY_PATH: ${{ steps.deploy-path.outputs.value }}
           EC2_HOST: ${{ steps.ec2-host.outputs.value }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -Eeuo pipefail
           SCRIPT_PATH="scripts/deploy-ec2.sh"
@@ -163,7 +161,6 @@ jobs:
             --arg deployPath "$EC2_DEPLOY_PATH" \
             --arg ec2Host "$EC2_HOST" \
             --arg dockerhubUsername "$DOCKERHUB_USERNAME" \
-            --arg dockerhubToken "$DOCKERHUB_TOKEN" \
             '. + [
               (
                 "base64 -d /tmp/deploy-ec2.sh.b64 > /tmp/deploy-ec2.sh" +
@@ -171,7 +168,7 @@ jobs:
                 " && base64 -d /tmp/deploy-sync.tgz.b64 > /tmp/deploy-sync.tgz" +
                 " && mkdir -p " + ($deployPath | @sh) +
                 " && tar -xzf /tmp/deploy-sync.tgz -C " + ($deployPath | @sh) + " --strip-components=1" +
-                " && bash /tmp/deploy-ec2.sh " + ($deployPath | @sh) + " " + ($ec2Host | @sh) + " " + ($dockerhubUsername | @sh) + " " + ($dockerhubToken | @sh) +
+                " && DOCKERHUB_USERNAME=" + ($dockerhubUsername | @sh) + " bash /tmp/deploy-ec2.sh " + ($deployPath | @sh) + " " + ($ec2Host | @sh) +
                 "; status=$?; rm -f /tmp/deploy-ec2.sh.b64 /tmp/deploy-sync.tgz.b64 /tmp/deploy-ec2.sh /tmp/deploy-sync.tgz; exit $status"
               )
             ]')"
@@ -180,6 +177,13 @@ jobs:
             --argjson commands "$COMMANDS_JSON" \
             --arg executionTimeout "$SSM_EXECUTION_TIMEOUT_SECONDS" \
             '{commands: $commands, executionTimeout: [$executionTimeout]}')"
+
+          PARAM_BYTES="$(printf '%s' "$SSM_PARAMETERS" | wc -c | tr -d ' ')"
+          COMMAND_COUNT="$(printf '%s' "$COMMANDS_JSON" | jq -r 'length')"
+          if [ "$PARAM_BYTES" -gt 900000 ]; then
+            echo "::error::SSM parameters payload too large (${PARAM_BYTES} bytes, commands=${COMMAND_COUNT}). Use smaller deploy bundle or switch to S3 artifact delivery."
+            exit 1
+          fi
 
           {
             echo "parameters<<EOF"
@@ -224,6 +228,7 @@ jobs:
 
           MAX_ATTEMPTS=$(( (SSM_EXECUTION_TIMEOUT_SECONDS + SSM_POLL_INTERVAL_SECONDS - 1) / SSM_POLL_INTERVAL_SECONDS ))
           STATUS=""
+          TERMINAL_REACHED="false"
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
             STATUS="$(aws ssm get-command-invocation \
               --region "$AWS_REGION" \
@@ -239,6 +244,7 @@ jobs:
 
             case "$STATUS" in
               Success|Failed|TimedOut|Cancelled|Cancelling)
+                TERMINAL_REACHED="true"
                 break
                 ;;
               *)
@@ -266,6 +272,11 @@ jobs:
             echo "::group::SSM stderr"
             printf '%s\n' "$STDERR_CONTENT"
             echo "::endgroup::"
+          fi
+
+          if [ "$TERMINAL_REACHED" != "true" ] && [ "$FINAL_STATUS" != "Success" ] && [ "$FINAL_STATUS" != "Failed" ] && [ "$FINAL_STATUS" != "TimedOut" ] && [ "$FINAL_STATUS" != "Cancelled" ] && [ "$FINAL_STATUS" != "Cancelling" ]; then
+            echo "::error::Polling timed out before terminal SSM status. finalStatus=$FINAL_STATUS"
+            exit 1
           fi
 
           if [ "$FINAL_STATUS" != "Success" ]; then

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -126,7 +126,8 @@ test -r ./secrets/spring_mail_password.txt && echo "readable"
 
 ### 6-4. 실패 시 로그 확인
 
-- 배포 스크립트는 실패 시 `docker compose ps`와 `docker compose logs --tail=80 backend nginx`를 출력함
+- 초기 검증 실패는 해당 에러 메시지만 출력될 수 있으며, Docker 단계 이후 실패 시 관련 서비스 로그가 일부 출력됨
+- 성공 시 `[7/7]`에서 `docker compose ps`와 `docker compose logs --tail=80 backend nginx`를 출력함
 - Actions 로그에서 SSM stdout/stderr를 함께 출력해 실패 지점 추적이 가능함
 
 ### 6-5. 필수 시크릿/권한
@@ -139,7 +140,10 @@ test -r ./secrets/spring_mail_password.txt && echo "readable"
   - `AWS_REGION`(선택, 기본 `ap-northeast-2`)
   - `AWS_OIDC_ROLE_ARN`(권장) 또는 `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
 - SSH 비밀키(`EC2_SSH_KEY`)와 SSH 사용자(`EC2_USER`) 없이 deploy 워크플로우가 동작해야 함
-- backend 이미지가 private이면 EC2에 Docker 인증이 사전 구성되어 있어야 함(예: 인스턴스에서 `docker login` 수행 또는 `DOCKERHUB_TOKEN` 환경변수 제공)
+- backend 이미지가 private이면 EC2 Docker 인증이 사전 구성되어 있어야 함
+  - 권장: 인스턴스에서 `docker login`을 미리 수행
+  - 대안: EC2 인스턴스 역할로 SSM Parameter Store SecureString/Secrets Manager에서 토큰을 조회해 `scripts/deploy-ec2.sh` 실행 환경의 `DOCKERHUB_TOKEN`으로 주입
+  - GitHub Secret `DOCKERHUB_TOKEN`은 deploy-ec2 워크플로우가 SSM 명령 본문으로 전달하지 않음
 - 워크플로우 권한 `id-token: write`는 OIDC 우선 경로를 위한 설정이며, Access Key fallback 사용 시에는 토큰이 발급되더라도 사용되지 않음
 - OIDC Role(IAM) 최소 권한:
   - `ssm:SendCommand`

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -122,7 +122,7 @@ test -r ./secrets/spring_mail_password.txt && echo "readable"
    - `SWAGGER_TLS_MODE=letsencrypt_ip`이면 Let’s Encrypt IP 인증서 발급/갱신 및 `./secrets/swagger_tls.*` 동기화 수행
 8. (`[5/7]`) `docker compose pull backend`
 9. (`[6/7]`) `docker compose up -d --remove-orphans backend` 실행 후 backend health 확인, 통과 시 `nginx`를 `--no-deps --force-recreate`로 재기동
-10. (`[7/7]`) `docker compose ps`로 최종 상태 출력
+10. (`[7/7]`) 미사용 이미지 정리(`docker image prune -f`) → `docker compose ps`로 최종 상태 출력 → `docker compose logs --tail=80 backend nginx`로 로그 요약 출력
 
 ### 6-4. 실패 시 로그 확인
 
@@ -134,12 +134,13 @@ test -r ./secrets/spring_mail_password.txt && echo "readable"
 - GitHub Secrets 권장 구성:
   - `EC2_INSTANCE_ID`(필수)
   - `DOCKERHUB_USERNAME`(필수)
-  - `DOCKERHUB_TOKEN`(필수)
   - `EC2_DEPLOY_PATH`(선택, 기본 `/home/ubuntu/GACHI-BE/deploy`)
-  - `EC2_HOST`(선택, `.env`의 `SWAGGER_TLS_IP` fallback 용도)
+  - `EC2_HOST`(조건부 필수: `SWAGGER_ENABLED=true` + `SWAGGER_TLS_MODE=letsencrypt_ip` + `.env`에 `SWAGGER_TLS_IP` 미설정 시)
   - `AWS_REGION`(선택, 기본 `ap-northeast-2`)
   - `AWS_OIDC_ROLE_ARN`(권장) 또는 `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
 - SSH 비밀키(`EC2_SSH_KEY`)와 SSH 사용자(`EC2_USER`) 없이 deploy 워크플로우가 동작해야 함
+- backend 이미지가 private이면 EC2에 Docker 인증이 사전 구성되어 있어야 함(예: 인스턴스에서 `docker login` 수행 또는 `DOCKERHUB_TOKEN` 환경변수 제공)
+- 워크플로우 권한 `id-token: write`는 OIDC 우선 경로를 위한 설정이며, Access Key fallback 사용 시에는 토큰이 발급되더라도 사용되지 않음
 - OIDC Role(IAM) 최소 권한:
   - `ssm:SendCommand`
     - 리소스: `arn:aws:ec2:<region>:<account-id>:instance/<instance-id>`

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -93,7 +93,7 @@ test -r ./secrets/spring_mail_password.txt && echo "readable"
 - 트리거: `main` 브랜치 push 또는 수동 실행(`workflow_dispatch`)
 - 목적: 서버에서 `git pull` 없이 `deploy/` 설정 파일을 EC2에 동기화하고 컨테이너를 재기동
 
-### 6-1. SCP 동기화 대상(화이트리스트)
+### 6-1. 배포 번들 동기화 대상(화이트리스트)
 
 - `deploy/docker-compose.yml`
 - `deploy/.env.example`
@@ -112,20 +112,46 @@ test -r ./secrets/spring_mail_password.txt && echo "readable"
 
 ### 6-3. 워크플로우 실행 순서(Actions 기준)
 
-1. `deploy/` 화이트리스트 파일을 SCP로 EC2 배포 경로에 복사
-2. (`[1/7]`) EC2 배포 경로로 이동
-3. (`[2/7]`) EC2에서 `.env` 존재 여부 확인(없으면 즉시 실패)
-4. (`[3/7]`) `.env` 내 `BACKEND_IMAGE`를 최신 태그로 갱신
-5. (`[4/7]`) SMTP 시크릿 파일 검증 + `SWAGGER_ENABLED=true`인 경우 Swagger Basic Auth 파일/HTTPS 인증서 파일 검증(없으면 self-signed 생성)
+1. GitHub Actions에서 AWS 자격증명 설정(OIDC 우선, Access Key fallback)
+2. `deploy/` 화이트리스트 파일 + `scripts/deploy-ec2.sh`를 번들로 묶어 SSM `AWS-RunShellScript`로 EC2에 전달
+3. EC2에서 번들을 배포 경로에 해제(기존 `.env`/실시크릿 파일은 유지)
+4. (`[1/7]`) EC2 배포 경로로 이동
+5. (`[2/7]`) EC2에서 `.env` 존재 여부 확인(없으면 즉시 실패)
+6. (`[3/7]`) `.env` 내 `BACKEND_IMAGE`를 최신 태그로 갱신
+7. (`[4/7]`) SMTP 시크릿 파일 검증 + `SWAGGER_ENABLED=true`인 경우 Swagger Basic Auth 파일/HTTPS 인증서 파일 검증(없으면 self-signed 생성)
    - `SWAGGER_TLS_MODE=letsencrypt_ip`이면 Let’s Encrypt IP 인증서 발급/갱신 및 `./secrets/swagger_tls.*` 동기화 수행
-6. (`[5/7]`) `docker compose pull backend`
-7. (`[6/7]`) `docker compose up -d --remove-orphans backend` 실행 후 backend health 확인, 통과 시 `nginx`를 `--no-deps --force-recreate`로 재기동
-8. (`[7/7]`) `docker compose ps`로 최종 상태 출력
+8. (`[5/7]`) `docker compose pull backend`
+9. (`[6/7]`) `docker compose up -d --remove-orphans backend` 실행 후 backend health 확인, 통과 시 `nginx`를 `--no-deps --force-recreate`로 재기동
+10. (`[7/7]`) `docker compose ps`로 최종 상태 출력
 
 ### 6-4. 실패 시 로그 확인
 
 - 배포 스크립트는 실패 시 `docker compose ps`와 `docker compose logs --tail=80 backend nginx`를 출력함
-- Actions 로그만으로 실패 지점과 컨테이너 상태를 바로 확인할 수 있음
+- Actions 로그에서 SSM stdout/stderr를 함께 출력해 실패 지점 추적이 가능함
+
+### 6-5. 필수 시크릿/권한
+
+- GitHub Secrets 권장 구성:
+  - `EC2_INSTANCE_ID`(필수)
+  - `DOCKERHUB_USERNAME`(필수)
+  - `DOCKERHUB_TOKEN`(필수)
+  - `EC2_DEPLOY_PATH`(선택, 기본 `/home/ubuntu/GACHI-BE/deploy`)
+  - `EC2_HOST`(선택, `.env`의 `SWAGGER_TLS_IP` fallback 용도)
+  - `AWS_REGION`(선택, 기본 `ap-northeast-2`)
+  - `AWS_OIDC_ROLE_ARN`(권장) 또는 `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
+- SSH 비밀키(`EC2_SSH_KEY`)와 SSH 사용자(`EC2_USER`) 없이 deploy 워크플로우가 동작해야 함
+- OIDC Role(IAM) 최소 권한:
+  - `ssm:SendCommand`
+    - 리소스: `arn:aws:ec2:<region>:<account-id>:instance/<instance-id>`
+    - 리소스: `arn:aws:ssm:<region>::document/AWS-RunShellScript`
+  - `ssm:GetCommandInvocation`
+- 운영 점검/확장 시 선택 권한:
+  - `ssm:ListCommandInvocations`
+  - `ec2:DescribeInstances`
+- SSM 실행/폴링 시간 정렬 확인:
+  - `SSM executionTimeout`: `SSM_EXECUTION_TIMEOUT_SECONDS` (현재 `3600`)
+  - `Actions polling`: `SSM_POLL_INTERVAL_SECONDS` 간격으로 최대 `executionTimeout`까지 조회(현재 `10초 * 360회 ≈ 60분`)
+- 대상 EC2 인스턴스에는 SSM Agent와 `AmazonSSMManagedInstanceCore` 권한이 필요함
 
 ## 7. Swagger IP 인증서 자동 갱신
 

--- a/scripts/deploy-ec2.sh
+++ b/scripts/deploy-ec2.sh
@@ -203,7 +203,7 @@ if [ "$SWAGGER_ENABLED_VALUE" = "true" ]; then
     chmod 600 "$TLS_KEY_FILE_PATH"
   fi
 
-  if ! docker compose --env-file .env exec -T nginx sh -c "test -r /etc/nginx/secrets/swagger_tls.crt && test -r /etc/nginx/secrets/swagger_tls.key"; then
+  if ! docker compose --env-file .env run --rm --no-deps --entrypoint /bin/sh nginx -c "test -r /etc/nginx/secrets/swagger_tls.crt && test -r /etc/nginx/secrets/swagger_tls.key"; then
     echo "TLS cert/key are not readable from nginx container path."
     ls -l "$TLS_CERT_FILE_PATH" "$TLS_KEY_FILE_PATH" || true
     exit 1

--- a/scripts/deploy-ec2.sh
+++ b/scripts/deploy-ec2.sh
@@ -28,16 +28,16 @@ to_abs_path() {
 
 DEPLOY_PATH_INPUT="${1:-${EC2_DEPLOY_PATH:-/home/ubuntu/GACHI-BE/deploy}}"
 EC2_HOST_INPUT="${2:-${EC2_HOST:-}}"
-DOCKERHUB_USERNAME_INPUT="${3:-${DOCKERHUB_USERNAME:-}}"
-DOCKERHUB_TOKEN_INPUT="${4:-${DOCKERHUB_TOKEN:-}}"
+DOCKERHUB_USERNAME_INPUT="${DOCKERHUB_USERNAME:-${3:-}}"
+DOCKERHUB_TOKEN_INPUT="${DOCKERHUB_TOKEN:-}"
 
 DEPLOY_PATH="$(echo "$DEPLOY_PATH_INPUT" | xargs)"
 EC2_HOST_INPUT="$(echo "$EC2_HOST_INPUT" | xargs)"
 DOCKERHUB_USERNAME_INPUT="${DOCKERHUB_USERNAME_INPUT%$'\r'}"
 DOCKERHUB_TOKEN_INPUT="${DOCKERHUB_TOKEN_INPUT%$'\r'}"
 
-if [ -z "$DOCKERHUB_USERNAME_INPUT" ] || [ -z "$DOCKERHUB_TOKEN_INPUT" ]; then
-  echo "DOCKERHUB_USERNAME/DOCKERHUB_TOKEN is required."
+if [ -z "$DOCKERHUB_USERNAME_INPUT" ]; then
+  echo "DOCKERHUB_USERNAME is required."
   exit 1
 fi
 
@@ -131,7 +131,6 @@ if [ "$SWAGGER_ENABLED_VALUE" = "true" ]; then
 
     if [ ! -s "$TLS_CERT_FILE_PATH" ] || [ ! -s "$TLS_KEY_FILE_PATH" ]; then
       BOOTSTRAP_CN="${SWAGGER_TLS_COMMON_NAME:-$SWAGGER_TLS_IP}"
-      BOOTSTRAP_CN="${BOOTSTRAP_CN:-$(hostname)}"
       echo "::warning::Bootstrap self-signed TLS cert is generated to make nginx available for ACME challenge."
       mkdir -p "$(dirname "$TLS_CERT_FILE_PATH")"
       mkdir -p "$(dirname "$TLS_KEY_FILE_PATH")"
@@ -214,14 +213,24 @@ else
 fi
 
 echo "[5/7] Pull latest backend image"
-echo "${DOCKERHUB_TOKEN_INPUT}" | docker login -u "${DOCKERHUB_USERNAME_INPUT}" --password-stdin
+if [ -n "${DOCKERHUB_TOKEN_INPUT:-}" ]; then
+  echo "${DOCKERHUB_TOKEN_INPUT}" | docker login -u "${DOCKERHUB_USERNAME_INPUT}" --password-stdin
+else
+  echo "::warning::DOCKERHUB_TOKEN is empty on instance. Skip docker login and try pull with current daemon credentials."
+fi
 docker compose --env-file .env pull backend
 
 echo "[6/7] Recreate services with synced compose/nginx settings"
 docker compose --env-file .env up -d --remove-orphans backend
 BACKEND_HEALTH="starting"
 for _ in $(seq 1 36); do
-  BACKEND_HEALTH="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' gachi-backend 2>/dev/null || echo "missing")"
+  BACKEND_CID="$(docker compose --env-file .env ps -q backend)"
+  if [ -z "$BACKEND_CID" ]; then
+    echo "backend container not found via compose ps."
+    docker compose --env-file .env ps
+    exit 1
+  fi
+  BACKEND_HEALTH="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$BACKEND_CID" 2>/dev/null || echo "missing")"
   echo "[debug] backend health: $BACKEND_HEALTH"
   if [ "$BACKEND_HEALTH" = "healthy" ]; then
     break

--- a/scripts/deploy-ec2.sh
+++ b/scripts/deploy-ec2.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+read_env_value() {
+  local key="$1"
+  local raw
+  raw="$(sed -n "s/^${key}=//p" .env | tail -n1 || true)"
+  printf "%s" "$raw" \
+    | tr -d '\r' \
+    | sed -E 's/^[[:space:]]+|[[:space:]]+$//g; s/^"//; s/"$//'
+}
+
+to_lower() {
+  local value="$1"
+  printf "%s" "$value" | tr '[:upper:]' '[:lower:]'
+}
+
+to_abs_path() {
+  local rel_or_abs="$1"
+  local candidate
+  if [ "${rel_or_abs#/}" = "$rel_or_abs" ]; then
+    candidate="$DEPLOY_PATH/${rel_or_abs#./}"
+  else
+    candidate="$rel_or_abs"
+  fi
+  realpath -m "$candidate"
+}
+
+DEPLOY_PATH_INPUT="${1:-${EC2_DEPLOY_PATH:-/home/ubuntu/GACHI-BE/deploy}}"
+EC2_HOST_INPUT="${2:-${EC2_HOST:-}}"
+DOCKERHUB_USERNAME_INPUT="${3:-${DOCKERHUB_USERNAME:-}}"
+DOCKERHUB_TOKEN_INPUT="${4:-${DOCKERHUB_TOKEN:-}}"
+
+DEPLOY_PATH="$(echo "$DEPLOY_PATH_INPUT" | xargs)"
+EC2_HOST_INPUT="$(echo "$EC2_HOST_INPUT" | xargs)"
+DOCKERHUB_USERNAME_INPUT="${DOCKERHUB_USERNAME_INPUT%$'\r'}"
+DOCKERHUB_TOKEN_INPUT="${DOCKERHUB_TOKEN_INPUT%$'\r'}"
+
+if [ -z "$DOCKERHUB_USERNAME_INPUT" ] || [ -z "$DOCKERHUB_TOKEN_INPUT" ]; then
+  echo "DOCKERHUB_USERNAME/DOCKERHUB_TOKEN is required."
+  exit 1
+fi
+
+echo "[1/7] Move to deploy path: $DEPLOY_PATH"
+if [ ! -d "$DEPLOY_PATH" ]; then
+  echo "Deploy path not found: $DEPLOY_PATH"
+  exit 1
+fi
+cd "$DEPLOY_PATH"
+echo "[debug] host=$(hostname) user=$(whoami) pwd=$(pwd)"
+ls -al
+
+echo "[2/7] Validate server-side .env preservation"
+if [ ! -f .env ]; then
+  echo ".env not found in $DEPLOY_PATH. Create .env on EC2 before deploy."
+  exit 1
+fi
+
+echo "[3/7] Pin latest backend image tag in .env"
+if grep -q "^BACKEND_IMAGE=" .env; then
+  sed -i "s|^BACKEND_IMAGE=.*|BACKEND_IMAGE=${DOCKERHUB_USERNAME_INPUT}/gachi-be:latest|" .env
+else
+  echo "BACKEND_IMAGE=${DOCKERHUB_USERNAME_INPUT}/gachi-be:latest" >> .env
+fi
+
+echo "[4/7] Validate SMTP/Swagger secrets and TLS files"
+SECRET_FILE_REL="$(read_env_value SPRING_MAIL_PASSWORD_SECRET_FILE)"
+SECRET_FILE_REL="${SECRET_FILE_REL:-./secrets/spring_mail_password.example.txt}"
+SECRET_FILE_PATH="$(to_abs_path "$SECRET_FILE_REL")"
+echo "[debug] secret file rel path: $SECRET_FILE_REL"
+echo "[debug] secret file absolute path: $SECRET_FILE_PATH"
+if [ -e "$SECRET_FILE_PATH" ]; then
+  if [ ! -r "$SECRET_FILE_PATH" ]; then
+    echo "SMTP secret file exists but is not readable: $SECRET_FILE_PATH"
+    exit 1
+  fi
+  if [ ! -s "$SECRET_FILE_PATH" ]; then
+    echo "SMTP secret file is empty: $SECRET_FILE_PATH (fallback env SPRING_MAIL_PASSWORD will be used if set)"
+  fi
+else
+  echo "SMTP secret file not found: $SECRET_FILE_PATH (fallback env SPRING_MAIL_PASSWORD will be used if set)"
+fi
+
+SWAGGER_ENABLED_VALUE="$(to_lower "$(read_env_value SWAGGER_ENABLED)")"
+echo "[debug] SWAGGER_ENABLED normalized value: ${SWAGGER_ENABLED_VALUE:-<empty>}"
+if [ "$SWAGGER_ENABLED_VALUE" = "true" ]; then
+  SWAGGER_AUTH_FILE_REL="$(read_env_value SWAGGER_BASIC_AUTH_FILE)"
+  SWAGGER_AUTH_FILE_REL="${SWAGGER_AUTH_FILE_REL:-./secrets/swagger_htpasswd.txt}"
+  SWAGGER_AUTH_FILE_PATH="$(to_abs_path "$SWAGGER_AUTH_FILE_REL")"
+  EXPECTED_SWAGGER_AUTH_FILE_PATH="$(realpath -m "$DEPLOY_PATH/secrets/swagger_htpasswd.txt")"
+  if [ "$SWAGGER_AUTH_FILE_PATH" != "$EXPECTED_SWAGGER_AUTH_FILE_PATH" ]; then
+    echo "SWAGGER_BASIC_AUTH_FILE must point to ./secrets/swagger_htpasswd.txt for nginx auth_basic_user_file compatibility."
+    exit 1
+  fi
+  echo "[debug] swagger auth file absolute path: $SWAGGER_AUTH_FILE_PATH"
+  if [ ! -s "$SWAGGER_AUTH_FILE_PATH" ]; then
+    echo "Swagger auth file missing or empty: $SWAGGER_AUTH_FILE_PATH"
+    exit 1
+  fi
+  if [ ! -r "$SWAGGER_AUTH_FILE_PATH" ]; then
+    echo "Swagger auth file is not readable: $SWAGGER_AUTH_FILE_PATH"
+    exit 1
+  fi
+
+  TLS_CERT_FILE_REL="$(read_env_value SWAGGER_TLS_CERT_FILE)"
+  TLS_KEY_FILE_REL="$(read_env_value SWAGGER_TLS_KEY_FILE)"
+  TLS_CERT_FILE_REL="${TLS_CERT_FILE_REL:-./secrets/swagger_tls.crt}"
+  TLS_KEY_FILE_REL="${TLS_KEY_FILE_REL:-./secrets/swagger_tls.key}"
+  TLS_CERT_FILE_PATH="$(to_abs_path "$TLS_CERT_FILE_REL")"
+  TLS_KEY_FILE_PATH="$(to_abs_path "$TLS_KEY_FILE_REL")"
+  EXPECTED_TLS_CERT_FILE_PATH="$(realpath -m "$DEPLOY_PATH/secrets/swagger_tls.crt")"
+  EXPECTED_TLS_KEY_FILE_PATH="$(realpath -m "$DEPLOY_PATH/secrets/swagger_tls.key")"
+  if [ "$TLS_CERT_FILE_PATH" != "$EXPECTED_TLS_CERT_FILE_PATH" ] || [ "$TLS_KEY_FILE_PATH" != "$EXPECTED_TLS_KEY_FILE_PATH" ]; then
+    echo "SWAGGER_TLS_CERT_FILE and SWAGGER_TLS_KEY_FILE must point to ./secrets/swagger_tls.crt and ./secrets/swagger_tls.key."
+    exit 1
+  fi
+
+  SWAGGER_TLS_MODE="$(to_lower "$(read_env_value SWAGGER_TLS_MODE)")"
+  SWAGGER_TLS_MODE="${SWAGGER_TLS_MODE:-letsencrypt_ip}"
+  SWAGGER_TLS_COMMON_NAME="$(read_env_value SWAGGER_TLS_COMMON_NAME)"
+  if [ "$SWAGGER_TLS_MODE" = "letsencrypt_ip" ]; then
+    SWAGGER_TLS_IP="$(read_env_value SWAGGER_TLS_IP)"
+    SWAGGER_TLS_IP="${SWAGGER_TLS_IP:-$EC2_HOST_INPUT}"
+    SWAGGER_TLS_IP="$(echo "$SWAGGER_TLS_IP" | xargs)"
+    if [ -z "$SWAGGER_TLS_IP" ]; then
+      echo "SWAGGER_TLS_IP is empty. Set SWAGGER_TLS_IP in .env or EC2_HOST secret."
+      exit 1
+    fi
+
+    CERTBOT_EMAIL_VALUE="$(read_env_value CERTBOT_EMAIL)"
+
+    if [ ! -s "$TLS_CERT_FILE_PATH" ] || [ ! -s "$TLS_KEY_FILE_PATH" ]; then
+      BOOTSTRAP_CN="${SWAGGER_TLS_COMMON_NAME:-$SWAGGER_TLS_IP}"
+      BOOTSTRAP_CN="${BOOTSTRAP_CN:-$(hostname)}"
+      echo "::warning::Bootstrap self-signed TLS cert is generated to make nginx available for ACME challenge."
+      mkdir -p "$(dirname "$TLS_CERT_FILE_PATH")"
+      mkdir -p "$(dirname "$TLS_KEY_FILE_PATH")"
+      openssl req -x509 -nodes -newkey rsa:2048 -days 7 \
+        -keyout "$TLS_KEY_FILE_PATH" \
+        -out "$TLS_CERT_FILE_PATH" \
+        -subj "/CN=$BOOTSTRAP_CN"
+      chmod 644 "$TLS_CERT_FILE_PATH"
+      chmod 600 "$TLS_KEY_FILE_PATH"
+    fi
+
+    echo "[debug] issue/renew Let's Encrypt IP cert for $SWAGGER_TLS_IP"
+    set +e
+    docker compose --env-file .env up -d --no-deps nginx
+    NGINX_UP_EXIT_CODE=$?
+    set -e
+    echo "[debug] nginx up exit code: $NGINX_UP_EXIT_CODE"
+    if [ "$NGINX_UP_EXIT_CODE" -ne 0 ]; then
+      echo "[error] failed to ensure nginx is running for ACME challenge."
+      docker compose --env-file .env logs --tail=120 nginx || true
+      exit "$NGINX_UP_EXIT_CODE"
+    fi
+
+    set +e
+    docker compose --env-file .env --profile tls rm -f certbot >/dev/null 2>&1
+    CERTBOT_RM_EXIT_CODE=$?
+    set -e
+    echo "[debug] certbot rm exit code: $CERTBOT_RM_EXIT_CODE"
+
+    CERTBOT_EXIT_CODE=0
+    if [ -n "${CERTBOT_EMAIL_VALUE:-}" ]; then
+      set +e
+      echo "[debug] running certbot certonly with email mode"
+      docker compose --env-file .env --profile tls run --rm --entrypoint certbot certbot certonly --non-interactive --agree-tos --keep-until-expiring --preferred-profile shortlived --webroot -w /var/www/certbot --cert-name swagger-ip --ip-address "$SWAGGER_TLS_IP" --email "$CERTBOT_EMAIL_VALUE" -v
+      CERTBOT_EXIT_CODE=$?
+      set -e
+    else
+      echo "::warning::CERTBOT_EMAIL is empty. Certificate account will be registered without email."
+      set +e
+      echo "[debug] running certbot certonly without email mode"
+      docker compose --env-file .env --profile tls run --rm --entrypoint certbot certbot certonly --non-interactive --agree-tos --keep-until-expiring --preferred-profile shortlived --webroot -w /var/www/certbot --cert-name swagger-ip --ip-address "$SWAGGER_TLS_IP" --register-unsafely-without-email -v
+      CERTBOT_EXIT_CODE=$?
+      set -e
+    fi
+    echo "[debug] certbot certonly exit code: $CERTBOT_EXIT_CODE"
+
+    if [ "$CERTBOT_EXIT_CODE" -ne 0 ]; then
+      echo "[error] certbot certonly failed (exit=$CERTBOT_EXIT_CODE)."
+      docker compose --env-file .env logs --tail=120 nginx || true
+      exit "$CERTBOT_EXIT_CODE"
+    fi
+
+    docker compose --env-file .env --profile tls run --rm --entrypoint /bin/sh certbot -c \
+      "set -eu; \
+      cp /etc/letsencrypt/live/swagger-ip/fullchain.pem /workspace/secrets/swagger_tls.crt; \
+      cp /etc/letsencrypt/live/swagger-ip/privkey.pem /workspace/secrets/swagger_tls.key; \
+      chmod 644 /workspace/secrets/swagger_tls.crt; \
+      chmod 600 /workspace/secrets/swagger_tls.key"
+  fi
+
+  if [ ! -s "$TLS_CERT_FILE_PATH" ] || [ ! -s "$TLS_KEY_FILE_PATH" ]; then
+    echo "::warning::TLS cert/key missing for Swagger HTTPS. Generating self-signed cert. This is NOT recommended for production!"
+    mkdir -p "$(dirname "$TLS_CERT_FILE_PATH")"
+    mkdir -p "$(dirname "$TLS_KEY_FILE_PATH")"
+    openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+      -keyout "$TLS_KEY_FILE_PATH" \
+      -out "$TLS_CERT_FILE_PATH" \
+      -subj "/CN=${SWAGGER_TLS_IP:-$(hostname)}"
+    chmod 644 "$TLS_CERT_FILE_PATH"
+    chmod 600 "$TLS_KEY_FILE_PATH"
+  fi
+
+  if ! docker compose --env-file .env exec -T nginx sh -c "test -r /etc/nginx/secrets/swagger_tls.crt && test -r /etc/nginx/secrets/swagger_tls.key"; then
+    echo "TLS cert/key are not readable from nginx container path."
+    ls -l "$TLS_CERT_FILE_PATH" "$TLS_KEY_FILE_PATH" || true
+    exit 1
+  fi
+else
+  echo "[debug] SWAGGER_ENABLED is not true. Swagger auth/tls validation skipped."
+fi
+
+echo "[5/7] Pull latest backend image"
+echo "${DOCKERHUB_TOKEN_INPUT}" | docker login -u "${DOCKERHUB_USERNAME_INPUT}" --password-stdin
+docker compose --env-file .env pull backend
+
+echo "[6/7] Recreate services with synced compose/nginx settings"
+docker compose --env-file .env up -d --remove-orphans backend
+BACKEND_HEALTH="starting"
+for _ in $(seq 1 36); do
+  BACKEND_HEALTH="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' gachi-backend 2>/dev/null || echo "missing")"
+  echo "[debug] backend health: $BACKEND_HEALTH"
+  if [ "$BACKEND_HEALTH" = "healthy" ]; then
+    break
+  fi
+  sleep 5
+done
+if [ "$BACKEND_HEALTH" != "healthy" ]; then
+  echo "backend health check timed out. Check backend logs."
+  docker compose --env-file .env logs --tail=120 backend || true
+  exit 1
+fi
+docker compose --env-file .env up -d --remove-orphans --force-recreate --no-deps nginx
+
+echo "[7/7] Print deploy status"
+docker image prune -f
+docker compose --env-file .env ps
+docker compose --env-file .env logs --tail=80 backend nginx || true


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - `deploy-ec2` 워크플로우의 SSH/SCP 의존(`appleboy/scp-action`, `appleboy/ssh-action`)을 제거하고 SSM 기반으로 전환
  - 배포 실행 로직을 `scripts/deploy-ec2.sh`로 분리
  - `deploy/` 화이트리스트 파일과 배포 스크립트를 번들로 묶어 SSM `AWS-RunShellScript`로 전달/해제/실행하도록 변경
  - AWS 인증은 OIDC 우선, Access Key fallback(세션 토큰 유무 분기 포함)으로 구성
  - SSM 명령 상태 polling, stdout/stderr 출력, 종료코드 보존(cleanup 이후 원래 status로 종료) 처리를 반영
  - `docs/deploy.md` 및 릴리즈 템플릿의 배포 검증 항목을 SSM 기준(`ssm-send-step`, `ssm-order`, `compose-ps`)으로 정렬 
- 관련 이슈: closes #33 

## 🌿 브랜치 정보

- **Source**: `chore/#33-deploy-ssm-migration`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

- GitHub Actions `deploy-ec2` 수동 실행(`workflow_dispatch`) 수행

| 대상 브랜치: `chore/#33-deploy-ssm-migration` |
|---|
| ![deploy-ec2](https://github.com/user-attachments/assets/d9e327db-d40a-4b06-833f-fabbb64a1021) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * EC2에 대한 SSM 기반 원격 배포 지원과 새 배포 스크립트 도입

* **Documentation**
  * EC2 배포 절차, 권한 요구사항 및 실패 로그/타임아웃 처리 가이드 업데이트
  * 배포 대상 표기(화이트리스트) 및 워크플로우 단계 설명 보강

* **Chores**
  * GitHub Actions 배포 워크플로우와 릴리스/풀리퀘스트 템플릿 내용 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->