### PR TITLE
feat: 알림 단계 설정과 자동 알림 발송 구현

### DIFF
--- a/src/main/java/com/gachi/be/GachiBeApplication.java
+++ b/src/main/java/com/gachi/be/GachiBeApplication.java
@@ -3,8 +3,10 @@ package com.gachi.be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableAsync
+@EnableScheduling
 @SpringBootApplication
 public class GachiBeApplication {
 

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/SignupRequest.java
@@ -1,5 +1,6 @@
 package com.gachi.be.domain.auth.dto.request;
 
+import com.gachi.be.domain.user.entity.enums.NotificationPreference;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -22,4 +23,5 @@ public record SignupRequest(
         @Pattern(
             regexp = "^(KO|US|ZH|VI)$",
             message = "지원하지 않는 언어 코드입니다. KO, US, ZH, VI 중 하나여야 합니다.")
-        String languageCode) {}
+        String languageCode,
+    NotificationPreference notificationPreference) {}

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -139,6 +139,7 @@ public class AuthServiceImpl implements AuthService {
             .phoneNumber(phoneNumber)
             .status(UserStatus.ACTIVE)
             .languageCode(request.languageCode())
+            .notificationPreference(request.notificationPreference())
             .emailVerifiedAt(now)
             .consentAgreedAt(now)
             .consentVersion(authProperties.getConsentVersion())

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -22,6 +22,7 @@ import com.gachi.be.domain.auth.service.JwtTokenProvider;
 import com.gachi.be.domain.auth.service.TokenHashService;
 import com.gachi.be.domain.auth.service.password.PasswordStrengthEvaluator;
 import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.entity.enums.NotificationPreference;
 import com.gachi.be.domain.user.entity.enums.UserStatus;
 import com.gachi.be.domain.user.repository.UserRepository;
 import com.gachi.be.global.code.ErrorCode;
@@ -139,7 +140,10 @@ public class AuthServiceImpl implements AuthService {
             .phoneNumber(phoneNumber)
             .status(UserStatus.ACTIVE)
             .languageCode(request.languageCode())
-            .notificationPreference(request.notificationPreference())
+            .notificationPreference(
+                request.notificationPreference() != null
+                    ? request.notificationPreference()
+                    : NotificationPreference.IMPORTANT)
             .emailVerifiedAt(now)
             .consentAgreedAt(now)
             .consentVersion(authProperties.getConsentVersion())

--- a/src/main/java/com/gachi/be/domain/calendar/repository/CalendarEventRepository.java
+++ b/src/main/java/com/gachi/be/domain/calendar/repository/CalendarEventRepository.java
@@ -54,6 +54,9 @@ public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Lo
   /** 소유권 검증 포함 단건 조회. */
   Optional<CalendarEvent> findByIdAndUserId(Long id, Long userId);
 
+  List<CalendarEvent> findByStartAtGreaterThanEqualAndStartAtLessThan(
+      OffsetDateTime rangeStart, OffsetDateTime rangeEnd);
+
   /** 특정 가정통신문의 모든 일정 삭제. */
   void deleteByNewsletterIdAndUserId(Long newsletterId, Long userId);
 

--- a/src/main/java/com/gachi/be/domain/checklist/repository/ChecklistRepository.java
+++ b/src/main/java/com/gachi/be/domain/checklist/repository/ChecklistRepository.java
@@ -2,6 +2,7 @@ package com.gachi.be.domain.checklist.repository;
 
 import com.gachi.be.domain.checklist.entity.Checklist;
 import com.gachi.be.domain.checklist.entity.enums.ChecklistType;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,6 +26,11 @@ public interface ChecklistRepository extends JpaRepository<Checklist, Long> {
   /** 특정 사용자의 미완료 CHECKLIST 항목 전체 조회. */
   List<Checklist> findByUserIdAndTypeAndCompletedFalse(Long userId, ChecklistType type);
 
+  long countByUserIdAndCompletedFalse(Long userId);
+
+  List<Checklist> findByTypeAndCompletedFalseAndTargetDate(
+      ChecklistType type, LocalDate targetDate);
+
   /** 특정 캘린더 일정에 연결된 CHECKLIST 타입 항목 조회. */
   List<Checklist> findByCalendarEventIdAndTypeOrderByIdAsc(
       Long calendarEventId, ChecklistType type);
@@ -47,4 +53,14 @@ public interface ChecklistRepository extends JpaRepository<Checklist, Long> {
 
   /** e ventId IN 절로 한 번에 조회하여 서비스에서 Map으로 그룹핑 */
   List<Checklist> findByCalendarEventIdInAndType(List<Long> calendarEventIds, ChecklistType type);
+
+  @Query(
+      """
+      SELECT c FROM Checklist c
+      WHERE c.calendarEventId IN :calendarEventIds
+        AND c.type = com.gachi.be.domain.checklist.entity.enums.ChecklistType.CHECKLIST
+        AND c.completed = false
+      """)
+  List<Checklist> findIncompleteChecklistItemsByCalendarEventIds(
+      @Param("calendarEventIds") List<Long> calendarEventIds);
 }

--- a/src/main/java/com/gachi/be/domain/checklist/repository/ChecklistRepository.java
+++ b/src/main/java/com/gachi/be/domain/checklist/repository/ChecklistRepository.java
@@ -26,7 +26,7 @@ public interface ChecklistRepository extends JpaRepository<Checklist, Long> {
   /** 특정 사용자의 미완료 CHECKLIST 항목 전체 조회. */
   List<Checklist> findByUserIdAndTypeAndCompletedFalse(Long userId, ChecklistType type);
 
-  long countByUserIdAndCompletedFalse(Long userId);
+  long countByUserIdAndTypeAndCompletedFalse(Long userId, ChecklistType type);
 
   List<Checklist> findByTypeAndCompletedFalseAndTargetDate(
       ChecklistType type, LocalDate targetDate);

--- a/src/main/java/com/gachi/be/domain/child/repository/ChildRepository.java
+++ b/src/main/java/com/gachi/be/domain/child/repository/ChildRepository.java
@@ -10,9 +10,9 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
 
   long countByUserId(Long userId);
 
-  /** 특정 사용자의 활성 자녀 목록 조회 */
   List<Child> findByUserIdAndDeletedAtIsNull(Long userId);
 
-  /** 특정 사용자의 특정 자녀 조회 */
   Optional<Child> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
+
+  Optional<Child> findFirstByUserIdAndNameAndDeletedAtIsNull(Long userId, String name);
 }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
@@ -188,7 +188,15 @@ public class NewsletterPipelineService {
             n -> {
               n.complete(ocrText, originalText, translatedText, title, summary);
               Newsletter saved = newsletterRepository.save(n);
-              createAnalysisCompletedNotification(saved);
+              try {
+                createAnalysisCompletedNotification(saved);
+              } catch (Exception ex) {
+                log.warn(
+                    "[Pipeline] 분석 완료 알림 생성 실패. newsletterId={}, error={}",
+                    saved.getId(),
+                    ex.getMessage(),
+                    ex);
+              }
             });
   }
 

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
@@ -1,26 +1,17 @@
 package com.gachi.be.domain.newsletter.pipeline;
 
-import com.gachi.be.domain.child.repository.ChildRepository;
 import com.gachi.be.domain.newsletter.entity.Newsletter;
 import com.gachi.be.domain.newsletter.pipeline.ClovaOcrClient.OcrField;
 import com.gachi.be.domain.newsletter.pipeline.NewsletterAiAnalyzer.AiAnalysisResult;
 import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
-import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
-import com.gachi.be.domain.notification.entity.enums.NotificationType;
-import com.gachi.be.domain.notification.service.NotificationCreateCommand;
-import com.gachi.be.domain.notification.service.NotificationService;
 import com.gachi.be.file.config.S3Properties;
 import com.gachi.be.global.exception.ExternalApiException;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -42,8 +33,7 @@ public class NewsletterPipelineService {
   private final PapagoTranslateClient papagoTranslateClient;
   private final NewsletterAiAnalyzer newsletterAiAnalyzer;
   private final NewsletterDateCandidateService newsletterDateCandidateService;
-  private final NotificationService notificationService;
-  private final ChildRepository childRepository;
+  private final NewsletterPipelineStatusService newsletterPipelineStatusService;
 
   @Async
   @Transactional
@@ -56,7 +46,7 @@ public class NewsletterPipelineService {
       return;
     }
 
-    markProcessing(newsletterId);
+    newsletterPipelineStatusService.markProcessing(newsletterId);
     log.debug("[Pipeline] PROCESSING 전환 완료. newsletterId={}", newsletterId);
 
     String tempFileKey = null;
@@ -126,13 +116,13 @@ public class NewsletterPipelineService {
             e.getClass().getSimpleName(),
             e.getMessage(),
             e);
-        markFailedWithSnapshot(
+        newsletterPipelineStatusService.markFailedWithSnapshot(
             newsletterId, ocrText, originalText, translatedText, failureStage, failureReason(e));
         return;
       }
       log.debug("[Pipeline][STEP7] AI 서버 분석 완료. title={}", aiResult.title());
 
-      markCompleted(
+      newsletterPipelineStatusService.markCompleted(
           newsletterId,
           ocrText,
           originalText,
@@ -149,7 +139,7 @@ public class NewsletterPipelineService {
           e.getClass().getSimpleName(),
           e.getMessage(),
           e);
-      markFailedWithSnapshot(
+      newsletterPipelineStatusService.markFailedWithSnapshot(
           newsletterId, ocrText, originalText, translatedText, failureStage, failureReason(e));
     } finally {
       if (tempFileKey != null) {
@@ -157,59 +147,11 @@ public class NewsletterPipelineService {
           deleteFromS3(tempFileKey);
           log.debug("[Pipeline] 임시 파일 삭제 완료. tempFileKey={}", tempFileKey);
         } catch (Exception ex) {
-          // 임시 파일 정리는 후처리라서 실패해도 분석 결과는 되돌리지 않는다.
           log.warn(
               "[Pipeline] 임시 파일 삭제 실패. tempFileKey={}, error={}", tempFileKey, ex.getMessage());
         }
       }
     }
-  }
-
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void markProcessing(Long newsletterId) {
-    newsletterRepository
-        .findById(newsletterId)
-        .ifPresent(
-            n -> {
-              n.startProcessing();
-              newsletterRepository.save(n);
-            });
-  }
-
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void markCompleted(
-      Long newsletterId,
-      String ocrText,
-      String originalText,
-      String translatedText,
-      String title,
-      String summary) {
-    newsletterRepository
-        .findById(newsletterId)
-        .ifPresent(
-            n -> {
-              n.complete(ocrText, originalText, translatedText, title, summary);
-              Newsletter saved = newsletterRepository.save(n);
-              scheduleAnalysisCompletedNotification(saved);
-            });
-  }
-
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void markFailedWithSnapshot(
-      Long newsletterId,
-      String ocrText,
-      String originalText,
-      String translatedText,
-      String failureStage,
-      String failureReason) {
-    newsletterRepository
-        .findById(newsletterId)
-        .ifPresent(
-            n -> {
-              n.failWithSnapshot(
-                  ocrText, originalText, translatedText, failureStage, failureReason);
-              newsletterRepository.save(n);
-            });
   }
 
   private String failureReason(Exception e) {
@@ -218,64 +160,6 @@ public class NewsletterPipelineService {
       return e.getClass().getSimpleName();
     }
     return e.getClass().getSimpleName() + ": " + message;
-  }
-
-  private void scheduleAnalysisCompletedNotification(Newsletter newsletter) {
-    if (TransactionSynchronizationManager.isSynchronizationActive()) {
-      TransactionSynchronizationManager.registerSynchronization(
-          new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-              createAnalysisCompletedNotificationSafely(newsletter);
-            }
-          });
-      return;
-    }
-    createAnalysisCompletedNotificationSafely(newsletter);
-  }
-
-  private void createAnalysisCompletedNotificationSafely(Newsletter newsletter) {
-    try {
-      createAnalysisCompletedNotification(newsletter);
-    } catch (Exception ex) {
-      log.warn(
-          "[Pipeline] 분석 완료 알림 생성 실패. newsletterId={}, error={}",
-          newsletter.getId(),
-          ex.getMessage(),
-          ex);
-    }
-  }
-
-  private void createAnalysisCompletedNotification(Newsletter newsletter) {
-    Long childId = resolveChildId(newsletter);
-    notificationService.createNotification(
-        newsletter.getUserId(),
-        new NotificationCreateCommand(
-            NotificationType.NEWSLETTER_ANALYSIS,
-            "새 가정통신문 분석 완료",
-            newsletter.getTitle() != null && !newsletter.getTitle().isBlank()
-                ? newsletter.getTitle() + " 분석이 완료되었어요"
-                : "가정통신문 분석이 완료되었어요",
-            Map.of(
-                "newsletterId",
-                newsletter.getId(),
-                "childName",
-                newsletter.getChildName() != null ? newsletter.getChildName() : ""),
-            "newsletter-analysis:" + newsletter.getId(),
-            NotificationLevel.IMPORTANT,
-            childId,
-            newsletter.getChildName()));
-  }
-
-  private Long resolveChildId(Newsletter newsletter) {
-    if (newsletter.getChildName() == null || newsletter.getChildName().isBlank()) {
-      return null;
-    }
-    return childRepository
-        .findFirstByUserIdAndNameAndDeletedAtIsNull(
-            newsletter.getUserId(), newsletter.getChildName())
-        .map(child -> child.getId())
-        .orElse(null);
   }
 
   private byte[] downloadFromS3(String fileKey) {

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
@@ -1,12 +1,18 @@
 package com.gachi.be.domain.newsletter.pipeline;
 
+import com.gachi.be.domain.child.repository.ChildRepository;
 import com.gachi.be.domain.newsletter.entity.Newsletter;
 import com.gachi.be.domain.newsletter.pipeline.ClovaOcrClient.OcrField;
 import com.gachi.be.domain.newsletter.pipeline.NewsletterAiAnalyzer.AiAnalysisResult;
 import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
+import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
+import com.gachi.be.domain.notification.entity.enums.NotificationType;
+import com.gachi.be.domain.notification.service.NotificationCreateCommand;
+import com.gachi.be.domain.notification.service.NotificationService;
 import com.gachi.be.file.config.S3Properties;
 import com.gachi.be.global.exception.ExternalApiException;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -34,6 +40,8 @@ public class NewsletterPipelineService {
   private final PapagoTranslateClient papagoTranslateClient;
   private final NewsletterAiAnalyzer newsletterAiAnalyzer;
   private final NewsletterDateCandidateService newsletterDateCandidateService;
+  private final NotificationService notificationService;
+  private final ChildRepository childRepository;
 
   @Async
   @Transactional
@@ -179,7 +187,8 @@ public class NewsletterPipelineService {
         .ifPresent(
             n -> {
               n.complete(ocrText, originalText, translatedText, title, summary);
-              newsletterRepository.save(n);
+              Newsletter saved = newsletterRepository.save(n);
+              createAnalysisCompletedNotification(saved);
             });
   }
 
@@ -207,6 +216,38 @@ public class NewsletterPipelineService {
       return e.getClass().getSimpleName();
     }
     return e.getClass().getSimpleName() + ": " + message;
+  }
+
+  private void createAnalysisCompletedNotification(Newsletter newsletter) {
+    Long childId = resolveChildId(newsletter);
+    notificationService.createNotification(
+        newsletter.getUserId(),
+        new NotificationCreateCommand(
+            NotificationType.NEWSLETTER_ANALYSIS,
+            "새 가정통신문 분석 완료",
+            newsletter.getTitle() != null && !newsletter.getTitle().isBlank()
+                ? newsletter.getTitle() + " 분석이 완료되었어요"
+                : "가정통신문 분석이 완료되었어요",
+            Map.of(
+                "newsletterId",
+                newsletter.getId(),
+                "childName",
+                newsletter.getChildName() != null ? newsletter.getChildName() : ""),
+            "newsletter-analysis:" + newsletter.getId(),
+            NotificationLevel.IMPORTANT,
+            childId,
+            newsletter.getChildName()));
+  }
+
+  private Long resolveChildId(Newsletter newsletter) {
+    if (newsletter.getChildName() == null || newsletter.getChildName().isBlank()) {
+      return null;
+    }
+    return childRepository
+        .findFirstByUserIdAndNameAndDeletedAtIsNull(
+            newsletter.getUserId(), newsletter.getChildName())
+        .map(child -> child.getId())
+        .orElse(null);
   }
 
   private byte[] downloadFromS3(String fileKey) {

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
@@ -19,6 +19,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -188,15 +190,7 @@ public class NewsletterPipelineService {
             n -> {
               n.complete(ocrText, originalText, translatedText, title, summary);
               Newsletter saved = newsletterRepository.save(n);
-              try {
-                createAnalysisCompletedNotification(saved);
-              } catch (Exception ex) {
-                log.warn(
-                    "[Pipeline] 분석 완료 알림 생성 실패. newsletterId={}, error={}",
-                    saved.getId(),
-                    ex.getMessage(),
-                    ex);
-              }
+              scheduleAnalysisCompletedNotification(saved);
             });
   }
 
@@ -224,6 +218,32 @@ public class NewsletterPipelineService {
       return e.getClass().getSimpleName();
     }
     return e.getClass().getSimpleName() + ": " + message;
+  }
+
+  private void scheduleAnalysisCompletedNotification(Newsletter newsletter) {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              createAnalysisCompletedNotificationSafely(newsletter);
+            }
+          });
+      return;
+    }
+    createAnalysisCompletedNotificationSafely(newsletter);
+  }
+
+  private void createAnalysisCompletedNotificationSafely(Newsletter newsletter) {
+    try {
+      createAnalysisCompletedNotification(newsletter);
+    } catch (Exception ex) {
+      log.warn(
+          "[Pipeline] 분석 완료 알림 생성 실패. newsletterId={}, error={}",
+          newsletter.getId(),
+          ex.getMessage(),
+          ex);
+    }
   }
 
   private void createAnalysisCompletedNotification(Newsletter newsletter) {

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusService.java
@@ -1,0 +1,132 @@
+package com.gachi.be.domain.newsletter.pipeline;
+
+import com.gachi.be.domain.child.repository.ChildRepository;
+import com.gachi.be.domain.newsletter.entity.Newsletter;
+import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
+import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
+import com.gachi.be.domain.notification.entity.enums.NotificationType;
+import com.gachi.be.domain.notification.service.NotificationCreateCommand;
+import com.gachi.be.domain.notification.service.NotificationService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewsletterPipelineStatusService {
+
+  private final NewsletterRepository newsletterRepository;
+  private final NotificationService notificationService;
+  private final ChildRepository childRepository;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void markProcessing(Long newsletterId) {
+    newsletterRepository
+        .findById(newsletterId)
+        .ifPresent(
+            newsletter -> {
+              newsletter.startProcessing();
+              newsletterRepository.save(newsletter);
+            });
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void markCompleted(
+      Long newsletterId,
+      String ocrText,
+      String originalText,
+      String translatedText,
+      String title,
+      String summary) {
+    newsletterRepository
+        .findById(newsletterId)
+        .ifPresent(
+            newsletter -> {
+              newsletter.complete(ocrText, originalText, translatedText, title, summary);
+              Newsletter saved = newsletterRepository.save(newsletter);
+              scheduleAnalysisCompletedNotification(saved);
+            });
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void markFailedWithSnapshot(
+      Long newsletterId,
+      String ocrText,
+      String originalText,
+      String translatedText,
+      String failureStage,
+      String failureReason) {
+    newsletterRepository
+        .findById(newsletterId)
+        .ifPresent(
+            newsletter -> {
+              newsletter.failWithSnapshot(
+                  ocrText, originalText, translatedText, failureStage, failureReason);
+              newsletterRepository.save(newsletter);
+            });
+  }
+
+  private void scheduleAnalysisCompletedNotification(Newsletter newsletter) {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              createAnalysisCompletedNotificationSafely(newsletter);
+            }
+          });
+      return;
+    }
+    createAnalysisCompletedNotificationSafely(newsletter);
+  }
+
+  private void createAnalysisCompletedNotificationSafely(Newsletter newsletter) {
+    try {
+      createAnalysisCompletedNotification(newsletter);
+    } catch (Exception ex) {
+      log.warn(
+          "[Pipeline] 분석 완료 알림 생성 실패. newsletterId={}, error={}",
+          newsletter.getId(),
+          ex.getMessage(),
+          ex);
+    }
+  }
+
+  private void createAnalysisCompletedNotification(Newsletter newsletter) {
+    Long childId = resolveChildId(newsletter);
+    notificationService.createNotification(
+        newsletter.getUserId(),
+        new NotificationCreateCommand(
+            NotificationType.NEWSLETTER_ANALYSIS,
+            "새 가정통신문 분석 완료",
+            newsletter.getTitle() != null && !newsletter.getTitle().isBlank()
+                ? newsletter.getTitle() + " 분석이 완료되었어요"
+                : "가정통신문 분석이 완료되었어요",
+            Map.of(
+                "newsletterId",
+                newsletter.getId(),
+                "childName",
+                newsletter.getChildName() != null ? newsletter.getChildName() : ""),
+            "newsletter-analysis:" + newsletter.getId(),
+            NotificationLevel.IMPORTANT,
+            childId,
+            newsletter.getChildName()));
+  }
+
+  private Long resolveChildId(Newsletter newsletter) {
+    if (newsletter.getChildName() == null || newsletter.getChildName().isBlank()) {
+      return null;
+    }
+    return childRepository
+        .findFirstByUserIdAndNameAndDeletedAtIsNull(
+            newsletter.getUserId(), newsletter.getChildName())
+        .map(child -> child.getId())
+        .orElse(null);
+  }
+}

