### PR TITLE
refactor: AI 서버 장애 시 분석 실패 정책 반영

### DIFF
--- a/docs/error-code.md
+++ b/docs/error-code.md
@@ -2,7 +2,7 @@
 
 상세 에러 코드는 아래 Google Sheets를 단일 원본으로 관리합니다.
 
-- Google Sheets: [Error Code Single Source](https://docs.google.com/spreadsheets/d/1sUG_JJsVl6a8nR6k8jO_b7UrIEZzuvQdPB6S2S6fqgo/edit?gid=2097363290#gid=2097363290)
+- Google Sheets: [Error Code Single Source](https://docs.google.com/spreadsheets/d/1sUG_JJsVl6a8nR6k8jO_b7UrIEZzuvQdPB6S2S6fqgo/edit?gid=1519705696#gid=1519705696)
 
 ## 운영 원칙
 

--- a/docs/newsletter-ai-failure-policy.md
+++ b/docs/newsletter-ai-failure-policy.md
@@ -1,0 +1,43 @@
+# AI 서버 장애 시 가정통신문 처리 정책
+
+이 문서는 API 명세서가 아니라 BE가 장애 상황에서 어떤 상태와 데이터를 남길지 정한 운영 정책이다.
+상세 API 명세는 노션을 기준으로 관리한다.
+
+## 결정 사항
+
+- AI 서버 호출 실패 시 newsletter 상태는 `FAILED`로 둔다.
+- 별도 부분 성공 상태는 이번 범위에서 추가하지 않는다.
+- OCR, 정제 원문, 번역 결과, 날짜 후보는 가능한 범위까지 저장한다.
+- AI 분석 결과에서 파생되는 제목, 요약, checklist, calendar event는 생성하지 않는다.
+- 실패 원인 추적을 위해 `failureStage`, `failureReason`을 저장한다.
+- 상태 조회 응답은 `FAILED`일 때 `canRetry=true`와 실패 단계를 반환한다.
+- 사용자는 `POST /api/v1/newsletters/{newsletterId}/analysis/retry`로 같은 문서를 다시 분석할 수 있다.
+
+## 실패 시 저장 범위
+
+AI 서버 단계에서 실패하면 다음 데이터는 남긴다.
+
+- `status = FAILED`
+- `ocrText`
+- `originalText`
+- `translatedText`
+- `dateCandidates`
+- `failureStage = AI_SERVER`
+- `failureReason`
+
+다음 데이터는 비워 둔다.
+
+- `title`
+- `summary`
+- checklist
+- calendar event
+
+## 재시도 정책
+
+재시도는 `FAILED` 상태에서만 허용한다.
+
+재시도 요청이 들어오면 기존 checklist와 calendar event 파생 데이터를 삭제하고, newsletter 상태를 `PENDING`으로 되돌린 뒤 파이프라인을 다시 실행한다.
+
+자동 재시도 큐는 이번 범위에서 만들지 않는다. AI 서버 장애와 문서 입력 문제를 자동으로 구분하기 어렵고, 외부 API 비용과 장애 확산 위험이 있기 때문이다.
+
+추후 필요하면 `failureStage=AI_SERVER`인 건만 백오프 큐에 넣는 방식으로 확장한다.

--- a/src/main/java/com/gachi/be/domain/newsletter/api/controller/NewsletterController.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/api/controller/NewsletterController.java
@@ -92,6 +92,24 @@ public class NewsletterController {
     return ApiResponse.success(SuccessCode.NEWSLETTER_STATUS_SUCCESS, response);
   }
 
+  /** 실패한 가정통신문 분석 재시도 API */
+  @Operation(
+      summary = "가정통신문 분석 재시도",
+      description =
+          """
+      FAILED 상태의 가정통신문 분석을 다시 시작합니다.
+      AI 서버 장애로 실패한 경우 기존 OCR/번역 결과는 보존되어 있고, 재시도 시 파이프라인이 다시 실행됩니다.
+      """)
+  @PostMapping("/{newsletterId}/analysis/retry")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public ApiResponse<NewsletterUploadResponse> retryAnalysis(
+      @AuthenticationPrincipal Long userId,
+      @Parameter(description = "가정통신문 ID", required = true) @PathVariable Long newsletterId) {
+
+    NewsletterUploadResponse response = newsletterService.retryAnalysis(userId, newsletterId);
+    return ApiResponse.success(SuccessCode.NEWSLETTER_RETRY_ACCEPTED, response);
+  }
+
   /** 번역 결과 조회 API. */
   @Operation(
       summary = "번역 결과 조회",

--- a/src/main/java/com/gachi/be/domain/newsletter/dto/response/NewsletterStatusResponse.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/dto/response/NewsletterStatusResponse.java
@@ -1,6 +1,7 @@
 package com.gachi.be.domain.newsletter.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.gachi.be.domain.newsletter.entity.Newsletter;
 import com.gachi.be.domain.newsletter.entity.enums.NewsletterStatus;
 
 /**
@@ -10,19 +11,31 @@ import com.gachi.be.domain.newsletter.entity.enums.NewsletterStatus;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL) // null인 필드는 JSON 응답에서 제외
 public record NewsletterStatusResponse(
-    NewsletterStatus status, int progressPercent, String progressMessage, String errorMessage) {
+    NewsletterStatus status,
+    int progressPercent,
+    String progressMessage,
+    String errorMessage,
+    String failureStage,
+    boolean canRetry) {
 
   /**
    * 분석 상태에 따라 적절한 진행률과 에러메시지를 자동 계산하는 팩토리 메서드. TODO: 현재는 고정값으로 처리, 추후 AI 서버에서 단계별 진행률을 받아 세분화 예정
    */
-  public static NewsletterStatusResponse of(NewsletterStatus status) {
-    String safeErrorMessage = "분석 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.";
+  public static NewsletterStatusResponse of(Newsletter newsletter) {
+    NewsletterStatus status = newsletter.getStatus();
     return switch (status) {
-      case PENDING -> new NewsletterStatusResponse(status, 0, "문서를 준비하고 있어요", null);
-      case PROCESSING -> new NewsletterStatusResponse(status, 60, "텍스트를 인식하고 번역하고 있어요", null);
-      case COMPLETED -> new NewsletterStatusResponse(status, 100, "분석이 완료되었어요", null);
+      case PENDING -> new NewsletterStatusResponse(status, 0, "문서를 준비하고 있어요", null, null, false);
+      case PROCESSING ->
+          new NewsletterStatusResponse(status, 60, "텍스트를 인식하고 번역하고 있어요", null, null, false);
+      case COMPLETED -> new NewsletterStatusResponse(status, 100, "분석이 완료되었어요", null, null, false);
       case FAILED ->
-          new NewsletterStatusResponse(status, 0, null, "분석 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요.");
+          new NewsletterStatusResponse(
+              status,
+              0,
+              null,
+              "분석 중 오류가 발생했어요. 다시 분석을 시도할 수 있어요.",
+              newsletter.getFailureStage(),
+              true);
     };
   }
 }

--- a/src/main/java/com/gachi/be/domain/newsletter/entity/Newsletter.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/entity/Newsletter.java
@@ -72,6 +72,12 @@ public class Newsletter {
   @Column(name = "summary", columnDefinition = "TEXT")
   private String summary;
 
+  @Column(name = "failure_stage", length = 50)
+  private String failureStage;
+
+  @Column(name = "failure_reason", columnDefinition = "TEXT")
+  private String failureReason;
+
   /** 날짜 후보는 최종 일정이 아니라 후속 AI 매칭을 위한 중간 재료이므로 JSON으로 보관합니다. */
   @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "date_candidates", columnDefinition = "jsonb")
@@ -125,6 +131,8 @@ public class Newsletter {
   /** AI 분석 시작 시 PROCESSING 상태로 전환합니다. */
   public void startProcessing() {
     this.status = NewsletterStatus.PROCESSING;
+    this.failureStage = null;
+    this.failureReason = null;
   }
 
   /** AI 분석 결과를 저장하고 COMPLETED 상태로 전환합니다. */
@@ -136,11 +144,37 @@ public class Newsletter {
     this.title = title;
     this.summary = summary;
     this.status = NewsletterStatus.COMPLETED;
+    this.failureStage = null;
+    this.failureReason = null;
   }
 
-  /** AI 분석 실패 시 FAILED 상태로 전환합니다. */
-  public void fail() {
+  /** 분석 실패 시 원인 추적을 위해 실패 단계와 사유를 함께 저장합니다. */
+  public void fail(String failureStage, String failureReason) {
     this.status = NewsletterStatus.FAILED;
+    this.failureStage = normalizeFailureStage(failureStage);
+    this.failureReason = normalizeFailureReason(failureReason);
+  }
+
+  /** OCR/번역 이후 AI 서버 장애가 나도 사용자가 원문 결과를 확인할 수 있도록 중간 산출물을 보존합니다. */
+  public void failWithSnapshot(
+      String ocrText,
+      String originalText,
+      String translatedText,
+      String failureStage,
+      String failureReason) {
+    this.ocrText = ocrText;
+    this.originalText = originalText;
+    this.translatedText = translatedText;
+    fail(failureStage, failureReason);
+  }
+
+  /** 실패한 분석을 사용자가 다시 시도할 때 이전 실패 사유를 비우고 대기 상태로 되돌립니다. */
+  public void prepareRetry() {
+    this.status = NewsletterStatus.PENDING;
+    this.failureStage = null;
+    this.failureReason = null;
+    this.title = null;
+    this.summary = null;
   }
 
   /** 날짜 후보 목록을 교체합니다. 후보가 없으면 빈 목록으로 저장합니다. */
@@ -152,5 +186,19 @@ public class Newsletter {
   /** 자녀 색상 변경 시 가정통신문에 복사된 색상도 함께 갱신합니다. */
   public void updateChildColor(String newColor) {
     this.childColor = newColor;
+  }
+
+  private String normalizeFailureStage(String failureStage) {
+    if (failureStage == null || failureStage.isBlank()) {
+      return "UNKNOWN";
+    }
+    return failureStage.length() <= 50 ? failureStage : failureStage.substring(0, 50);
+  }
+
+  private String normalizeFailureReason(String failureReason) {
+    if (failureReason == null || failureReason.isBlank()) {
+      return null;
+    }
+    return failureReason.length() <= 1000 ? failureReason : failureReason.substring(0, 1000);
   }
 }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
@@ -5,6 +5,7 @@ import com.gachi.be.domain.newsletter.pipeline.ClovaOcrClient.OcrField;
 import com.gachi.be.domain.newsletter.pipeline.NewsletterAiAnalyzer.AiAnalysisResult;
 import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
 import com.gachi.be.file.config.S3Properties;
+import com.gachi.be.global.exception.ExternalApiException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,8 +50,13 @@ public class NewsletterPipelineService {
     log.debug("[Pipeline] PROCESSING 전환 완료. newsletterId={}", newsletterId);
 
     String tempFileKey = null;
+    String failureStage = "PIPELINE_START";
+    String ocrText = null;
+    String originalText = null;
+    String translatedText = null;
 
     try {
+      failureStage = "S3_DOWNLOAD";
       log.debug("[Pipeline][STEP1] S3 다운로드 시작. fileKey={}", newsletter.getFileKey());
       byte[] fileBytes = downloadFromS3(newsletter.getFileKey());
       log.debug("[Pipeline][STEP1] 다운로드 완료. size={}bytes", fileBytes.length);
@@ -58,6 +64,7 @@ public class NewsletterPipelineService {
       boolean isPdf = newsletter.getFileKey().toLowerCase().endsWith(".pdf");
       String ocrTargetKey;
 
+      failureStage = "IMAGE_PREPROCESS";
       if (isPdf) {
         log.debug("[Pipeline][STEP2] PDF 파일. Clova OCR에 원본 파일을 전달합니다.");
         ocrTargetKey = newsletter.getFileKey();
@@ -70,31 +77,49 @@ public class NewsletterPipelineService {
         log.debug("[Pipeline][STEP2] 전처리 파일 임시 업로드 완료. tempFileKey={}", tempFileKey);
       }
 
+      failureStage = "CLOVA_OCR";
       log.debug("[Pipeline][STEP3] Clova OCR 호출 시작. ocrTargetKey={}", ocrTargetKey);
       List<List<OcrField>> ocrPageFields =
           clovaOcrClient.callOcr(s3Properties.getBucket(), ocrTargetKey);
       log.debug("[Pipeline][STEP3] OCR 완료. totalFieldsCount={}", ocrPageFields.size());
 
+      failureStage = "OCR_TEXT_PARSE";
       log.debug("[Pipeline][STEP4] OCR 텍스트 파싱 시작.");
-      String ocrText = ocrTextRefiner.parseFields(ocrPageFields);
+      ocrText = ocrTextRefiner.parseFields(ocrPageFields);
       log.debug("[Pipeline][STEP4] 파싱 완료. length={}chars", ocrText.length());
 
+      failureStage = "TEXT_REFINE";
       log.debug("[Pipeline][STEP5] 텍스트 정제 및 날짜 후보 추출 시작.");
-      String originalText = ocrTextRefiner.refineText(ocrText);
+      originalText = ocrTextRefiner.refineText(ocrText);
       newsletterDateCandidateService.extractAndReplace(newsletterId, originalText);
       log.debug("[Pipeline][STEP5] 정제 완료. length={}chars", originalText.length());
 
+      failureStage = "PAPAGO_TRANSLATE";
       log.debug("[Pipeline][STEP6] Papago 번역 시작. language={}", newsletter.getLanguage());
-      String translatedText =
-          papagoTranslateClient.translate(originalText, newsletter.getLanguage());
+      translatedText = papagoTranslateClient.translate(originalText, newsletter.getLanguage());
       log.debug(
           "[Pipeline][STEP6] 번역 완료. translated={}",
           translatedText != null ? translatedText.length() + "chars" : "null(KO 스킵)");
 
+      failureStage = "AI_SERVER";
       log.debug("[Pipeline][STEP7] AI 서버 분석 시작.");
-      AiAnalysisResult aiResult =
-          newsletterAiAnalyzer.analyze(
-              newsletterId, originalText, translatedText, newsletter.getLanguage());
+      AiAnalysisResult aiResult;
+      try {
+        aiResult =
+            newsletterAiAnalyzer.analyze(
+                newsletterId, originalText, translatedText, newsletter.getLanguage());
+      } catch (ExternalApiException e) {
+        log.error(
+            "[Pipeline][STEP7] AI 서버 분석 실패. newsletterId={}, stage={}, exceptionType={}, error={}",
+            newsletterId,
+            failureStage,
+            e.getClass().getSimpleName(),
+            e.getMessage(),
+            e);
+        markFailedWithSnapshot(
+            newsletterId, ocrText, originalText, translatedText, failureStage, failureReason(e));
+        return;
+      }
       log.debug("[Pipeline][STEP7] AI 서버 분석 완료. title={}", aiResult.title());
 
       markCompleted(
@@ -107,8 +132,15 @@ public class NewsletterPipelineService {
 
       log.info("[Pipeline] 파이프라인 완료. newsletterId={}", newsletterId);
     } catch (Exception e) {
-      log.error("[Pipeline] 파이프라인 실패. newsletterId={}, error={}", newsletterId, e.getMessage(), e);
-      markFailed(newsletterId);
+      log.error(
+          "[Pipeline] 파이프라인 실패. newsletterId={}, stage={}, exceptionType={}, error={}",
+          newsletterId,
+          failureStage,
+          e.getClass().getSimpleName(),
+          e.getMessage(),
+          e);
+      markFailedWithSnapshot(
+          newsletterId, ocrText, originalText, translatedText, failureStage, failureReason(e));
     } finally {
       if (tempFileKey != null) {
         try {
@@ -152,14 +184,29 @@ public class NewsletterPipelineService {
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void markFailed(Long newsletterId) {
+  public void markFailedWithSnapshot(
+      Long newsletterId,
+      String ocrText,
+      String originalText,
+      String translatedText,
+      String failureStage,
+      String failureReason) {
     newsletterRepository
         .findById(newsletterId)
         .ifPresent(
             n -> {
-              n.fail();
+              n.failWithSnapshot(
+                  ocrText, originalText, translatedText, failureStage, failureReason);
               newsletterRepository.save(n);
             });
+  }
+
+  private String failureReason(Exception e) {
+    String message = e.getMessage();
+    if (message == null || message.isBlank()) {
+      return e.getClass().getSimpleName();
+    }
+    return e.getClass().getSimpleName() + ": " + message;
   }
 
   private byte[] downloadFromS3(String fileKey) {

--- a/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
@@ -34,6 +34,27 @@ public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
       @Param("childName") String childName,
       @Param("newColor") String newColor);
 
+  /**
+   * FAILED 상태인 가정통신문만 PENDING으로 원자적으로 전환합니다.
+   *
+   * <p>동시 재시도 요청이 들어와도 첫 요청만 update count 1을 받고, 나머지는 0을 받아 중복 파이프라인 실행을 막습니다.
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      """
+      UPDATE Newsletter n
+      SET n.status = com.gachi.be.domain.newsletter.entity.enums.NewsletterStatus.PENDING,
+          n.failureStage = null,
+          n.failureReason = null,
+          n.title = null,
+          n.summary = null
+      WHERE n.id = :newsletterId
+        AND n.userId = :userId
+        AND n.status = com.gachi.be.domain.newsletter.entity.enums.NewsletterStatus.FAILED
+      """)
+  int markRetryPendingIfFailed(
+      @Param("newsletterId") Long newsletterId, @Param("userId") Long userId);
+
   /** 가정통신문 목록 조회 (자녀 필터 + 제목 검색 + 페이지네이션). */
   @Query(
       value =

--- a/src/main/java/com/gachi/be/domain/newsletter/service/NewsletterService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/service/NewsletterService.java
@@ -26,6 +26,9 @@ public interface NewsletterService {
    */
   NewsletterStatusResponse getStatus(Long userId, Long newsletterId);
 
+  /** 실패한 가정통신문 분석을 다시 대기 상태로 되돌리고 파이프라인을 재실행합니다. */
+  NewsletterUploadResponse retryAnalysis(Long userId, Long newsletterId);
+
   /** 번역 결과 조회 */
   NewsletterTranslationResponse getTranslation(Long userId, Long newsletterId);
 

--- a/src/main/java/com/gachi/be/domain/newsletter/service/impl/NewsletterServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/service/impl/NewsletterServiceImpl.java
@@ -204,14 +204,14 @@ public class NewsletterServiceImpl implements NewsletterService {
     Newsletter newsletter = findNewsletterById(newsletterId);
     validateOwnership(newsletter, userId);
 
-    if (newsletter.getStatus() != NewsletterStatus.FAILED) {
+    int updated = newsletterRepository.markRetryPendingIfFailed(newsletterId, userId);
+    if (updated == 0) {
       throw new BusinessException(ErrorCode.NEWSLETTER_RETRY_NOT_ALLOWED);
     }
 
     checklistRepository.deleteByNewsletterId(newsletterId);
     calendarEventRepository.deleteByNewsletterIdAndUserId(newsletterId, userId);
-    newsletter.prepareRetry();
-    Newsletter saved = newsletterRepository.save(newsletter);
+    Newsletter saved = findNewsletterById(newsletterId);
 
     TransactionSynchronizationManager.registerSynchronization(
         new TransactionSynchronization() {

--- a/src/main/java/com/gachi/be/domain/newsletter/service/impl/NewsletterServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/service/impl/NewsletterServiceImpl.java
@@ -194,7 +194,35 @@ public class NewsletterServiceImpl implements NewsletterService {
   public NewsletterStatusResponse getStatus(Long userId, Long newsletterId) {
     Newsletter newsletter = findNewsletterById(newsletterId);
     validateOwnership(newsletter, userId);
-    return NewsletterStatusResponse.of(newsletter.getStatus());
+    return NewsletterStatusResponse.of(newsletter);
+  }
+
+  /** 실패한 분석을 사용자가 다시 시도할 수 있도록 파생 데이터를 비우고 파이프라인을 재실행합니다. */
+  @Override
+  @Transactional
+  public NewsletterUploadResponse retryAnalysis(Long userId, Long newsletterId) {
+    Newsletter newsletter = findNewsletterById(newsletterId);
+    validateOwnership(newsletter, userId);
+
+    if (newsletter.getStatus() != NewsletterStatus.FAILED) {
+      throw new BusinessException(ErrorCode.NEWSLETTER_RETRY_NOT_ALLOWED);
+    }
+
+    checklistRepository.deleteByNewsletterId(newsletterId);
+    calendarEventRepository.deleteByNewsletterIdAndUserId(newsletterId, userId);
+    newsletter.prepareRetry();
+    Newsletter saved = newsletterRepository.save(newsletter);
+
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            log.info("[Newsletter] 분석 재시도 파이프라인 트리거. newsletterId={}", newsletterId);
+            newsletterPipelineService.runPipeline(newsletterId);
+          }
+        });
+
+    return new NewsletterUploadResponse(saved.getId(), saved.getStatus());
   }
 
   /** 번역 결과 조회 */
@@ -203,7 +231,7 @@ public class NewsletterServiceImpl implements NewsletterService {
   public NewsletterTranslationResponse getTranslation(Long userId, Long newsletterId) {
     Newsletter newsletter = findNewsletterById(newsletterId);
     validateOwnership(newsletter, userId);
-    validateCompleted(newsletter);
+    validateTextReadable(newsletter);
 
     String fileUrl = null;
     try {
@@ -512,5 +540,17 @@ public class NewsletterServiceImpl implements NewsletterService {
     if (newsletter.getStatus() != NewsletterStatus.COMPLETED) {
       throw new BusinessException(ErrorCode.NEWSLETTER_NOT_COMPLETED);
     }
+  }
+
+  private void validateTextReadable(Newsletter newsletter) {
+    if (newsletter.getStatus() == NewsletterStatus.COMPLETED) {
+      return;
+    }
+    if (newsletter.getStatus() == NewsletterStatus.FAILED
+        && newsletter.getOriginalText() != null
+        && !newsletter.getOriginalText().isBlank()) {
+      return;
+    }
+    throw new BusinessException(ErrorCode.NEWSLETTER_NOT_COMPLETED);
   }
 }

--- a/src/main/java/com/gachi/be/global/code/ErrorCode.java
+++ b/src/main/java/com/gachi/be/global/code/ErrorCode.java
@@ -195,6 +195,12 @@ public enum ErrorCode {
       "아직 분석이 완료되지 않은 가정통신문입니다.",
       "COMPLETED 상태가 아닌 newsletter 조회 시도",
       ErrorLogLevel.WARN),
+  NEWSLETTER_RETRY_NOT_ALLOWED(
+      HttpStatus.BAD_REQUEST,
+      "NL4005",
+      "실패한 가정통신문만 다시 분석할 수 있습니다.",
+      "FAILED 상태가 아닌 newsletter 분석 재시도 요청",
+      ErrorLogLevel.WARN),
 
   CHECKLIST_NOT_FOUND(
       HttpStatus.NOT_FOUND,

--- a/src/main/java/com/gachi/be/global/code/SuccessCode.java
+++ b/src/main/java/com/gachi/be/global/code/SuccessCode.java
@@ -20,6 +20,7 @@ public enum SuccessCode {
   CHILD_CREATE_SUCCESS(HttpStatus.CREATED, "CHILD2011", "자녀 정보 등록에 성공하였습니다."),
   CHILD_GET_LIST_SUCCESS(HttpStatus.OK, "CHILD2001", "내 자녀 목록 조회에 성공하였습니다."),
   NEWSLETTER_UPLOAD_SUCCESS(HttpStatus.CREATED, "NL2011", "업로드가 시작되었습니다."),
+  NEWSLETTER_RETRY_ACCEPTED(HttpStatus.ACCEPTED, "NL2021", "가정통신문 분석 재시도가 시작되었습니다."),
   NEWSLETTER_STATUS_SUCCESS(HttpStatus.OK, "NL2001", "요청에 성공하였습니다."),
   NEWSLETTER_TRANSLATION_SUCCESS(HttpStatus.OK, "NL2002", "번역 결과 조회에 성공하였습니다."),
   NEWSLETTER_SUMMARY_SUCCESS(HttpStatus.OK, "NL2003", "요약 결과 조회에 성공하였습니다."),

--- a/src/main/resources/db/migration/V11__newsletter_failure_reason.sql
+++ b/src/main/resources/db/migration/V11__newsletter_failure_reason.sql
@@ -1,0 +1,5 @@
+ALTER TABLE newsletter
+    ADD COLUMN IF NOT EXISTS failure_stage VARCHAR(50) NULL;
+
+ALTER TABLE newsletter
+    ADD COLUMN IF NOT EXISTS failure_reason TEXT NULL;

--- a/src/test/java/com/gachi/be/domain/newsletter/dto/response/NewsletterStatusResponseTest.java
+++ b/src/test/java/com/gachi/be/domain/newsletter/dto/response/NewsletterStatusResponseTest.java
@@ -1,0 +1,29 @@
+package com.gachi.be.domain.newsletter.dto.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gachi.be.domain.newsletter.entity.Newsletter;
+import com.gachi.be.domain.newsletter.entity.enums.NewsletterStatus;
+import org.junit.jupiter.api.Test;
+
+class NewsletterStatusResponseTest {
+
+  @Test
+  void failedStatusIsRetryableAndContainsFailureStage() {
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(1L)
+            .fileKey("newsletters/sample.png")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("KO")
+            .build();
+    newsletter.fail("AI_SERVER", "timeout");
+
+    NewsletterStatusResponse response = NewsletterStatusResponse.of(newsletter);
+
+    assertThat(response.status()).isEqualTo(NewsletterStatus.FAILED);
+    assertThat(response.canRetry()).isTrue();
+    assertThat(response.failureStage()).isEqualTo("AI_SERVER");
+  }
+}

--- a/src/test/java/com/gachi/be/domain/newsletter/entity/NewsletterTest.java
+++ b/src/test/java/com/gachi/be/domain/newsletter/entity/NewsletterTest.java
@@ -1,0 +1,57 @@
+package com.gachi.be.domain.newsletter.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gachi.be.domain.newsletter.entity.enums.NewsletterStatus;
+import org.junit.jupiter.api.Test;
+
+class NewsletterTest {
+
+  @Test
+  void failWithSnapshotPreservesTextExtractionResult() {
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(1L)
+            .fileKey("newsletters/sample.png")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("KO")
+            .build();
+
+    newsletter.failWithSnapshot(
+        "ocr text",
+        "original text",
+        "translated text",
+        "AI_SERVER",
+        "ExternalApiException: timeout");
+
+    assertThat(newsletter.getStatus()).isEqualTo(NewsletterStatus.FAILED);
+    assertThat(newsletter.getOcrText()).isEqualTo("ocr text");
+    assertThat(newsletter.getOriginalText()).isEqualTo("original text");
+    assertThat(newsletter.getTranslatedText()).isEqualTo("translated text");
+    assertThat(newsletter.getFailureStage()).isEqualTo("AI_SERVER");
+    assertThat(newsletter.getFailureReason()).contains("timeout");
+  }
+
+  @Test
+  void prepareRetryClearsFailureFieldsAndDerivedSummary() {
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(1L)
+            .fileKey("newsletters/sample.png")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("KO")
+            .build();
+    newsletter.complete("ocr text", "original text", null, "title", "summary");
+    newsletter.fail("AI_SERVER", "timeout");
+
+    newsletter.prepareRetry();
+
+    assertThat(newsletter.getStatus()).isEqualTo(NewsletterStatus.PENDING);
+    assertThat(newsletter.getFailureStage()).isNull();
+    assertThat(newsletter.getFailureReason()).isNull();
+    assertThat(newsletter.getTitle()).isNull();
+    assertThat(newsletter.getSummary()).isNull();
+  }
+}


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - AI 서버 호출 실패 시 newsletter 상태는 `FAILED`로 유지
  - AI 서버 장애가 발생해도 OCR/정제 원문/번역 결과/dateCandidates는 보존
  - AI 분석 결과에서 파생되는 title, summary, checklist, calendar event는 실패 시 생성하지 않도록 정리
  - 실패 원인 추적을 위한 `failureStage`, `failureReason` 저장 필드 추가
  - 상태 조회 응답에 `failureStage`, `canRetry` 추가
  - 실패한 가정통신문을 다시 분석할 수 있는 `POST /api/v1/newsletters/{newsletterId}/analysis/retry` 추가
  - AI 서버 장애 시 저장 범위와 재시도 정책 문서화
  - ErrorCode 동기화
    - `NL4005` (HTTP 400 Bad Request): 실패 상태가 아닌 가정통신문 분석 재시도 차단
  - 에러코드 스냅샷 탭(v8): [error-code-v8(gid=1519705696)](https://docs.google.com/spreadsheets/d/1sUG_JJsVl6a8nR6k8jO_b7UrIEZzuvQdPB6S2S6fqgo/edit?gid=1519705696#gid=1519705696)
  - 커밋 해시: b444225
- 관련 이슈: closes #60 

## 🌿 브랜치 정보

- **Source**: `refac/#60-newsletter-ai-failure-policy`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

```powershell
$env:GRADLE_USER_HOME='C:\Users\mjmdm\IdeaProjects\GACHI-BE\.gradle-user-home'; .\gradlew.bat --no-daemon compileJava
# BUILD SUCCESSFUL

$env:GRADLE_USER_HOME='C:\Users\mjmdm\IdeaProjects\GACHI-BE\.gradle-user-home'; .\gradlew.bat --no-daemon spotlessCheck
# BUILD SUCCESSFUL

$env:GRADLE_USER_HOME='C:\Users\mjmdm\IdeaProjects\GACHI-BE\.gradle-user-home'; .\gradlew.bat --no-daemon test --tests "com.gachi.be.domain.newsletter.entity.NewsletterTest" --tests "com.gachi.be.domain.newsletter.dto.response.NewsletterStatusResponseTest"
# BUILD SUCCESSFUL

.\scripts\run-tests-with-postgres.ps1
# PostgreSQL test container 기반 전체 테스트
# BUILD SUCCESSFUL
```