### PR TITLE
fix: 가정통신문 완료 알림 트랜잭션 분리

### DIFF
--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusService.java
@@ -11,10 +11,13 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
 @Service
@@ -24,6 +27,7 @@ public class NewsletterPipelineStatusService {
   private final NewsletterRepository newsletterRepository;
   private final NotificationService notificationService;
   private final ChildRepository childRepository;
+  private final PlatformTransactionManager transactionManager;
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void markProcessing(Long newsletterId) {
@@ -88,7 +92,7 @@ public class NewsletterPipelineStatusService {
 
   private void createAnalysisCompletedNotificationSafely(Newsletter newsletter) {
     try {
-      createAnalysisCompletedNotification(newsletter);
+      createAnalysisCompletedNotificationInNewTransaction(newsletter);
     } catch (Exception ex) {
       log.warn(
           "[Pipeline] 분석 완료 알림 생성 실패. newsletterId={}, error={}",
@@ -96,6 +100,14 @@ public class NewsletterPipelineStatusService {
           ex.getMessage(),
           ex);
     }
+  }
+
+  private void createAnalysisCompletedNotificationInNewTransaction(Newsletter newsletter) {
+    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+    transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    // afterCommit 콜백 안에서는 기존 트랜잭션 리소스가 남아 알림 저장과 이벤트 커밋 경계가 꼬일 수 있습니다.
+    transactionTemplate.executeWithoutResult(
+        status -> createAnalysisCompletedNotification(newsletter));
   }
 
   private void createAnalysisCompletedNotification(Newsletter newsletter) {

--- a/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusServiceTest.java
+++ b/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusServiceTest.java
@@ -1,0 +1,189 @@
+package com.gachi.be.domain.newsletter.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gachi.be.domain.child.repository.ChildRepository;
+import com.gachi.be.domain.newsletter.entity.Newsletter;
+import com.gachi.be.domain.newsletter.entity.enums.NewsletterStatus;
+import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
+import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
+import com.gachi.be.domain.notification.entity.enums.NotificationType;
+import com.gachi.be.domain.notification.service.NotificationCreateCommand;
+import com.gachi.be.domain.notification.service.NotificationService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+
+@SpringJUnitConfig(NewsletterPipelineStatusServiceTest.TestConfig.class)
+class NewsletterPipelineStatusServiceTest {
+
+  @Autowired private NewsletterPipelineStatusService newsletterPipelineStatusService;
+  @Autowired private NewsletterRepository newsletterRepository;
+  @Autowired private NotificationService notificationService;
+  @Autowired private ChildRepository childRepository;
+  @Autowired private CapturingTransactionManager transactionManager;
+
+  @BeforeEach
+  void setUp() {
+    reset(newsletterRepository, notificationService, childRepository);
+    transactionManager.reset();
+  }
+
+  @Test
+  void markCompletedCreatesAnalysisNotificationInNewTransactionAfterCommit() {
+    Newsletter newsletter = processingNewsletter(88L);
+    when(newsletterRepository.findById(88L)).thenReturn(Optional.of(newsletter));
+    when(newsletterRepository.save(newsletter)).thenReturn(newsletter);
+
+    assertThat(AopUtils.isAopProxy(newsletterPipelineStatusService)).isTrue();
+    newsletterPipelineStatusService.markCompleted(
+        88L, "ocr text", "original text", null, "newsletter title", "summary");
+
+    assertThat(newsletter.getStatus()).isEqualTo(NewsletterStatus.COMPLETED);
+
+    ArgumentCaptor<NotificationCreateCommand> commandCaptor =
+        ArgumentCaptor.forClass(NotificationCreateCommand.class);
+    verify(notificationService).createNotification(anyLong(), commandCaptor.capture());
+    NotificationCreateCommand command = commandCaptor.getValue();
+
+    assertThat(command.type()).isEqualTo(NotificationType.NEWSLETTER_ANALYSIS);
+    assertThat(command.level()).isEqualTo(NotificationLevel.IMPORTANT);
+    assertThat(command.payload()).containsEntry("newsletterId", 88L);
+    assertThat(command.dedupeKey()).isEqualTo("newsletter-analysis:88");
+    assertThat(transactionManager.requiresNewCount()).isEqualTo(2);
+    assertThat(transactionManager.commits).isGreaterThanOrEqualTo(2);
+  }
+
+  @Test
+  void markCompletedKeepsCompletedStateWhenNotificationCreationFailsAfterCommit() {
+    Newsletter newsletter = processingNewsletter(89L);
+    when(newsletterRepository.findById(89L)).thenReturn(Optional.of(newsletter));
+    when(newsletterRepository.save(newsletter)).thenReturn(newsletter);
+    doThrow(new IllegalStateException("push event failure"))
+        .when(notificationService)
+        .createNotification(anyLong(), any());
+
+    assertThatCode(
+            () ->
+                newsletterPipelineStatusService.markCompleted(
+                    89L, "ocr text", "original text", null, "newsletter title", "summary"))
+        .doesNotThrowAnyException();
+
+    assertThat(newsletter.getStatus()).isEqualTo(NewsletterStatus.COMPLETED);
+    verify(notificationService).createNotification(anyLong(), any());
+    assertThat(transactionManager.requiresNewCount()).isEqualTo(2);
+    assertThat(transactionManager.commits).isGreaterThanOrEqualTo(1);
+    assertThat(transactionManager.rollbacks).isGreaterThanOrEqualTo(1);
+  }
+
+  private Newsletter processingNewsletter(Long id) {
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(4L)
+            .fileKey("newsletter/test.png")
+            .fileHash("hash-newsletter-complete-" + id)
+            .status(NewsletterStatus.PROCESSING)
+            .language("KO")
+            .build();
+    ReflectionTestUtils.setField(newsletter, "id", id);
+    return newsletter;
+  }
+
+  @Configuration
+  @EnableTransactionManagement
+  static class TestConfig {
+
+    @Bean
+    NewsletterPipelineStatusService newsletterPipelineStatusService(
+        NewsletterRepository newsletterRepository,
+        NotificationService notificationService,
+        ChildRepository childRepository,
+        CapturingTransactionManager transactionManager) {
+      return new NewsletterPipelineStatusService(
+          newsletterRepository, notificationService, childRepository, transactionManager);
+    }
+
+    @Bean
+    NewsletterRepository newsletterRepository() {
+      return mock(NewsletterRepository.class);
+    }
+
+    @Bean
+    NotificationService notificationService() {
+      return mock(NotificationService.class);
+    }
+
+    @Bean
+    ChildRepository childRepository() {
+      return mock(ChildRepository.class);
+    }
+
+    @Bean
+    CapturingTransactionManager transactionManager() {
+      return new CapturingTransactionManager();
+    }
+  }
+
+  static class CapturingTransactionManager extends AbstractPlatformTransactionManager {
+    private final List<TransactionDefinition> definitions = new ArrayList<>();
+    private int commits;
+    private int rollbacks;
+
+    @Override
+    protected Object doGetTransaction() {
+      return new Object();
+    }
+
+    @Override
+    protected void doBegin(Object transaction, TransactionDefinition definition) {
+      definitions.add(definition);
+    }
+
+    @Override
+    protected void doCommit(DefaultTransactionStatus status) {
+      commits++;
+    }
+
+    @Override
+    protected void doRollback(DefaultTransactionStatus status) {
+      rollbacks++;
+    }
+
+    private List<Integer> propagationBehaviors() {
+      return definitions.stream().map(TransactionDefinition::getPropagationBehavior).toList();
+    }
+
+    private long requiresNewCount() {
+      return propagationBehaviors().stream()
+          .filter(behavior -> behavior == TransactionDefinition.PROPAGATION_REQUIRES_NEW)
+          .count();
+    }
+
+    private void reset() {
+      definitions.clear();
+      commits = 0;
+      rollbacks = 0;
+    }
+  }
+}


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 가정통신문 OCR/AI 분석 완료 후 완료 알림 생성 과정에서 트랜잭션 콜백 예외가 발생하던 문제 수정
  - 분석 완료 알림 생성 로직을 별도 `REQUIRES_NEW` 트랜잭션으로 분리
  - 기존 트랜잭션 `afterCommit` 콜백에서 알림 저장/이벤트 발행 경계가 꼬여 `notificationId`가 null로 전달될 수 있는 흐름 방지
  - 완료 알림 생성 트랜잭션 분리 동작을 검증하는 단위 테스트 추가
- 관련 이슈: closes #88 

## 🌿 브랜치 정보

- **Source**: `bugfix/#88-newsletter-completion-notification`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

```bash
./gradlew.bat --no-daemon test --tests "com.gachi.be.domain.newsletter.pipeline.NewsletterPipelineStatusServiceTest"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 픽스
* 뉴스레터 분석 완료 알림 생성 처리 개선

## 테스트
* 뉴스레터 분석 알림 생성 기능 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->