--- a/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
@@ -97,6 +97,9 @@ public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
       @Param("rangeStart") OffsetDateTime rangeStart,
       @Param("rangeEnd") OffsetDateTime rangeEnd);
 
+  long countByUserIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+      Long userId, OffsetDateTime rangeStart, OffsetDateTime rangeEnd);
+
   /** 언어 변경 시 진행중인 파이프라인 중단 처리용 쿼리 */
   @Modifying
   @Query(

--- a/src/main/java/com/gachi/be/domain/notification/api/controller/NotificationController.java
+++ b/src/main/java/com/gachi/be/domain/notification/api/controller/NotificationController.java
@@ -40,14 +40,9 @@ public class NotificationController {
 
   private final NotificationService notificationService;
 
-  /** 푸시 수신 누락을 복구하기 위해 서버에 저장된 알림 보관함을 최신순으로 조회한다. */
   @Operation(
       summary = "알림 목록 조회",
-      description =
-          """
-          React Native 앱이 푸시를 받지 못한 경우에도 이 API로 서버 보관함을 동기화할 수 있습니다.
-          cursor는 이전 응답의 nextCursor를 그대로 전달하고, unreadOnly=true면 미읽음 알림만 조회합니다.
-          """)
+      description = "서버에 저장된 알림을 최신순으로 조회합니다. childId를 전달하면 특정 아이의 알림만 조회합니다.")
   @GetMapping
   public ApiResponse<NotificationListResponse> getNotifications(
       @AuthenticationPrincipal Long userId,
@@ -59,10 +54,13 @@ public class NotificationController {
           @Max(100)
           Integer size,
       @Parameter(description = "미읽음 알림만 조회할지 여부") @RequestParam(defaultValue = "false")
-          boolean unreadOnly) {
+          boolean unreadOnly,
+      @Parameter(description = "아이별 알림 조회용 childId. 생략하면 전체 알림을 조회합니다.")
+          @RequestParam(required = false)
+          Long childId) {
     return ApiResponse.success(
         SuccessCode.NOTIFICATION_LIST_SUCCESS,
-        notificationService.getNotifications(userId, cursor, size, unreadOnly));
+        notificationService.getNotifications(userId, cursor, size, unreadOnly, childId));
   }
 
   @Operation(summary = "미읽음 알림 수 조회", description = "사용자 기준 미읽음 알림 개수를 반환합니다.")
@@ -73,7 +71,7 @@ public class NotificationController {
         SuccessCode.NOTIFICATION_UNREAD_COUNT_SUCCESS, notificationService.getUnreadCount(userId));
   }
 
