### PR TITLE
chore: AI Swagger 접근 보호 설정

### DIFF
--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -100,6 +100,36 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /ai/docs {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
+      proxy_pass http://ai_upstream;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /ai/openapi.json {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
+      proxy_pass http://ai_upstream;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /ai/redoc {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
+      proxy_pass http://ai_upstream;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /ai/ {
       proxy_pass http://ai_upstream;
       proxy_set_header Host $host;

--- a/deploy/nginx/nginx.https.template.conf
+++ b/deploy/nginx/nginx.https.template.conf
@@ -80,6 +80,36 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /ai/docs {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
+      proxy_pass http://ai_upstream;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /ai/openapi.json {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
+      proxy_pass http://ai_upstream;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /ai/redoc {
+      auth_basic "GACHI Swagger";
+      auth_basic_user_file /etc/nginx/secrets/swagger_htpasswd.txt;
+      proxy_pass http://ai_upstream;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /ai/ {
       proxy_pass http://ai_upstream;
       proxy_set_header Host $host;


### PR DESCRIPTION
## 📌 작업 요약

- 요약: 
  - AI 서버 Swagger 문서 엔드포인트에 Basic Auth를 적용
  - 기존 BE Swagger에서 사용하는 `swagger_htpasswd.txt` 인증 파일을 동일하게 재사용하도록 설정
  - 배포/헬스체크에 필요한 `/ai/health`와 BE 내부 호출 대상인 `/ai/newsletters/*`는 기존 `/ai/` 프록시를 유지
- 관련 이슈: closes #56 

## 🌿 브랜치 정보

- **Source**: `chore/#56-protect-ai-swagger`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

- `docker compose --env-file deploy/.env.example -f deploy/docker-compose.yml config` 실행 확인
  - 결과: Compose 설정 렌더링 성공
- `docker run --rm --add-host backend:127.0.0.1 --add-host ai:127.0.0.1 -v ${PWD}\deploy\nginx\nginx.conf:/etc/nginx/nginx.conf:ro -v ${PWD}\deploy\secrets:/etc/nginx/secrets:ro nginx:1.27-alpine nginx -t` 실행 확인
  - 결과: `nginx: configuration file /etc/nginx/nginx.conf test is successful`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 보안

* AI 문서 엔드포인트(/ai/docs, /ai/openapi.json, /ai/redoc)에 인증이 추가되었습니다. 이제 이 엔드포인트에 접근하려면 인증 정보가 필요합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GACHI-Project/GACHI-BE/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->