### PR TITLE
feat: 번역 조회 응답에 원문 파일 URL 추가 및 일정 마커에 자녀 색상 반영

### DIFF
--- a/src/main/java/com/gachi/be/domain/calendar/dto/response/CalendarMonthlyResponse.java
+++ b/src/main/java/com/gachi/be/domain/calendar/dto/response/CalendarMonthlyResponse.java
@@ -3,6 +3,6 @@ package com.gachi.be.domain.calendar.dto.response;
 import java.util.List;
 
 /** 월별 달력 화면에서 일정이 있는 날짜에 자녀 색깔 점(마커)을 표시하기 위한 데이터. 날짜 목록만 반환하고 일정 상세는 포함 X */
-public record CalendarMonthlyResponse(List<String> markedDates) {
+public record CalendarMonthlyResponse( List<MarkerItem> markedDates) {
     public record MarkerItem(String date, String childName, String childColor) {}
 }

--- a/src/main/java/com/gachi/be/domain/calendar/dto/response/CalendarMonthlyResponse.java
+++ b/src/main/java/com/gachi/be/domain/calendar/dto/response/CalendarMonthlyResponse.java
@@ -3,6 +3,6 @@ package com.gachi.be.domain.calendar.dto.response;
 import java.util.List;
 
 /** 월별 달력 화면에서 일정이 있는 날짜에 자녀 색깔 점(마커)을 표시하기 위한 데이터. 날짜 목록만 반환하고 일정 상세는 포함 X */
-public record CalendarMonthlyResponse( List<MarkerItem> markedDates) {
-    public record MarkerItem(String date, String childName, String childColor) {}
+public record CalendarMonthlyResponse(List<MarkerItem> markedDates) {
+  public record MarkerItem(String date, String childName, String childColor) {}
 }

--- a/src/main/java/com/gachi/be/domain/calendar/dto/response/CalendarMonthlyResponse.java
+++ b/src/main/java/com/gachi/be/domain/calendar/dto/response/CalendarMonthlyResponse.java
@@ -3,4 +3,6 @@ package com.gachi.be.domain.calendar.dto.response;
 import java.util.List;
 
 /** 월별 달력 화면에서 일정이 있는 날짜에 자녀 색깔 점(마커)을 표시하기 위한 데이터. 날짜 목록만 반환하고 일정 상세는 포함 X */
-public record CalendarMonthlyResponse(List<String> markedDates) {}
+public record CalendarMonthlyResponse(List<String> markedDates) {
+    public record MarkerItem(String date, String childName, String childColor) {}
+}

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/CalendarQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/CalendarQueryServiceImpl.java
@@ -68,13 +68,13 @@ public class CalendarQueryServiceImpl implements CalendarQueryService {
         events.stream()
             .map(
                 e -> {
-                    String date =
-                        e.getStartAt()
-                            .withOffsetSameInstant(KST_OFFSET)
-                            .toLocalDate()
-                            .format(DateTimeFormatter.ISO_LOCAL_DATE);
-                    return new CalendarMonthlyResponse.MarkerItem(
-                        date, e.getChildName(), e.getChildColor());
+                  String date =
+                      e.getStartAt()
+                          .withOffsetSameInstant(KST_OFFSET)
+                          .toLocalDate()
+                          .format(DateTimeFormatter.ISO_LOCAL_DATE);
+                  return new CalendarMonthlyResponse.MarkerItem(
+                      date, e.getChildName(), e.getChildColor());
                 })
             // 같은 날짜+같은 자녀 조합은 마커 1개로 중복 제거
             .distinct()

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/CalendarQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/CalendarQueryServiceImpl.java
@@ -64,18 +64,23 @@ public class CalendarQueryServiceImpl implements CalendarQueryService {
             userId, rangeStart, rangeEnd, normalizedChildName);
 
     // 일정이 있는 날짜만 추출 (중복 제거, 정렬)
-    List<String> markedDates =
+    List<CalendarMonthlyResponse.MarkerItem> markedDates =
         events.stream()
             .map(
-                e ->
-                    e.getStartAt()
-                        .withOffsetSameInstant(KST_OFFSET)
-                        .toLocalDate()
-                        .format(DateTimeFormatter.ISO_LOCAL_DATE))
+                e -> {
+                    String date =
+                        e.getStartAt()
+                            .withOffsetSameInstant(KST_OFFSET)
+                            .toLocalDate()
+                            .format(DateTimeFormatter.ISO_LOCAL_DATE);
+                    return new CalendarMonthlyResponse.MarkerItem(
+                        date, e.getChildName(), e.getChildColor());
+                })
+            // 같은 날짜+같은 자녀 조합은 마커 1개로 중복 제거
             .distinct()
-            .sorted()
+            // 날짜 기준 오름차순 정렬
+            .sorted(Comparator.comparing(CalendarMonthlyResponse.MarkerItem::date))
             .toList();
-
     log.debug(
         "[CalendarQuery] 월별 마커 조회. userId={}, {}-{}, childName={}, count={}",
         userId,

--- a/src/main/java/com/gachi/be/domain/newsletter/api/controller/NewsletterController.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/api/controller/NewsletterController.java
@@ -42,7 +42,7 @@ public class NewsletterController {
   /**
    * 가정통신문 업로드 API.
    *
-   * <p>요청 형식: multipart/form-data Swagger에서 "file" 파라미터를 통해 직접 파일을 선택해서 테스트 가능. 업로드 성공 시
+   * 요청 형식: multipart/form-data Swagger에서 "file" 파라미터를 통해 직접 파일을 선택해서 테스트 가능. 업로드 성공 시
    * newsletterId를 받고, 이 ID로 /status API를 폴링 O.
    */
   @Operation(

--- a/src/main/java/com/gachi/be/domain/newsletter/api/controller/NewsletterController.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/api/controller/NewsletterController.java
@@ -42,7 +42,7 @@ public class NewsletterController {
   /**
    * 가정통신문 업로드 API.
    *
-   * 요청 형식: multipart/form-data Swagger에서 "file" 파라미터를 통해 직접 파일을 선택해서 테스트 가능. 업로드 성공 시
+   * <p>요청 형식: multipart/form-data Swagger에서 "file" 파라미터를 통해 직접 파일을 선택해서 테스트 가능. 업로드 성공 시
    * newsletterId를 받고, 이 ID로 /status API를 폴링 O.
    */
   @Operation(

--- a/src/main/java/com/gachi/be/domain/newsletter/dto/response/NewsletterTranslationResponse.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/dto/response/NewsletterTranslationResponse.java
@@ -11,14 +11,16 @@ public record NewsletterTranslationResponse(
     String originalText,
     String translatedText,
     String language,
+    String fileUrl,
     List<NewsletterDateCandidateResponse> dateCandidates) {
 
   public static NewsletterTranslationResponse from(
-      Newsletter newsletter, List<NewsletterDateCandidate> dateCandidates) {
+      Newsletter newsletter, List<NewsletterDateCandidate> dateCandidates, String fileUrl) {
     return new NewsletterTranslationResponse(
         newsletter.getOriginalText(),
         newsletter.getTranslatedText(),
         newsletter.getLanguage(),
+        fileUrl,
         dateCandidates == null
             ? List.of()
             : dateCandidates.stream().map(NewsletterDateCandidateResponse::from).toList());

--- a/src/main/java/com/gachi/be/domain/newsletter/service/impl/NewsletterServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/service/impl/NewsletterServiceImpl.java
@@ -203,7 +203,10 @@ public class NewsletterServiceImpl implements NewsletterService {
     Newsletter newsletter = findNewsletterById(newsletterId);
     validateOwnership(newsletter, userId);
     validateCompleted(newsletter);
-    return NewsletterTranslationResponse.from(newsletter, newsletter.getDateCandidates());
+
+    String fileUrl = s3FileService.generatePresignedUrl(newsletter.getFileKey());
+    log.debug("[Newsletter] Presigned URL 생성. newsletterId={}", newsletterId);
+    return NewsletterTranslationResponse.from(newsletter, newsletter.getDateCandidates(), fileUrl);
   }
 
   /** 요약 결과 조회. 스캔 결과 [AI요약] 탭 상단의 요약문을 반환합니다. */

--- a/src/main/java/com/gachi/be/domain/newsletter/service/impl/NewsletterServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/service/impl/NewsletterServiceImpl.java
@@ -19,8 +19,8 @@ import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
 import com.gachi.be.domain.newsletter.service.NewsletterService;
 import com.gachi.be.file.service.S3FileService;
 import com.gachi.be.global.code.ErrorCode;
-import com.gachi.be.global.config.external.ExternalApiConfig;
 import com.gachi.be.global.exception.BusinessException;
+import com.gachi.be.global.exception.ExternalApiException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
@@ -31,8 +31,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import com.gachi.be.global.exception.ExternalApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -209,14 +207,14 @@ public class NewsletterServiceImpl implements NewsletterService {
 
     String fileUrl = null;
     try {
-        fileUrl = s3FileService.generatePresignedUrl(newsletter.getFileKey());
-        log.debug("[Newsletter] Presigned URL 생성. newsletterId={}", newsletterId);
-    } catch (ExternalApiException e){
-        log.warn(
-                      "[Newsletter] Presigned URL 생성 실패. newsletterId={}, fileKey={}",
-                      newsletterId,
-                      newsletter.getFileKey(),
-                      e);
+      fileUrl = s3FileService.generatePresignedUrl(newsletter.getFileKey());
+      log.debug("[Newsletter] Presigned URL 생성. newsletterId={}", newsletterId);
+    } catch (ExternalApiException e) {
+      log.warn(
+          "[Newsletter] Presigned URL 생성 실패. newsletterId={}, fileKey={}",
+          newsletterId,
+          newsletter.getFileKey(),
+          e);
     }
     return NewsletterTranslationResponse.from(newsletter, newsletter.getDateCandidates(), fileUrl);
   }

--- a/src/main/java/com/gachi/be/domain/newsletter/service/impl/NewsletterServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/service/impl/NewsletterServiceImpl.java
@@ -19,6 +19,7 @@ import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
 import com.gachi.be.domain.newsletter.service.NewsletterService;
 import com.gachi.be.file.service.S3FileService;
 import com.gachi.be.global.code.ErrorCode;
+import com.gachi.be.global.config.external.ExternalApiConfig;
 import com.gachi.be.global.exception.BusinessException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,6 +31,8 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import com.gachi.be.global.exception.ExternalApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -204,8 +207,17 @@ public class NewsletterServiceImpl implements NewsletterService {
     validateOwnership(newsletter, userId);
     validateCompleted(newsletter);
 
-    String fileUrl = s3FileService.generatePresignedUrl(newsletter.getFileKey());
-    log.debug("[Newsletter] Presigned URL 생성. newsletterId={}", newsletterId);
+    String fileUrl = null;
+    try {
+        fileUrl = s3FileService.generatePresignedUrl(newsletter.getFileKey());
+        log.debug("[Newsletter] Presigned URL 생성. newsletterId={}", newsletterId);
+    } catch (ExternalApiException e){
+        log.warn(
+                      "[Newsletter] Presigned URL 생성 실패. newsletterId={}, fileKey={}",
+                      newsletterId,
+                      newsletter.getFileKey(),
+                      e);
+    }
     return NewsletterTranslationResponse.from(newsletter, newsletter.getDateCandidates(), fileUrl);
   }
 

--- a/src/main/java/com/gachi/be/file/service/S3FileService.java
+++ b/src/main/java/com/gachi/be/file/service/S3FileService.java
@@ -11,4 +11,6 @@ public interface S3FileService {
   S3UploadResponse uploadNewsletter(MultipartFile file);
 
   void deleteFile(String fileKey);
+
+  String generatePresignedUrl(String fileKey);
 }

--- a/src/main/java/com/gachi/be/file/service/impl/S3FileServiceImpl.java
+++ b/src/main/java/com/gachi/be/file/service/impl/S3FileServiceImpl.java
@@ -77,29 +77,26 @@ public class S3FileServiceImpl implements S3FileService {
 
   @Override
   public String generatePresignedUrl(String fileKey) {
-      try {
-          GetObjectRequest getObjectRequest =
-              GetObjectRequest.builder()
-                  .bucket(s3Properties.getBucket())
-                  .key(fileKey)
-                  .build();
+    try {
+      GetObjectRequest getObjectRequest =
+          GetObjectRequest.builder().bucket(s3Properties.getBucket()).key(fileKey).build();
 
-          GetObjectPresignRequest presignRequest =
-              GetObjectPresignRequest.builder()
-                  .signatureDuration(PRESIGNED_URL_EXPIRY)
-                  .getObjectRequest(getObjectRequest)
-                  .build();
+      GetObjectPresignRequest presignRequest =
+          GetObjectPresignRequest.builder()
+              .signatureDuration(PRESIGNED_URL_EXPIRY)
+              .getObjectRequest(getObjectRequest)
+              .build();
 
-          PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
-          String presignedUrl = presignedRequest.url().toString();
+      PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+      String presignedUrl = presignedRequest.url().toString();
 
-          log.debug("[S3] Presigned URL 생성 완료. fileKey={}, expiresIn=1hour", fileKey);
-          return presignedUrl;
-      } catch (Exception e) {
-          log.error("[S3] Presigned URL 생성 실패. fileKey={}, error={}", fileKey, e.getMessage());
-          throw new ExternalApiException(
-              ErrorCode.EXTERNAL_API_ERROR, "Presigned URL 생성 실패: " + e.getMessage());
-      }
+      log.debug("[S3] Presigned URL 생성 완료. fileKey={}, expiresIn=1hour", fileKey);
+      return presignedUrl;
+    } catch (Exception e) {
+      log.error("[S3] Presigned URL 생성 실패. fileKey={}, error={}", fileKey, e.getMessage());
+      throw new ExternalApiException(
+          ErrorCode.EXTERNAL_API_ERROR, "Presigned URL 생성 실패: " + e.getMessage());
+    }
   }
 
   private S3UploadResponse doUpload(MultipartFile file, String key) {

--- a/src/main/java/com/gachi/be/file/service/impl/S3FileServiceImpl.java
+++ b/src/main/java/com/gachi/be/file/service/impl/S3FileServiceImpl.java
@@ -8,6 +8,7 @@ import com.gachi.be.global.exception.BusinessException;
 import com.gachi.be.global.exception.ExternalApiException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.Set;
 import java.util.UUID;
@@ -20,8 +21,12 @@ import org.springframework.web.util.UriUtils;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 @Slf4j
 @Service
@@ -36,8 +41,10 @@ public class S3FileServiceImpl implements S3FileService {
 
   // 가정통신문 전용 S3 prefix
   private static final String NEWSLETTER_PREFIX = "newsletters";
+  private static final Duration PRESIGNED_URL_EXPIRY = Duration.ofHours(1);
   private final S3Client s3Client;
   private final S3Properties s3Properties;
+  private final S3Presigner s3Presigner;
   private static final long MAX_NEWSLETTER_SIZE_BYTES = 10 * 1024 * 1024L;
 
   @Override
@@ -66,6 +73,33 @@ public class S3FileServiceImpl implements S3FileService {
       throw new ExternalApiException(
           ErrorCode.EXTERNAL_API_ERROR, "S3 파일 삭제 실패: " + e.awsErrorDetails().errorMessage());
     }
+  }
+
+  @Override
+  public String generatePresignedUrl(String fileKey) {
+      try {
+          GetObjectRequest getObjectRequest =
+              GetObjectRequest.builder()
+                  .bucket(s3Properties.getBucket())
+                  .key(fileKey)
+                  .build();
+
+          GetObjectPresignRequest presignRequest =
+              GetObjectPresignRequest.builder()
+                  .signatureDuration(PRESIGNED_URL_EXPIRY)
+                  .getObjectRequest(getObjectRequest)
+                  .build();
+
+          PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+          String presignedUrl = presignedRequest.url().toString();
+
+          log.debug("[S3] Presigned URL 생성 완료. fileKey={}, expiresIn=1hour", fileKey);
+          return presignedUrl;
+      } catch (Exception e) {
+          log.error("[S3] Presigned URL 생성 실패. fileKey={}, error={}", fileKey, e.getMessage());
+          throw new ExternalApiException(
+              ErrorCode.EXTERNAL_API_ERROR, "Presigned URL 생성 실패: " + e.getMessage());
+      }
   }
 
   private S3UploadResponse doUpload(MultipartFile file, String key) {

--- a/src/main/java/com/gachi/be/file/service/impl/S3FileServiceImpl.java
+++ b/src/main/java/com/gachi/be/file/service/impl/S3FileServiceImpl.java
@@ -93,7 +93,7 @@ public class S3FileServiceImpl implements S3FileService {
       log.debug("[S3] Presigned URL 생성 완료. fileKey={}, expiresIn=1hour", fileKey);
       return presignedUrl;
     } catch (Exception e) {
-      log.error("[S3] Presigned URL 생성 실패. fileKey={}, error={}", fileKey, e.getMessage());
+        log.error("[S3] Presigned URL 생성 실패. fileKey={}", fileKey, e);
       throw new ExternalApiException(
           ErrorCode.EXTERNAL_API_ERROR, "Presigned URL 생성 실패: " + e.getMessage());
     }

--- a/src/main/java/com/gachi/be/file/service/impl/S3FileServiceImpl.java
+++ b/src/main/java/com/gachi/be/file/service/impl/S3FileServiceImpl.java
@@ -93,7 +93,7 @@ public class S3FileServiceImpl implements S3FileService {
       log.debug("[S3] Presigned URL 생성 완료. fileKey={}, expiresIn=1hour", fileKey);
       return presignedUrl;
     } catch (Exception e) {
-        log.error("[S3] Presigned URL 생성 실패. fileKey={}", fileKey, e);
+      log.error("[S3] Presigned URL 생성 실패. fileKey={}", fileKey, e);
       throw new ExternalApiException(
           ErrorCode.EXTERNAL_API_ERROR, "Presigned URL 생성 실패: " + e.getMessage());
     }


### PR DESCRIPTION
## 📌 작업 요약

- 요약: 가정통신문 번역 조회 시에 파일 URL 같이 첨부
- 월별 마커 조회 응답시 자녀 캘린더 색상 response 반영 
- 관련 이슈: closes #52 

## 🌿 브랜치 정보

- **Source**: `feat/#52-get-file-and-children-color`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

<img width="1223" height="719" alt="스크린샷 2026-05-18 184607" src="https://github.com/user-attachments/assets/bc952b56-5743-48c3-87ee-f3b5c0b9a6d4" />
<img width="1203" height="677" alt="스크린샷 2026-05-18 184632" src="https://github.com/user-attachments/assets/97872152-5f58-4d7f-ba05-5def57c38910" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 월별 달력 마커에 자녀명 및 색상 정보 추가로 더욱 명확한 일정 표시 제공
  * 뉴스레터 파일 접근을 위한 안전한 URL 제공 (1시간 유효)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GACHI-Project/GACHI-BE/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->