-  @Operation(summary = "단건 읽음 처리", description = "알림 상세 진입 또는 알림 탭 노출 후 단건 읽음 처리에 사용합니다.")
+  @Operation(summary = "단건 읽음 처리", description = "알림 클릭 후 관련 페이지로 이동할 때 호출합니다.")
   @PatchMapping("/{notificationId}/read")
   public ApiResponse<NotificationReadResponse> markRead(
       @AuthenticationPrincipal Long userId, @PathVariable Long notificationId) {
@@ -82,7 +80,7 @@ public class NotificationController {
         notificationService.markRead(userId, notificationId));
   }
 
-  @Operation(summary = "일괄 읽음 처리", description = "앱이 서버 보관함을 동기화한 뒤 여러 알림을 한 번에 읽음 처리합니다.")
+  @Operation(summary = "일괄 읽음 처리", description = "여러 알림을 한 번에 읽음 처리합니다.")
   @PatchMapping("/read")
   public ApiResponse<NotificationReadResponse> markRead(
       @AuthenticationPrincipal Long userId, @Valid @RequestBody NotificationReadRequest request) {
@@ -97,13 +95,7 @@ public class NotificationController {
         SuccessCode.NOTIFICATION_READ_SUCCESS, notificationService.markAllRead(userId));
   }
 
-  @Operation(
-      summary = "푸시 토큰 등록/갱신",
-      description =
-          """
-          RN 앱 시작, 로그인 직후, 토큰 refresh 이벤트에서 호출합니다.
-          같은 토큰이 재등록되면 기존 레코드를 활성화하고 플랫폼/디바이스 정보를 갱신합니다.
-          """)
+  @Operation(summary = "푸시 토큰 등록/갱신", description = "RN 앱 시작, 로그인 직후, 토큰 refresh 이벤트에서 호출합니다.")
   @PostMapping("/tokens")
   public ApiResponse<PushTokenResponse> registerPushToken(
       @AuthenticationPrincipal Long userId, @Valid @RequestBody PushTokenRegisterRequest request) {
@@ -112,9 +104,7 @@ public class NotificationController {
         notificationService.registerPushToken(userId, request));
   }
 
-  @Operation(
-      summary = "푸시 토큰 삭제",
-      description = "로그아웃, 권한 철회, 앱 삭제 전 토큰 정리 시 호출합니다. 이미 삭제된 토큰도 성공으로 처리합니다.")
+  @Operation(summary = "푸시 토큰 삭제", description = "로그아웃, 권한 철회, 탈퇴 시 토큰 정리에 사용합니다.")
   @DeleteMapping("/tokens")
   public ApiResponse<Void> deletePushToken(
       @AuthenticationPrincipal Long userId, @Valid @RequestBody PushTokenDeleteRequest request) {

--- a/src/main/java/com/gachi/be/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/gachi/be/domain/notification/dto/response/NotificationResponse.java
@@ -1,5 +1,6 @@
 package com.gachi.be.domain.notification.dto.response;
 
+import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
 import com.gachi.be.domain.notification.entity.enums.NotificationType;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -7,6 +8,9 @@ import java.util.Map;
 public record NotificationResponse(
     Long id,
     NotificationType type,
+    NotificationLevel level,
+    Long childId,
+    String childName,
     String title,
     String body,
     Map<String, Object> payload,

--- a/src/main/java/com/gachi/be/domain/notification/entity/Notification.java
+++ b/src/main/java/com/gachi/be/domain/notification/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.gachi.be.domain.notification.entity;
 
+import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
 import com.gachi.be.domain.notification.entity.enums.NotificationType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -35,6 +36,16 @@ public class Notification {
   @Column(nullable = false, length = 40)
   private NotificationType type;
 
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private NotificationLevel level;
+
+  @Column(name = "child_id")
+  private Long childId;
+
+  @Column(name = "child_name", length = 50)
+  private String childName;
+
   @Column(nullable = false, length = 120)
   private String title;
 
@@ -60,12 +71,18 @@ public class Notification {
   public Notification(
       Long userId,
       NotificationType type,
+      NotificationLevel level,
+      Long childId,
+      String childName,
       String title,
       String body,
       String payloadJson,
       String dedupeKey) {
     this.userId = userId;
     this.type = type;
+    this.level = level != null ? level : NotificationLevel.IMPORTANT;
+    this.childId = childId;
+    this.childName = childName;
     this.title = title;
     this.body = body;
     this.payloadJson = payloadJson;
@@ -87,6 +104,9 @@ public class Notification {
     OffsetDateTime now = OffsetDateTime.now();
     if (createdAt == null) {
       createdAt = now;
+    }
+    if (level == null) {
+      level = NotificationLevel.IMPORTANT;
     }
     updatedAt = now;
   }

--- a/src/main/java/com/gachi/be/domain/notification/entity/enums/NotificationLevel.java
+++ b/src/main/java/com/gachi/be/domain/notification/entity/enums/NotificationLevel.java
@@ -1,0 +1,8 @@
+package com.gachi.be.domain.notification.entity.enums;
+
+/** 사용자 알림 설정 단계에서 외부 푸시 발송 여부를 판단할 때 사용하는 중요도. */
+public enum NotificationLevel {
+  URGENT,
+  IMPORTANT,
+  NORMAL
+}

--- a/src/main/java/com/gachi/be/domain/notification/entity/enums/NotificationType.java
+++ b/src/main/java/com/gachi/be/domain/notification/entity/enums/NotificationType.java
@@ -3,8 +3,10 @@ package com.gachi.be.domain.notification.entity.enums;
 /** 앱 알림이 어떤 기능에서 만들어졌는지 구분한다. */
 public enum NotificationType {
   NEWSLETTER_ANALYSIS,
+  DEADLINE_REMINDER,
   CALENDAR_EVENT,
   CHECKLIST_DUE,
+  WEEKLY_SUMMARY,
   SYSTEM,
   ANNOUNCEMENT
 }

--- a/src/main/java/com/gachi/be/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gachi/be/domain/notification/repository/NotificationRepository.java
@@ -19,7 +19,11 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
       WHERE n.userId = :userId
         AND (:cursorId IS NULL OR n.id < :cursorId)
         AND (:unreadOnly = false OR n.readAt IS NULL)
-        AND (:childId IS NULL OR n.childId = :childId OR n.childName = :childName)
+        AND (
+          :childId IS NULL
+          OR n.childId = :childId
+          OR (n.childId IS NULL AND n.childName = :childName)
+        )
       ORDER BY n.id DESC
       """)
   List<Notification> findInbox(

--- a/src/main/java/com/gachi/be/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gachi/be/domain/notification/repository/NotificationRepository.java
@@ -19,11 +19,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
       WHERE n.userId = :userId
         AND (:cursorId IS NULL OR n.id < :cursorId)
         AND (:unreadOnly = false OR n.readAt IS NULL)
+        AND (:childId IS NULL OR n.childId = :childId OR n.childName = :childName)
       ORDER BY n.id DESC
       """)
   List<Notification> findInbox(
       @Param("userId") Long userId,
       @Param("cursorId") Long cursorId,
+      @Param("childId") Long childId,
+      @Param("childName") String childName,
       @Param("unreadOnly") boolean unreadOnly,
       Pageable pageable);
 

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationCreateCommand.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationCreateCommand.java
@@ -1,12 +1,26 @@
 package com.gachi.be.domain.notification.service;
 
+import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
 import com.gachi.be.domain.notification.entity.enums.NotificationType;
 import java.util.Map;
 
-/** 다른 도메인에서 사용자 알림을 만들 때 넘기는 최소 입력값. */
+/** 다른 도메인이 사용자 알림을 생성할 때 전달하는 최소 입력값. */
 public record NotificationCreateCommand(
     NotificationType type,
     String title,
     String body,
     Map<String, Object> payload,
-    String dedupeKey) {}
+    String dedupeKey,
+    NotificationLevel level,
+    Long childId,
+    String childName) {
+
+  public NotificationCreateCommand(
+      NotificationType type,
+      String title,
+      String body,
+      Map<String, Object> payload,
+      String dedupeKey) {
+    this(type, title, body, payload, dedupeKey, NotificationLevel.IMPORTANT, null, null);
+  }
+}

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationPushDispatcher.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationPushDispatcher.java
@@ -67,8 +67,8 @@ public class NotificationPushDispatcher {
       saveSkipped(notification, null, "사용자를 찾을 수 없어 푸시 발송을 건너뜁니다.");
       return;
     }
-    if (!user.isNotificationEnabled()) {
-      saveSkipped(notification, null, "사용자 알림 수신 설정이 꺼져 있습니다.");
+    if (!user.getNotificationPreference().allows(notification.getLevel())) {
+      saveSkipped(notification, null, "사용자 알림 단계에서 제외된 알림입니다.");
       return;
     }
     if (!properties.isEnabled()) {

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationScheduler.java
@@ -70,7 +70,7 @@ public class NotificationScheduler {
       payload.put("targetDate", targetDate.toString());
       putIfPresent(payload, "childName", event.getChildName());
 
-      notificationService.createNotification(
+      createNotificationSafely(
           event.getUserId(),
           new NotificationCreateCommand(
               NotificationType.DEADLINE_REMINDER,
@@ -80,7 +80,8 @@ public class NotificationScheduler {
               "deadline:" + event.getId() + ":" + targetDate,
               NotificationLevel.URGENT,
               childId,
-              event.getChildName()));
+              event.getChildName()),
+          "deadline:" + event.getId());
     }
   }
 
@@ -104,7 +105,7 @@ public class NotificationScheduler {
       payload.put("targetDate", targetDate.toString());
       putIfPresent(payload, "childName", childName);
 
-      notificationService.createNotification(
+      createNotificationSafely(
           checklist.getUserId(),
           new NotificationCreateCommand(
               NotificationType.CHECKLIST_DUE,
@@ -114,7 +115,8 @@ public class NotificationScheduler {
               "todo:" + checklist.getId() + ":d-" + daysBefore + ":" + targetDate,
               NotificationLevel.IMPORTANT,
               childId,
-              childName));
+              childName),
+          "todo:" + checklist.getId());
     }
   }
 
@@ -147,7 +149,7 @@ public class NotificationScheduler {
       payload.put("targetDate", targetDate.toString());
       putIfPresent(payload, "childName", event.getChildName());
 
-      notificationService.createNotification(
+      createNotificationSafely(
           checklist.getUserId(),
           new NotificationCreateCommand(
               NotificationType.CHECKLIST_DUE,
@@ -157,7 +159,8 @@ public class NotificationScheduler {
               "checklist:" + checklist.getId() + ":d-" + daysBefore + ":" + targetDate,
               NotificationLevel.IMPORTANT,
               childId,
-              event.getChildName()));
+              event.getChildName()),
+          "checklist:" + checklist.getId());
     }
   }
 
@@ -170,7 +173,9 @@ public class NotificationScheduler {
       long newsletterCount =
           newsletterRepository.countByUserIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
               user.getId(), rangeStart, rangeEnd);
-      long incompleteCount = checklistRepository.countByUserIdAndCompletedFalse(user.getId());
+      long incompleteCount =
+          checklistRepository.countByUserIdAndTypeAndCompletedFalse(
+              user.getId(), ChecklistType.CHECKLIST);
 
       Map<String, Object> payload = payload();
       payload.put("rangeStart", rangeStartDate.toString());
@@ -178,7 +183,7 @@ public class NotificationScheduler {
       payload.put("newsletterCount", newsletterCount);
       payload.put("incompleteChecklistCount", incompleteCount);
 
-      notificationService.createNotification(
+      createNotificationSafely(
           user.getId(),
           new NotificationCreateCommand(
               NotificationType.WEEKLY_SUMMARY,
@@ -188,7 +193,8 @@ public class NotificationScheduler {
               "weekly-summary:" + user.getId() + ":" + rangeStartDate,
               NotificationLevel.NORMAL,
               null,
-              null));
+              null),
+          "weekly-summary:" + user.getId());
     }
   }
 
@@ -222,6 +228,20 @@ public class NotificationScheduler {
   private void putIfPresent(Map<String, Object> payload, String key, Object value) {
     if (value != null) {
       payload.put(key, value);
+    }
+  }
+
+  private void createNotificationSafely(
+      Long userId, NotificationCreateCommand command, String context) {
+    try {
+      notificationService.createNotification(userId, command);
+    } catch (Exception e) {
+      log.warn(
+          "[Scheduler] 알림 생성 실패. context={}, userId={}, error={}",
+          context,
+          userId,
+          e.getMessage(),
+          e);
     }
   }
 

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationScheduler.java
@@ -1,0 +1,229 @@
+package com.gachi.be.domain.notification.service;
+
+import com.gachi.be.domain.calendar.entity.CalendarEvent;
+import com.gachi.be.domain.calendar.repository.CalendarEventRepository;
+import com.gachi.be.domain.checklist.entity.Checklist;
+import com.gachi.be.domain.checklist.entity.enums.ChecklistType;
+import com.gachi.be.domain.checklist.repository.ChecklistRepository;
+import com.gachi.be.domain.child.repository.ChildRepository;
+import com.gachi.be.domain.newsletter.entity.Newsletter;
+import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
+import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
+import com.gachi.be.domain.notification.entity.enums.NotificationType;
+import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.entity.enums.UserStatus;
+import com.gachi.be.domain.user.repository.UserRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** 마감/체크리스트/주간 요약처럼 사용자의 별도 요청 없이 생성되어야 하는 알림을 만든다. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+  private final CalendarEventRepository calendarEventRepository;
+  private final ChecklistRepository checklistRepository;
+  private final NewsletterRepository newsletterRepository;
+  private final UserRepository userRepository;
+  private final ChildRepository childRepository;
+  private final NotificationService notificationService;
+  private final Clock clock;
+
+  @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
+  public void createDailyReminders() {
+    LocalDate today = LocalDate.now(clock);
+    createDeadlineReminders(today.plusDays(1));
+    createChecklistReminders(today.plusDays(3), 3);
+    createChecklistReminders(today.plusDays(1), 1);
+  }
+
+  @Scheduled(cron = "0 30 9 * * SUN", zone = "Asia/Seoul")
+  public void createWeeklySummaries() {
+    LocalDate today = LocalDate.now(clock);
+    createWeeklySummaries(today.minusDays(6), today.plusDays(1));
+  }
+
+  public void createDeadlineReminders(LocalDate targetDate) {
+    TimeRange range = dayRange(targetDate);
+    List<CalendarEvent> events =
+        calendarEventRepository.findByStartAtGreaterThanEqualAndStartAtLessThan(
+            range.start(), range.end());
+
+    for (CalendarEvent event : events) {
+      Long childId = resolveChildId(event.getUserId(), event.getChildName());
+      Map<String, Object> payload = payload();
+      payload.put("calendarEventId", event.getId());
+      payload.put("newsletterId", event.getNewsletterId());
+      payload.put("targetDate", targetDate.toString());
+      putIfPresent(payload, "childName", event.getChildName());
+
+      notificationService.createNotification(
+          event.getUserId(),
+          new NotificationCreateCommand(
+              NotificationType.DEADLINE_REMINDER,
+              event.getTitle() + " 마감 D-1",
+              "내일 마감이에요",
+              payload,
+              "deadline:" + event.getId() + ":" + targetDate,
+              NotificationLevel.URGENT,
+              childId,
+              event.getChildName()));
+    }
+  }
+
+  public void createChecklistReminders(LocalDate targetDate, int daysBefore) {
+    createTodoReminders(targetDate, daysBefore);
+    createLinkedChecklistReminders(targetDate, daysBefore);
+  }
+
+  private void createTodoReminders(LocalDate targetDate, int daysBefore) {
+    List<Checklist> todos =
+        checklistRepository.findByTypeAndCompletedFalseAndTargetDate(
+            ChecklistType.TODO, targetDate);
+    for (Checklist checklist : todos) {
+      Newsletter newsletter = findNewsletter(checklist.getNewsletterId());
+      String childName = newsletter != null ? newsletter.getChildName() : null;
+      Long childId = resolveChildId(checklist.getUserId(), childName);
+
+      Map<String, Object> payload = payload();
+      payload.put("checklistId", checklist.getId());
+      payload.put("newsletterId", checklist.getNewsletterId());
+      payload.put("targetDate", targetDate.toString());
+      putIfPresent(payload, "childName", childName);
+
+      notificationService.createNotification(
+          checklist.getUserId(),
+          new NotificationCreateCommand(
+              NotificationType.CHECKLIST_DUE,
+              "미완료 할 일이 있어요",
+              checklist.getContent(),
+              payload,
+              "todo:" + checklist.getId() + ":d-" + daysBefore + ":" + targetDate,
+              NotificationLevel.IMPORTANT,
+              childId,
+              childName));
+    }
+  }
+
+  private void createLinkedChecklistReminders(LocalDate targetDate, int daysBefore) {
+    TimeRange range = dayRange(targetDate);
+    List<CalendarEvent> events =
+        calendarEventRepository.findByStartAtGreaterThanEqualAndStartAtLessThan(
+            range.start(), range.end());
+    if (events.isEmpty()) {
+      return;
+    }
+
+    Map<Long, CalendarEvent> eventById =
+        events.stream().collect(Collectors.toMap(CalendarEvent::getId, Function.identity()));
+    List<Checklist> checklists =
+        checklistRepository.findIncompleteChecklistItemsByCalendarEventIds(
+            eventById.keySet().stream().toList());
+
+    for (Checklist checklist : checklists) {
+      CalendarEvent event = eventById.get(checklist.getCalendarEventId());
+      if (event == null) {
+        continue;
+      }
+      Long childId = resolveChildId(checklist.getUserId(), event.getChildName());
+
+      Map<String, Object> payload = payload();
+      payload.put("checklistId", checklist.getId());
+      payload.put("calendarEventId", event.getId());
+      payload.put("newsletterId", checklist.getNewsletterId());
+      payload.put("targetDate", targetDate.toString());
+      putIfPresent(payload, "childName", event.getChildName());
+
+      notificationService.createNotification(
+          checklist.getUserId(),
+          new NotificationCreateCommand(
+              NotificationType.CHECKLIST_DUE,
+              "미완료 할 일이 있어요",
+              checklist.getContent(),
+              payload,
+              "checklist:" + checklist.getId() + ":d-" + daysBefore + ":" + targetDate,
+              NotificationLevel.IMPORTANT,
+              childId,
+              event.getChildName()));
+    }
+  }
+
+  public void createWeeklySummaries(LocalDate rangeStartDate, LocalDate rangeEndDate) {
+    OffsetDateTime rangeStart = rangeStartDate.atStartOfDay(KST).toOffsetDateTime();
+    OffsetDateTime rangeEnd = rangeEndDate.atStartOfDay(KST).toOffsetDateTime();
+    List<User> users = userRepository.findAllByStatus(UserStatus.ACTIVE);
+
+    for (User user : users) {
+      long newsletterCount =
+          newsletterRepository.countByUserIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+              user.getId(), rangeStart, rangeEnd);
+      long incompleteCount = checklistRepository.countByUserIdAndCompletedFalse(user.getId());
+
+      Map<String, Object> payload = payload();
+      payload.put("rangeStart", rangeStartDate.toString());
+      payload.put("rangeEnd", rangeEndDate.minusDays(1).toString());
+      payload.put("newsletterCount", newsletterCount);
+      payload.put("incompleteChecklistCount", incompleteCount);
+
+      notificationService.createNotification(
+          user.getId(),
+          new NotificationCreateCommand(
+              NotificationType.WEEKLY_SUMMARY,
+              "이번 주 요약이 도착했어요",
+              "이번 주 가정통신문 " + newsletterCount + "개와 미완료 할 일 " + incompleteCount + "개를 확인해보세요",
+              payload,
+              "weekly-summary:" + user.getId() + ":" + rangeStartDate,
+              NotificationLevel.NORMAL,
+              null,
+              null));
+    }
+  }
+
+  private TimeRange dayRange(LocalDate targetDate) {
+    return new TimeRange(
+        targetDate.atStartOfDay(KST).toOffsetDateTime(),
+        targetDate.plusDays(1).atStartOfDay(KST).toOffsetDateTime());
+  }
+
+  private Newsletter findNewsletter(Long newsletterId) {
+    if (newsletterId == null) {
+      return null;
+    }
+    return newsletterRepository.findById(newsletterId).orElse(null);
+  }
+
+  private Long resolveChildId(Long userId, String childName) {
+    if (childName == null || childName.isBlank()) {
+      return null;
+    }
+    return childRepository
+        .findFirstByUserIdAndNameAndDeletedAtIsNull(userId, childName)
+        .map(child -> child.getId())
+        .orElse(null);
+  }
+
+  private Map<String, Object> payload() {
+    return new LinkedHashMap<>();
+  }
+
+  private void putIfPresent(Map<String, Object> payload, String key, Object value) {
+    if (value != null) {
+      payload.put(key, value);
+    }
+  }
+
+  private record TimeRange(OffsetDateTime start, OffsetDateTime end) {}
+}

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationService.java
@@ -2,6 +2,7 @@ package com.gachi.be.domain.notification.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gachi.be.domain.child.repository.ChildRepository;
 import com.gachi.be.domain.notification.dto.request.NotificationReadRequest;
 import com.gachi.be.domain.notification.dto.request.PushTokenDeleteRequest;
 import com.gachi.be.domain.notification.dto.request.PushTokenRegisterRequest;
@@ -46,16 +47,18 @@ public class NotificationService {
   private final NotificationRepository notificationRepository;
   private final PushDeviceTokenRepository pushDeviceTokenRepository;
   private final NotificationDeliveryLogRepository notificationDeliveryLogRepository;
+  private final ChildRepository childRepository;
   private final ObjectMapper objectMapper;
   private final ApplicationEventPublisher eventPublisher;
 
   @Transactional(readOnly = true)
   public NotificationListResponse getNotifications(
-      Long userId, Long cursorId, Integer size, boolean unreadOnly) {
+      Long userId, Long cursorId, Integer size, boolean unreadOnly, Long childId) {
     int pageSize = normalizePageSize(size);
+    String childName = resolveChildName(userId, childId);
     List<Notification> rows =
         notificationRepository.findInbox(
-            userId, cursorId, unreadOnly, PageRequest.of(0, pageSize + 1));
+            userId, cursorId, childId, childName, unreadOnly, PageRequest.of(0, pageSize + 1));
 
     boolean hasNext = rows.size() > pageSize;
     List<Notification> page = hasNext ? rows.subList(0, pageSize) : rows;
@@ -63,6 +66,12 @@ public class NotificationService {
 
     return new NotificationListResponse(
         page.stream().map(this::toResponse).toList(), nextCursor, hasNext);
+  }
+
+  @Transactional(readOnly = true)
+  public NotificationListResponse getNotifications(
+      Long userId, Long cursorId, Integer size, boolean unreadOnly) {
+    return getNotifications(userId, cursorId, size, unreadOnly, null);
   }
 
   @Transactional(readOnly = true)
@@ -166,6 +175,9 @@ public class NotificationService {
         Notification.builder()
             .userId(userId)
             .type(command.type())
+            .level(command.level())
+            .childId(command.childId())
+            .childName(normalizeOptional(command.childName()))
             .title(normalizeRequired(command.title()))
             .body(normalizeRequired(command.body()))
             .payloadJson(serializePayload(command.payload()))
@@ -215,6 +227,9 @@ public class NotificationService {
     return new NotificationResponse(
         notification.getId(),
         notification.getType(),
+        notification.getLevel(),
+        notification.getChildId(),
+        notification.getChildName(),
         notification.getTitle(),
         notification.getBody(),
         deserializePayload(notification.getPayloadJson()),
@@ -231,6 +246,16 @@ public class NotificationService {
         token.getAppVersion(),
         token.isEnabled(),
         token.getLastRegisteredAt());
+  }
+
+  private String resolveChildName(Long userId, Long childId) {
+    if (childId == null) {
+      return null;
+    }
+    return childRepository
+        .findByIdAndUserIdAndDeletedAtIsNull(childId, userId)
+        .map(child -> normalizeOptional(child.getName()))
+        .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
   }
 
   private int normalizePageSize(Integer size) {

--- a/src/main/java/com/gachi/be/domain/user/api/controller/UserController.java
+++ b/src/main/java/com/gachi/be/domain/user/api/controller/UserController.java
@@ -4,6 +4,7 @@ import com.gachi.be.domain.auth.service.AuthenticatedUserResolver;
 import com.gachi.be.domain.newsletter.entity.enums.NewsletterStatus;
 import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
 import com.gachi.be.domain.user.dto.request.ChangeLanguageRequest;
+import com.gachi.be.domain.user.dto.request.ChangeNotificationRequest;
 import com.gachi.be.domain.user.dto.response.UserMeResponse;
 import com.gachi.be.domain.user.entity.User;
 import com.gachi.be.domain.user.repository.UserRepository;
@@ -49,6 +50,7 @@ public class UserController {
             user.getName(),
             user.getLanguageCode(),
             user.isNotificationEnabled(),
+            user.getNotificationPreference(),
             user.getCreatedAt()));
   }
 
@@ -93,5 +95,17 @@ public class UserController {
         cancelledCount);
 
     return ApiResponse.success(SuccessCode.USER_LANGUAGE_UPDATED, null);
+  }
+
+  @Operation(summary = "사용자 알림 설정 변경", description = "마이페이지에서 알림 수신 단계를 변경합니다.")
+  @PatchMapping("/me/notification")
+  @Transactional
+  public ApiResponse<Void> changeNotificationPreference(
+      @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+      @RequestBody @Valid ChangeNotificationRequest request) {
+    User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
+    user.updateNotificationPreference(request.notificationPreference());
+    userRepository.save(user);
+    return ApiResponse.success(SuccessCode.USER_NOTIFICATION_UPDATED, null);
   }
 }

--- a/src/main/java/com/gachi/be/domain/user/dto/request/ChangeNotificationRequest.java
+++ b/src/main/java/com/gachi/be/domain/user/dto/request/ChangeNotificationRequest.java
@@ -1,7 +1,9 @@
 package com.gachi.be.domain.user.dto.request;
 
+import com.gachi.be.domain.user.entity.enums.NotificationPreference;
 import jakarta.validation.constraints.NotNull;
 
-/** 알림 설정 변경 요청 DTO. */
+/** 설정 화면에서 알림 수신 단계를 변경할 때 사용하는 요청 DTO. */
 public record ChangeNotificationRequest(
-    @NotNull(message = "notificationEnabled는 필수입니다.") boolean notificationEnabled) {}
+    @NotNull(message = "notificationPreference는 필수입니다.")
+        NotificationPreference notificationPreference) {}

--- a/src/main/java/com/gachi/be/domain/user/dto/response/UserMeResponse.java
+++ b/src/main/java/com/gachi/be/domain/user/dto/response/UserMeResponse.java
@@ -1,5 +1,6 @@
 package com.gachi.be.domain.user.dto.response;
 
+import com.gachi.be.domain.user.entity.enums.NotificationPreference;
 import java.time.LocalDateTime;
 
 /** 내 정보 조회 응답 DTO. */
@@ -10,4 +11,5 @@ public record UserMeResponse(
     String name,
     String languageCode,
     Boolean notificationEnabled,
+    NotificationPreference notificationPreference,
     LocalDateTime createdAt) {}

--- a/src/main/java/com/gachi/be/domain/user/entity/User.java
+++ b/src/main/java/com/gachi/be/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.gachi.be.domain.user.entity;
 
+import com.gachi.be.domain.user.entity.enums.NotificationPreference;
 import com.gachi.be.domain.user.entity.enums.UserStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -54,6 +55,10 @@ public class User {
   @Column(name = "notification_enabled", nullable = false)
   private boolean notificationEnabled;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "notification_preference", nullable = false, length = 20)
+  private NotificationPreference notificationPreference;
+
   @Column(name = "deleted_at")
   private OffsetDateTime deletedAt;
 
@@ -88,6 +93,7 @@ public class User {
       UserStatus status,
       String languageCode,
       Boolean notificationEnabled,
+      NotificationPreference notificationPreference,
       OffsetDateTime emailVerifiedAt,
       OffsetDateTime consentAgreedAt,
       String consentVersion,
@@ -100,7 +106,11 @@ public class User {
     this.phoneNumber = phoneNumber;
     this.status = status;
     this.languageCode = languageCode != null ? languageCode : "KO";
-    this.notificationEnabled = notificationEnabled != null ? notificationEnabled : true;
+    this.notificationPreference =
+        notificationPreference != null
+            ? notificationPreference
+            : NotificationPreference.fromLegacyEnabled(notificationEnabled);
+    this.notificationEnabled = this.notificationPreference.isPushEnabled();
     this.emailVerifiedAt = emailVerifiedAt;
     this.consentAgreedAt = consentAgreedAt;
     this.consentVersion = consentVersion;
@@ -121,7 +131,25 @@ public class User {
   }
 
   public void updateNotificationEnabled(boolean notificationEnabled) {
-    this.notificationEnabled = notificationEnabled;
+    updateNotificationPreference(NotificationPreference.fromLegacyEnabled(notificationEnabled));
+  }
+
+  public void updateNotificationPreference(NotificationPreference notificationPreference) {
+    this.notificationPreference =
+        notificationPreference != null
+            ? notificationPreference
+            : NotificationPreference.defaultValue();
+    this.notificationEnabled = this.notificationPreference.isPushEnabled();
+  }
+
+  public NotificationPreference getNotificationPreference() {
+    return notificationPreference != null
+        ? notificationPreference
+        : NotificationPreference.fromLegacyEnabled(notificationEnabled);
+  }
+
+  public boolean isNotificationEnabled() {
+    return getNotificationPreference().isPushEnabled();
   }
 
   @PrePersist
@@ -137,6 +165,10 @@ public class User {
     if (languageCode == null) {
       languageCode = "KO";
     }
+    if (notificationPreference == null) {
+      notificationPreference = NotificationPreference.fromLegacyEnabled(notificationEnabled);
+    }
+    notificationEnabled = notificationPreference.isPushEnabled();
   }
 
   @PreUpdate

--- a/src/main/java/com/gachi/be/domain/user/entity/enums/NotificationPreference.java
+++ b/src/main/java/com/gachi/be/domain/user/entity/enums/NotificationPreference.java
@@ -1,0 +1,36 @@
+package com.gachi.be.domain.user.entity.enums;
+
+import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
+
+/** 사용자가 외부 푸시로 받고 싶은 알림 범위를 나타낸다. */
+public enum NotificationPreference {
+  URGENT_ONLY,
+  IMPORTANT,
+  ALL,
+  OFF;
+
+  public static NotificationPreference defaultValue() {
+    return IMPORTANT;
+  }
+
+  public static NotificationPreference fromLegacyEnabled(Boolean notificationEnabled) {
+    if (notificationEnabled == null) {
+      return defaultValue();
+    }
+    return notificationEnabled ? defaultValue() : OFF;
+  }
+
+  public boolean allows(NotificationLevel level) {
+    NotificationLevel resolvedLevel = level != null ? level : NotificationLevel.IMPORTANT;
+    return switch (this) {
+      case ALL -> true;
+      case IMPORTANT -> resolvedLevel != NotificationLevel.NORMAL;
+      case URGENT_ONLY -> resolvedLevel == NotificationLevel.URGENT;
+      case OFF -> false;
+    };
+  }
+
+  public boolean isPushEnabled() {
+    return this != OFF;
+  }
+}

--- a/src/main/java/com/gachi/be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gachi/be/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.gachi.be.domain.user.repository;
 
 import com.gachi.be.domain.user.entity.User;
 import com.gachi.be.domain.user.entity.enums.UserStatus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByLoginId(String loginId);
 
   Optional<User> findByIdAndStatus(Long id, UserStatus status);
+
+  List<User> findAllByStatus(UserStatus status);
 }

--- a/src/main/java/com/gachi/be/global/code/SuccessCode.java
+++ b/src/main/java/com/gachi/be/global/code/SuccessCode.java
@@ -39,6 +39,7 @@ public enum SuccessCode {
   CHECKLIST_COMPLETE_SUCCESS(HttpStatus.OK, "CL2002", "체크리스트 완료 처리에 성공하였습니다."),
   CHECKLIST_DELETED(HttpStatus.OK, "CL2003", "체크리스트 삭제에 성공하였습니다."),
   USER_LANGUAGE_UPDATED(HttpStatus.OK, "USER2001", "언어 설정이 변경되었습니다."),
+  USER_NOTIFICATION_UPDATED(HttpStatus.OK, "USER2002", "알림 설정이 변경되었습니다."),
   NOTIFICATION_LIST_SUCCESS(HttpStatus.OK, "NOTI2001", "알림 목록 조회에 성공하였습니다."),
   NOTIFICATION_UNREAD_COUNT_SUCCESS(HttpStatus.OK, "NOTI2002", "미읽음 알림 수 조회에 성공하였습니다."),
   NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "NOTI2003", "알림 읽음 처리에 성공하였습니다."),

--- a/src/main/resources/db/migration/V16__notification_preference_and_context.sql
+++ b/src/main/resources/db/migration/V16__notification_preference_and_context.sql
@@ -1,0 +1,63 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS notification_preference VARCHAR(20);
+
+UPDATE users
+SET notification_preference = CASE
+    WHEN notification_enabled = FALSE THEN 'OFF'
+    ELSE 'IMPORTANT'
+END
+WHERE notification_preference IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN notification_preference SET DEFAULT 'IMPORTANT',
+    ALTER COLUMN notification_preference SET NOT NULL;
+
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS chk_users_notification_preference;
+
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_notification_preference
+        CHECK (notification_preference IN ('URGENT_ONLY', 'IMPORTANT', 'ALL', 'OFF'));
+
+ALTER TABLE notifications
+    ADD COLUMN IF NOT EXISTS level VARCHAR(20),
+    ADD COLUMN IF NOT EXISTS child_id BIGINT,
+    ADD COLUMN IF NOT EXISTS child_name VARCHAR(50);
+
+UPDATE notifications
+SET level = 'IMPORTANT'
+WHERE level IS NULL;
+
+ALTER TABLE notifications
+    ALTER COLUMN level SET DEFAULT 'IMPORTANT',
+    ALTER COLUMN level SET NOT NULL;
+
+ALTER TABLE notifications
+    DROP CONSTRAINT IF EXISTS chk_notifications_type;
+
+ALTER TABLE notifications
+    ADD CONSTRAINT chk_notifications_type
+        CHECK (type IN (
+            'NEWSLETTER_ANALYSIS',
+            'DEADLINE_REMINDER',
+            'CALENDAR_EVENT',
+            'CHECKLIST_DUE',
+            'WEEKLY_SUMMARY',
+            'SYSTEM',
+            'ANNOUNCEMENT'
+        ));
+
+ALTER TABLE notifications
+    DROP CONSTRAINT IF EXISTS chk_notifications_level;
+
+ALTER TABLE notifications
+    ADD CONSTRAINT chk_notifications_level
+        CHECK (level IN ('URGENT', 'IMPORTANT', 'NORMAL'));
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_child_id
+    ON notifications (user_id, child_id, id DESC)
+    WHERE child_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_child_name
+    ON notifications (user_id, child_name, id DESC)
+    WHERE child_name IS NOT NULL;


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 알림 수신 단계를 `URGENT_ONLY`, `IMPORTANT`, `ALL`, `OFF`로 확장
  - 회원가입/설정에서 알림 단계를 저장하고 변경할 수 있도록 API를 추가
  - 알림 목록 응답에 `level`, `childId`, `childName`을 추가하고, `childId` 기준 필터 조회를 지원
  - 가정통신문 분석 완료 시 알림을 자동 생성하도록 연결
  - 마감 D-1, 체크리스트 D-3/D-1, 주간 요약 알림을 생성하는 스케줄러를 추가
  - 사용자 알림 단계에 따라 Expo 푸시 발송 여부를 필터링하도록 변경
  - 기존 데이터 마이그레이션을 위한 V16 Flyway migration을 추가
- 관련 이슈: closes #76 

## 🌿 브랜치 정보

- **Source**: `feat/#76-notification-settings-auto`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

```bash
./gradlew.bat --no-daemon compileJava
BUILD SUCCESSFUL

./gradlew.bat --no-daemon compileTestJava
BUILD SUCCESSFUL

./gradlew.bat --no-daemon spotlessCheck
BUILD SUCCESSFUL
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 자동 알림 시스템 도입: 마감 리마인더, 체크리스트 알림, 주간 요약, 뉴스레터 분석 완료 알림이 스케줄에 따라 발송됩니다.
  * 알림에 중요도(level)와 자녀(child) 정보가 포함되어 표시됩니다.
* **변경 사항**
  * 알림 수신 단계가 4단계(긴급만/중요/전체/차단)로 확장되어 세분화된 수신 설정 가능.
  * 알림 목록 조회에서 자녀별 필터링(childId) 가능.
  * 마이페이지에 알림 단계 표시 및 알림 설정 변경 API 추가.
* **데이터베이스**
  * 사용자·알림 관련 필드와 제약이 추가되어 기본값 및 검증 강화되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GACHI-Project/GACHI-BE/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->