### PR TITLE
feat: 챗봇 API 구현

### DIFF
--- a/src/main/java/com/gachi/be/domain/chat/api/controller/ChatController.java
+++ b/src/main/java/com/gachi/be/domain/chat/api/controller/ChatController.java
@@ -1,0 +1,46 @@
+package com.gachi.be.domain.chat.api.controller;
+
+import com.gachi.be.domain.chat.dto.request.ChatMessageRequest;
+import com.gachi.be.domain.chat.dto.response.ChatMessageResponse;
+import com.gachi.be.domain.chat.service.ChatService;
+import com.gachi.be.global.api.ApiResponse;
+import com.gachi.be.global.code.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**채팅 컨트롤러. */
+@Tag(name = "Chat", description = "AI 챗봇 API")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chat")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @Operation(
+        summary = "채팅 메시지 전송",
+        description = """
+          AI 챗봇에게 메시지를 전송하고 응답을 받습니다.
+
+          - sessionId가 null이면 새 세션을 생성합니다.
+          - sessionId를 응답에서 받아 다음 요청에 재사용하면 대화 맥락이 유지됩니다.
+          - 앱을 종료하고 재진입 시 sessionId 없이 요청하면 새 대화가 시작됩니다.
+          - chatType: GENERAL(학교 문화/용어 질문), DOCUMENT는 추후 지원 예정
+          """)
+    @PostMapping("/messages")
+    public ApiResponse<ChatMessageResponse> sendMessage(
+        @AuthenticationPrincipal Long userId,
+        @Valid @RequestBody ChatMessageRequest request) {
+        ChatMessageResponse response = chatService.sendMessage(userId, request);
+        return ApiResponse.success(SuccessCode.CHAT_MESSAGE_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/gachi/be/domain/chat/api/controller/ChatController.java
+++ b/src/main/java/com/gachi/be/domain/chat/api/controller/ChatController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**채팅 컨트롤러. */
+/** 채팅 컨트롤러. */
 @Tag(name = "Chat", description = "AI 챗봇 API")
 @SecurityRequirement(name = "bearerAuth")
 @RestController
@@ -24,11 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/chat")
 public class ChatController {
 
-    private final ChatService chatService;
+  private final ChatService chatService;
 
-    @Operation(
-        summary = "채팅 메시지 전송",
-        description = """
+  @Operation(
+      summary = "채팅 메시지 전송",
+      description =
+          """
           AI 챗봇에게 메시지를 전송하고 응답을 받습니다.
 
           - sessionId가 null이면 새 세션을 생성합니다.
@@ -36,11 +37,10 @@ public class ChatController {
           - 앱을 종료하고 재진입 시 sessionId 없이 요청하면 새 대화가 시작됩니다.
           - chatType: GENERAL(학교 문화/용어 질문), DOCUMENT는 추후 지원 예정
           """)
-    @PostMapping("/messages")
-    public ApiResponse<ChatMessageResponse> sendMessage(
-        @AuthenticationPrincipal Long userId,
-        @Valid @RequestBody ChatMessageRequest request) {
-        ChatMessageResponse response = chatService.sendMessage(userId, request);
-        return ApiResponse.success(SuccessCode.CHAT_MESSAGE_SUCCESS, response);
-    }
+  @PostMapping("/messages")
+  public ApiResponse<ChatMessageResponse> sendMessage(
+      @AuthenticationPrincipal Long userId, @Valid @RequestBody ChatMessageRequest request) {
+    ChatMessageResponse response = chatService.sendMessage(userId, request);
+    return ApiResponse.success(SuccessCode.CHAT_MESSAGE_SUCCESS, response);
+  }
 }

--- a/src/main/java/com/gachi/be/domain/chat/client/AiChatClient.java
+++ b/src/main/java/com/gachi/be/domain/chat/client/AiChatClient.java
@@ -15,92 +15,90 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-/**AI 서버 채팅 엔드포인트 클라이언트.*/
+/** AI 서버 채팅 엔드포인트 클라이언트. */
 @Slf4j
 @Component
 public class AiChatClient {
 
-    private static final String CHAT_PATH = "/ai/chat/messages";
+  private static final String CHAT_PATH = "/ai/chat/messages";
 
-    private final AiServerProperties aiServerProperties;
-    private final ObjectMapper objectMapper;
-    private final HttpClient httpClient;
+  private final AiServerProperties aiServerProperties;
+  private final ObjectMapper objectMapper;
+  private final HttpClient httpClient;
 
-    public AiChatClient(AiServerProperties aiServerProperties, ObjectMapper objectMapper) {
-        this.aiServerProperties = aiServerProperties;
-        this.objectMapper = objectMapper;
-        // AiNewsletterClient와 동일하게 HTTP/1.1 고정 (HTTP/2 mismatch 방지)
-        this.httpClient =
-            HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(aiServerProperties.getConnectTimeoutSeconds()))
-                .version(HttpClient.Version.HTTP_1_1)
-                .build();
+  public AiChatClient(AiServerProperties aiServerProperties, ObjectMapper objectMapper) {
+    this.aiServerProperties = aiServerProperties;
+    this.objectMapper = objectMapper;
+    // AiNewsletterClient와 동일하게 HTTP/1.1 고정 (HTTP/2 mismatch 방지)
+    this.httpClient =
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(aiServerProperties.getConnectTimeoutSeconds()))
+            .version(HttpClient.Version.HTTP_1_1)
+            .build();
+  }
+
+  /** AI 서버에 채팅 요청. */
+  public String chat(
+      String message, List<Map<String, String>> history, String language, String chatType) {
+    try {
+      String requestBody =
+          objectMapper.writeValueAsString(new ChatRequest(message, history, language, chatType));
+
+      log.info(
+          "[AiChatClient] 채팅 요청. language={}, chatType={}, historySize={}",
+          language,
+          chatType,
+          history.size());
+
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(normalizedBaseUrl() + CHAT_PATH))
+              .header("Content-Type", "application/json")
+              .header("Accept", "application/json")
+              .timeout(Duration.ofSeconds(aiServerProperties.getReadTimeoutSeconds()))
+              .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+              .build();
+
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+        log.error(
+            "[AiChatClient] AI 서버 응답 실패. status={}, body={}",
+            response.statusCode(),
+            response.body());
+        throw new ExternalApiException(
+            ErrorCode.CHAT_AI_ERROR, "AI 서버 채팅 실패. status=" + response.statusCode());
+      }
+
+      ChatResponse chatResponse = objectMapper.readValue(response.body(), ChatResponse.class);
+      log.info("[AiChatClient] 채팅 응답 수신 완료.");
+      return chatResponse.reply();
+
+    } catch (ExternalApiException e) {
+      throw e;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ExternalApiException(
+          ErrorCode.CHAT_AI_ERROR, "AI 서버 채팅 통신 인터럽트: " + e.getMessage(), e);
+    } catch (IOException e) {
+      throw new ExternalApiException(
+          ErrorCode.CHAT_AI_ERROR, "AI 서버 채팅 통신 오류: " + e.getMessage(), e);
     }
+  }
 
-    /**AI 서버에 채팅 요청. */
-    public String chat(
-        String message,
-        List<Map<String, String>> history,
-        String language,
-        String chatType) {
-        try {
-            String requestBody =
-                objectMapper.writeValueAsString(
-                    new ChatRequest(message, history, language, chatType));
-
-            log.info("[AiChatClient] 채팅 요청. language={}, chatType={}, historySize={}",
-                language, chatType, history.size());
-
-            HttpRequest request =
-                HttpRequest.newBuilder()
-                    .uri(URI.create(normalizedBaseUrl() + CHAT_PATH))
-                    .header("Content-Type", "application/json")
-                    .header("Accept", "application/json")
-                    .timeout(Duration.ofSeconds(aiServerProperties.getReadTimeoutSeconds()))
-                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
-                    .build();
-
-            HttpResponse<String> response =
-                httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                log.error("[AiChatClient] AI 서버 응답 실패. status={}, body={}",
-                    response.statusCode(), response.body());
-                throw new ExternalApiException(
-                    ErrorCode.CHAT_AI_ERROR, "AI 서버 채팅 실패. status=" + response.statusCode());
-            }
-
-            ChatResponse chatResponse = objectMapper.readValue(response.body(), ChatResponse.class);
-            log.info("[AiChatClient] 채팅 응답 수신 완료.");
-            return chatResponse.reply();
-
-        } catch (ExternalApiException e) {
-            throw e;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new ExternalApiException(
-                ErrorCode.CHAT_AI_ERROR, "AI 서버 채팅 통신 인터럽트: " + e.getMessage(), e);
-        } catch (IOException e) {
-            throw new ExternalApiException(
-                ErrorCode.CHAT_AI_ERROR, "AI 서버 채팅 통신 오류: " + e.getMessage(), e);
-        }
+  private String normalizedBaseUrl() {
+    String baseUrl = aiServerProperties.getBaseUrl();
+    if (baseUrl == null || baseUrl.isBlank()) {
+      throw new ExternalApiException(ErrorCode.CHAT_AI_ERROR, "AI 서버 base-url이 비어 있습니다.");
     }
+    return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+  }
 
-    private String normalizedBaseUrl() {
-        String baseUrl = aiServerProperties.getBaseUrl();
-        if (baseUrl == null || baseUrl.isBlank()) {
-            throw new ExternalApiException(ErrorCode.CHAT_AI_ERROR, "AI 서버 base-url이 비어 있습니다.");
-        }
-        return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
-    }
+  // AI 서버로 보내는 요청 body
+  record ChatRequest(
+      String message, List<Map<String, String>> history, String language, String chatType) {}
 
-    // AI 서버로 보내는 요청 body
-    record ChatRequest(
-        String message,
-        List<Map<String, String>> history,
-        String language,
-        String chatType) {}
-
-    // AI 서버에서 받는 응답 body
-    record ChatResponse(String reply) {}
+  // AI 서버에서 받는 응답 body
+  record ChatResponse(String reply) {}
 }

--- a/src/main/java/com/gachi/be/domain/chat/client/AiChatClient.java
+++ b/src/main/java/com/gachi/be/domain/chat/client/AiChatClient.java
@@ -1,0 +1,106 @@
+package com.gachi.be.domain.chat.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gachi.be.global.code.ErrorCode;
+import com.gachi.be.global.config.external.AiServerProperties;
+import com.gachi.be.global.exception.ExternalApiException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**AI 서버 채팅 엔드포인트 클라이언트.*/
+@Slf4j
+@Component
+public class AiChatClient {
+
+    private static final String CHAT_PATH = "/ai/chat/messages";
+
+    private final AiServerProperties aiServerProperties;
+    private final ObjectMapper objectMapper;
+    private final HttpClient httpClient;
+
+    public AiChatClient(AiServerProperties aiServerProperties, ObjectMapper objectMapper) {
+        this.aiServerProperties = aiServerProperties;
+        this.objectMapper = objectMapper;
+        // AiNewsletterClient와 동일하게 HTTP/1.1 고정 (HTTP/2 mismatch 방지)
+        this.httpClient =
+            HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(aiServerProperties.getConnectTimeoutSeconds()))
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+    }
+
+    /**AI 서버에 채팅 요청. */
+    public String chat(
+        String message,
+        List<Map<String, String>> history,
+        String language,
+        String chatType) {
+        try {
+            String requestBody =
+                objectMapper.writeValueAsString(
+                    new ChatRequest(message, history, language, chatType));
+
+            log.info("[AiChatClient] 채팅 요청. language={}, chatType={}, historySize={}",
+                language, chatType, history.size());
+
+            HttpRequest request =
+                HttpRequest.newBuilder()
+                    .uri(URI.create(normalizedBaseUrl() + CHAT_PATH))
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json")
+                    .timeout(Duration.ofSeconds(aiServerProperties.getReadTimeoutSeconds()))
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                    .build();
+
+            HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                log.error("[AiChatClient] AI 서버 응답 실패. status={}, body={}",
+                    response.statusCode(), response.body());
+                throw new ExternalApiException(
+                    ErrorCode.CHAT_AI_ERROR, "AI 서버 채팅 실패. status=" + response.statusCode());
+            }
+
+            ChatResponse chatResponse = objectMapper.readValue(response.body(), ChatResponse.class);
+            log.info("[AiChatClient] 채팅 응답 수신 완료.");
+            return chatResponse.reply();
+
+        } catch (ExternalApiException e) {
+            throw e;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ExternalApiException(
+                ErrorCode.CHAT_AI_ERROR, "AI 서버 채팅 통신 인터럽트: " + e.getMessage(), e);
+        } catch (IOException e) {
+            throw new ExternalApiException(
+                ErrorCode.CHAT_AI_ERROR, "AI 서버 채팅 통신 오류: " + e.getMessage(), e);
+        }
+    }
+
+    private String normalizedBaseUrl() {
+        String baseUrl = aiServerProperties.getBaseUrl();
+        if (baseUrl == null || baseUrl.isBlank()) {
+            throw new ExternalApiException(ErrorCode.CHAT_AI_ERROR, "AI 서버 base-url이 비어 있습니다.");
+        }
+        return baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+    }
+
+    // AI 서버로 보내는 요청 body
+    record ChatRequest(
+        String message,
+        List<Map<String, String>> history,
+        String language,
+        String chatType) {}
+
+    // AI 서버에서 받는 응답 body
+    record ChatResponse(String reply) {}
+}

--- a/src/main/java/com/gachi/be/domain/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/gachi/be/domain/chat/dto/request/ChatMessageRequest.java
@@ -4,12 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record ChatMessageRequest(
-
     String sessionId,
-
-    @NotBlank(message = "메시지를 입력해주세요.")
-    @Size(max = 1000, message = "메시지는 1000자 이하여야 합니다.")
-    String message,
-
-    String chatType
-) {}
+    @NotBlank(message = "메시지를 입력해주세요.") @Size(max = 1000, message = "메시지는 1000자 이하여야 합니다.")
+        String message,
+    String chatType) {}

--- a/src/main/java/com/gachi/be/domain/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/gachi/be/domain/chat/dto/request/ChatMessageRequest.java
@@ -1,0 +1,15 @@
+package com.gachi.be.domain.chat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChatMessageRequest(
+
+    String sessionId,
+
+    @NotBlank(message = "메시지를 입력해주세요.")
+    @Size(max = 1000, message = "메시지는 1000자 이하여야 합니다.")
+    String message,
+
+    String chatType
+) {}

--- a/src/main/java/com/gachi/be/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/gachi/be/domain/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,7 @@
+package com.gachi.be.domain.chat.dto.response;
+
+public record ChatMessageResponse(
+
+    String sessionId,
+    String reply
+) {}

--- a/src/main/java/com/gachi/be/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/gachi/be/domain/chat/dto/response/ChatMessageResponse.java
@@ -1,8 +1,3 @@
 package com.gachi.be.domain.chat.dto.response;
 
-public record ChatMessageResponse(
-
-    String sessionId,
-    String reply,
-    String sentAt
-) {}
+public record ChatMessageResponse(String sessionId, String reply, String sentAt) {}

--- a/src/main/java/com/gachi/be/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/gachi/be/domain/chat/dto/response/ChatMessageResponse.java
@@ -3,5 +3,6 @@ package com.gachi.be.domain.chat.dto.response;
 public record ChatMessageResponse(
 
     String sessionId,
-    String reply
+    String reply,
+    String sentAt
 ) {}

--- a/src/main/java/com/gachi/be/domain/chat/service/ChatRedisService.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/ChatRedisService.java
@@ -1,0 +1,90 @@
+package com.gachi.be.domain.chat.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**채팅 히스토리 Redis 관리 서비스.*/
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRedisService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    // Redis 키 prefix
+    private static final String SESSION_KEY_PREFIX = "chat:session:";
+
+    // TTL 1시간: 프론트에서 sessionId를 버리면 자연 만료
+    private static final Duration SESSION_TTL = Duration.ofHours(1);
+
+    // 토큰 폭발 방지: 히스토리 최대 20턴(유저+AI 각 1개 = 1턴)
+    private static final int MAX_HISTORY_TURNS = 20;
+
+    /** 히스토리 조회. 키 없으면 빈 리스트 반환. */
+    public List<Map<String, String>> getHistory(String sessionId) {
+        String key = buildKey(sessionId);
+        String json = redisTemplate.opsForValue().get(key);
+
+        if (json == null) {
+            log.debug("[ChatRedis] 히스토리 없음. sessionId={}", sessionId);
+            return new ArrayList<>();
+        }
+
+        try {
+            List<Map<String, String>> history =
+                objectMapper.readValue(json, new TypeReference<List<Map<String, String>>>() {});
+            log.debug("[ChatRedis] 히스토리 조회. sessionId={}, size={}", sessionId, history.size());
+            return history;
+        } catch (Exception e) {
+            log.error("[ChatRedis] 히스토리 파싱 실패. sessionId={}", sessionId, e);
+            // 파싱 실패 시 새 대화로 처리 (파이프라인 중단하지 않음)
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * 유저 메시지 + AI 응답을 히스토리에 추가 후 저장.
+     * MAX_HISTORY_TURNS 초과 시 오래된 턴부터 제거.
+     */
+    public void appendAndSave(String sessionId, String userMessage, String assistantReply) {
+        List<Map<String, String>> history = getHistory(sessionId);
+
+        // 유저 메시지 추가
+        history.add(Map.of("role", "user", "content", userMessage));
+        // AI 응답 추가
+        history.add(Map.of("role", "assistant", "content", assistantReply));
+
+        // 최대 턴 수 초과 시 앞에서부터 2개씩 제거 (가장 오래된 1턴)
+        while (history.size() > MAX_HISTORY_TURNS * 2) {
+            history.remove(0);
+            history.remove(0);
+        }
+
+        try {
+            String json = objectMapper.writeValueAsString(history);
+            redisTemplate.opsForValue().set(buildKey(sessionId), json, SESSION_TTL);
+            log.debug("[ChatRedis] 히스토리 저장. sessionId={}, size={}", sessionId, history.size());
+        } catch (Exception e) {
+            // 저장 실패해도 이미 응답은 반환됐으므로 로그만
+            log.error("[ChatRedis] 히스토리 저장 실패. sessionId={}", sessionId, e);
+        }
+    }
+
+    /** TTL 갱신 (응답 성공 시 세션 연장) */
+    public void refreshTtl(String sessionId) {
+        redisTemplate.expire(buildKey(sessionId), SESSION_TTL);
+    }
+
+    private String buildKey(String sessionId) {
+        return SESSION_KEY_PREFIX + sessionId;
+    }
+}

--- a/src/main/java/com/gachi/be/domain/chat/service/ChatRedisService.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/ChatRedisService.java
@@ -1,9 +1,9 @@
 package com.gachi.be.domain.chat.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -11,77 +11,79 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-/** 채팅 히스토리 Redis 관리 서비스. */
+/**채팅 히스토리 Redis 관리 서비스. */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatRedisService {
 
-  private final StringRedisTemplate redisTemplate;
-  private final ObjectMapper objectMapper;
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
 
-  // Redis 키 prefix
-  private static final String SESSION_KEY_PREFIX = "chat:session:";
+    private static final String SESSION_KEY_PREFIX = "chat:session:";
+    private static final Duration SESSION_TTL = Duration.ofHours(1);
 
-  // TTL 1시간: 프론트에서 sessionId를 버리면 자연 만료
-  private static final Duration SESSION_TTL = Duration.ofHours(1);
+    // 최대 20턴 = 메시지 40개 (유저+AI 각 1개)
+    // LTRIM으로 최근 40개만 유지 → 원자적 처리
+    private static final int MAX_MESSAGES = 40;
 
-  // 토큰 폭발 방지: 히스토리 최대 20턴(유저+AI 각 1개 = 1턴)
-  private static final int MAX_HISTORY_TURNS = 20;
+    /**히스토리 전체 조회.*/
+    public List<Map<String, String>> getHistory(String sessionId) {
+        String key = buildKey(sessionId);
 
-  /** 히스토리 조회. 키 없으면 빈 리스트 반환. */
-  public List<Map<String, String>> getHistory(String sessionId) {
-    String key = buildKey(sessionId);
-    String json = redisTemplate.opsForValue().get(key);
+        try {
+            // [수정] opsForValue().get() → opsForList().range() 로 변경
+            List<String> jsonList = redisTemplate.opsForList().range(key, 0, -1);
 
-    if (json == null) {
-      log.debug("[ChatRedis] 히스토리 없음. sessionId={}", sessionId);
-      return new ArrayList<>();
+            if (jsonList == null || jsonList.isEmpty()) {
+                log.debug("[ChatRedis] 히스토리 없음. sessionId={}", sessionId);
+                return new ArrayList<>();
+            }
+
+            List<Map<String, String>> history = new ArrayList<>();
+            for (String json : jsonList) {
+                @SuppressWarnings("unchecked")
+                Map<String, String> message = objectMapper.readValue(json, Map.class);
+                history.add(message);
+            }
+
+            log.debug("[ChatRedis] 히스토리 조회. sessionId={}, size={}", sessionId, history.size());
+            return history;
+
+        } catch (Exception e) {
+            log.error("[ChatRedis] 히스토리 파싱 실패. sessionId={}", sessionId, e);
+            return new ArrayList<>();
+        }
     }
 
-    try {
-      List<Map<String, String>> history =
-          objectMapper.readValue(json, new TypeReference<List<Map<String, String>>>() {});
-      log.debug("[ChatRedis] 히스토리 조회. sessionId={}, size={}", sessionId, history.size());
-      return history;
-    } catch (Exception e) {
-      log.error("[ChatRedis] 히스토리 파싱 실패. sessionId={}", sessionId, e);
-      // 파싱 실패 시 새 대화로 처리 (파이프라인 중단하지 않음)
-      return new ArrayList<>();
+    /**유저 메시지 + AI 응답을 히스토리에 원자적으로 추가.*/
+    public void appendAndSave(String sessionId, String userMessage, String assistantReply) {
+        String key = buildKey(sessionId);
+
+        try {
+            String userJson = objectMapper.writeValueAsString(
+                Map.of("role", "user", "content", userMessage != null ? userMessage : ""));
+            String assistantJson = objectMapper.writeValueAsString(
+                Map.of("role", "assistant", "content", assistantReply != null ? assistantReply : ""));
+
+            // RPUSH로 원자적 추가 (동시 요청이 와도 각 RPUSH는 독립적으로 처리됨)
+            redisTemplate.opsForList().rightPush(key, userJson);
+            redisTemplate.opsForList().rightPush(key, assistantJson);
+
+            // LTRIM으로 최근 MAX_MESSAGES개만 유지 (음수 인덱스: -MAX_MESSAGES ~ -1)
+            redisTemplate.opsForList().trim(key, -MAX_MESSAGES, -1);
+
+            // TTL 갱신
+            redisTemplate.expire(key, SESSION_TTL);
+
+            log.debug("[ChatRedis] 히스토리 저장 완료. sessionId={}", sessionId);
+
+        } catch (Exception e) {
+            log.error("[ChatRedis] 히스토리 저장 실패. sessionId={}", sessionId, e);
+        }
     }
-  }
 
-  /** 유저 메시지 + AI 응답을 히스토리에 추가 후 저장. MAX_HISTORY_TURNS 초과 시 오래된 턴부터 제거. */
-  public void appendAndSave(String sessionId, String userMessage, String assistantReply) {
-    List<Map<String, String>> history = getHistory(sessionId);
-
-    // 유저 메시지 추가
-    history.add(Map.of("role", "user", "content", userMessage));
-    // AI 응답 추가
-    history.add(Map.of("role", "assistant", "content", assistantReply));
-
-    // 최대 턴 수 초과 시 앞에서부터 2개씩 제거 (가장 오래된 1턴)
-    while (history.size() > MAX_HISTORY_TURNS * 2) {
-      history.remove(0);
-      history.remove(0);
+    private String buildKey(String sessionId) {
+        return SESSION_KEY_PREFIX + sessionId;
     }
-
-    try {
-      String json = objectMapper.writeValueAsString(history);
-      redisTemplate.opsForValue().set(buildKey(sessionId), json, SESSION_TTL);
-      log.debug("[ChatRedis] 히스토리 저장. sessionId={}, size={}", sessionId, history.size());
-    } catch (Exception e) {
-      // 저장 실패해도 이미 응답은 반환됐으므로 로그만
-      log.error("[ChatRedis] 히스토리 저장 실패. sessionId={}", sessionId, e);
-    }
-  }
-
-  /** TTL 갱신 (응답 성공 시 세션 연장) */
-  public void refreshTtl(String sessionId) {
-    redisTemplate.expire(buildKey(sessionId), SESSION_TTL);
-  }
-
-  private String buildKey(String sessionId) {
-    return SESSION_KEY_PREFIX + sessionId;
-  }
 }

--- a/src/main/java/com/gachi/be/domain/chat/service/ChatRedisService.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/ChatRedisService.java
@@ -3,7 +3,6 @@ package com.gachi.be.domain.chat.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -11,79 +10,81 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-/**채팅 히스토리 Redis 관리 서비스. */
+/** 채팅 히스토리 Redis 관리 서비스. */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatRedisService {
 
-    private final StringRedisTemplate redisTemplate;
-    private final ObjectMapper objectMapper;
+  private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
 
-    private static final String SESSION_KEY_PREFIX = "chat:session:";
-    private static final Duration SESSION_TTL = Duration.ofHours(1);
+  private static final String SESSION_KEY_PREFIX = "chat:session:";
+  private static final Duration SESSION_TTL = Duration.ofHours(1);
 
-    // 최대 20턴 = 메시지 40개 (유저+AI 각 1개)
-    // LTRIM으로 최근 40개만 유지 → 원자적 처리
-    private static final int MAX_MESSAGES = 40;
+  // 최대 20턴 = 메시지 40개 (유저+AI 각 1개)
+  // LTRIM으로 최근 40개만 유지 → 원자적 처리
+  private static final int MAX_MESSAGES = 40;
 
-    /**히스토리 전체 조회.*/
-    public List<Map<String, String>> getHistory(String sessionId) {
-        String key = buildKey(sessionId);
+  /** 히스토리 전체 조회. */
+  public List<Map<String, String>> getHistory(String sessionId) {
+    String key = buildKey(sessionId);
 
-        try {
-            // [수정] opsForValue().get() → opsForList().range() 로 변경
-            List<String> jsonList = redisTemplate.opsForList().range(key, 0, -1);
+    try {
+      // [수정] opsForValue().get() → opsForList().range() 로 변경
+      List<String> jsonList = redisTemplate.opsForList().range(key, 0, -1);
 
-            if (jsonList == null || jsonList.isEmpty()) {
-                log.debug("[ChatRedis] 히스토리 없음. sessionId={}", sessionId);
-                return new ArrayList<>();
-            }
+      if (jsonList == null || jsonList.isEmpty()) {
+        log.debug("[ChatRedis] 히스토리 없음. sessionId={}", sessionId);
+        return new ArrayList<>();
+      }
 
-            List<Map<String, String>> history = new ArrayList<>();
-            for (String json : jsonList) {
-                @SuppressWarnings("unchecked")
-                Map<String, String> message = objectMapper.readValue(json, Map.class);
-                history.add(message);
-            }
+      List<Map<String, String>> history = new ArrayList<>();
+      for (String json : jsonList) {
+        @SuppressWarnings("unchecked")
+        Map<String, String> message = objectMapper.readValue(json, Map.class);
+        history.add(message);
+      }
 
-            log.debug("[ChatRedis] 히스토리 조회. sessionId={}, size={}", sessionId, history.size());
-            return history;
+      log.debug("[ChatRedis] 히스토리 조회. sessionId={}, size={}", sessionId, history.size());
+      return history;
 
-        } catch (Exception e) {
-            log.error("[ChatRedis] 히스토리 파싱 실패. sessionId={}", sessionId, e);
-            return new ArrayList<>();
-        }
+    } catch (Exception e) {
+      log.error("[ChatRedis] 히스토리 파싱 실패. sessionId={}", sessionId, e);
+      return new ArrayList<>();
     }
+  }
 
-    /**유저 메시지 + AI 응답을 히스토리에 원자적으로 추가.*/
-    public void appendAndSave(String sessionId, String userMessage, String assistantReply) {
-        String key = buildKey(sessionId);
+  /** 유저 메시지 + AI 응답을 히스토리에 원자적으로 추가. */
+  public void appendAndSave(String sessionId, String userMessage, String assistantReply) {
+    String key = buildKey(sessionId);
 
-        try {
-            String userJson = objectMapper.writeValueAsString(
-                Map.of("role", "user", "content", userMessage != null ? userMessage : ""));
-            String assistantJson = objectMapper.writeValueAsString(
-                Map.of("role", "assistant", "content", assistantReply != null ? assistantReply : ""));
+    try {
+      String userJson =
+          objectMapper.writeValueAsString(
+              Map.of("role", "user", "content", userMessage != null ? userMessage : ""));
+      String assistantJson =
+          objectMapper.writeValueAsString(
+              Map.of("role", "assistant", "content", assistantReply != null ? assistantReply : ""));
 
-            // RPUSH로 원자적 추가 (동시 요청이 와도 각 RPUSH는 독립적으로 처리됨)
-            redisTemplate.opsForList().rightPush(key, userJson);
-            redisTemplate.opsForList().rightPush(key, assistantJson);
+      // RPUSH로 원자적 추가 (동시 요청이 와도 각 RPUSH는 독립적으로 처리됨)
+      redisTemplate.opsForList().rightPush(key, userJson);
+      redisTemplate.opsForList().rightPush(key, assistantJson);
 
-            // LTRIM으로 최근 MAX_MESSAGES개만 유지 (음수 인덱스: -MAX_MESSAGES ~ -1)
-            redisTemplate.opsForList().trim(key, -MAX_MESSAGES, -1);
+      // LTRIM으로 최근 MAX_MESSAGES개만 유지 (음수 인덱스: -MAX_MESSAGES ~ -1)
+      redisTemplate.opsForList().trim(key, -MAX_MESSAGES, -1);
 
-            // TTL 갱신
-            redisTemplate.expire(key, SESSION_TTL);
+      // TTL 갱신
+      redisTemplate.expire(key, SESSION_TTL);
 
-            log.debug("[ChatRedis] 히스토리 저장 완료. sessionId={}", sessionId);
+      log.debug("[ChatRedis] 히스토리 저장 완료. sessionId={}", sessionId);
 
-        } catch (Exception e) {
-            log.error("[ChatRedis] 히스토리 저장 실패. sessionId={}", sessionId, e);
-        }
+    } catch (Exception e) {
+      log.error("[ChatRedis] 히스토리 저장 실패. sessionId={}", sessionId, e);
     }
+  }
 
-    private String buildKey(String sessionId) {
-        return SESSION_KEY_PREFIX + sessionId;
-    }
+  private String buildKey(String sessionId) {
+    return SESSION_KEY_PREFIX + sessionId;
+  }
 }

--- a/src/main/java/com/gachi/be/domain/chat/service/ChatRedisService.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/ChatRedisService.java
@@ -11,80 +11,77 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-/**채팅 히스토리 Redis 관리 서비스.*/
+/** 채팅 히스토리 Redis 관리 서비스. */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatRedisService {
 
-    private final StringRedisTemplate redisTemplate;
-    private final ObjectMapper objectMapper;
+  private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
 
-    // Redis 키 prefix
-    private static final String SESSION_KEY_PREFIX = "chat:session:";
+  // Redis 키 prefix
+  private static final String SESSION_KEY_PREFIX = "chat:session:";
 
-    // TTL 1시간: 프론트에서 sessionId를 버리면 자연 만료
-    private static final Duration SESSION_TTL = Duration.ofHours(1);
+  // TTL 1시간: 프론트에서 sessionId를 버리면 자연 만료
+  private static final Duration SESSION_TTL = Duration.ofHours(1);
 
-    // 토큰 폭발 방지: 히스토리 최대 20턴(유저+AI 각 1개 = 1턴)
-    private static final int MAX_HISTORY_TURNS = 20;
+  // 토큰 폭발 방지: 히스토리 최대 20턴(유저+AI 각 1개 = 1턴)
+  private static final int MAX_HISTORY_TURNS = 20;
 
-    /** 히스토리 조회. 키 없으면 빈 리스트 반환. */
-    public List<Map<String, String>> getHistory(String sessionId) {
-        String key = buildKey(sessionId);
-        String json = redisTemplate.opsForValue().get(key);
+  /** 히스토리 조회. 키 없으면 빈 리스트 반환. */
+  public List<Map<String, String>> getHistory(String sessionId) {
+    String key = buildKey(sessionId);
+    String json = redisTemplate.opsForValue().get(key);
 
-        if (json == null) {
-            log.debug("[ChatRedis] 히스토리 없음. sessionId={}", sessionId);
-            return new ArrayList<>();
-        }
-
-        try {
-            List<Map<String, String>> history =
-                objectMapper.readValue(json, new TypeReference<List<Map<String, String>>>() {});
-            log.debug("[ChatRedis] 히스토리 조회. sessionId={}, size={}", sessionId, history.size());
-            return history;
-        } catch (Exception e) {
-            log.error("[ChatRedis] 히스토리 파싱 실패. sessionId={}", sessionId, e);
-            // 파싱 실패 시 새 대화로 처리 (파이프라인 중단하지 않음)
-            return new ArrayList<>();
-        }
+    if (json == null) {
+      log.debug("[ChatRedis] 히스토리 없음. sessionId={}", sessionId);
+      return new ArrayList<>();
     }
 
-    /**
-     * 유저 메시지 + AI 응답을 히스토리에 추가 후 저장.
-     * MAX_HISTORY_TURNS 초과 시 오래된 턴부터 제거.
-     */
-    public void appendAndSave(String sessionId, String userMessage, String assistantReply) {
-        List<Map<String, String>> history = getHistory(sessionId);
+    try {
+      List<Map<String, String>> history =
+          objectMapper.readValue(json, new TypeReference<List<Map<String, String>>>() {});
+      log.debug("[ChatRedis] 히스토리 조회. sessionId={}, size={}", sessionId, history.size());
+      return history;
+    } catch (Exception e) {
+      log.error("[ChatRedis] 히스토리 파싱 실패. sessionId={}", sessionId, e);
+      // 파싱 실패 시 새 대화로 처리 (파이프라인 중단하지 않음)
+      return new ArrayList<>();
+    }
+  }
 
-        // 유저 메시지 추가
-        history.add(Map.of("role", "user", "content", userMessage));
-        // AI 응답 추가
-        history.add(Map.of("role", "assistant", "content", assistantReply));
+  /** 유저 메시지 + AI 응답을 히스토리에 추가 후 저장. MAX_HISTORY_TURNS 초과 시 오래된 턴부터 제거. */
+  public void appendAndSave(String sessionId, String userMessage, String assistantReply) {
+    List<Map<String, String>> history = getHistory(sessionId);
 
-        // 최대 턴 수 초과 시 앞에서부터 2개씩 제거 (가장 오래된 1턴)
-        while (history.size() > MAX_HISTORY_TURNS * 2) {
-            history.remove(0);
-            history.remove(0);
-        }
+    // 유저 메시지 추가
+    history.add(Map.of("role", "user", "content", userMessage));
+    // AI 응답 추가
+    history.add(Map.of("role", "assistant", "content", assistantReply));
 
-        try {
-            String json = objectMapper.writeValueAsString(history);
-            redisTemplate.opsForValue().set(buildKey(sessionId), json, SESSION_TTL);
-            log.debug("[ChatRedis] 히스토리 저장. sessionId={}, size={}", sessionId, history.size());
-        } catch (Exception e) {
-            // 저장 실패해도 이미 응답은 반환됐으므로 로그만
-            log.error("[ChatRedis] 히스토리 저장 실패. sessionId={}", sessionId, e);
-        }
+    // 최대 턴 수 초과 시 앞에서부터 2개씩 제거 (가장 오래된 1턴)
+    while (history.size() > MAX_HISTORY_TURNS * 2) {
+      history.remove(0);
+      history.remove(0);
     }
 
-    /** TTL 갱신 (응답 성공 시 세션 연장) */
-    public void refreshTtl(String sessionId) {
-        redisTemplate.expire(buildKey(sessionId), SESSION_TTL);
+    try {
+      String json = objectMapper.writeValueAsString(history);
+      redisTemplate.opsForValue().set(buildKey(sessionId), json, SESSION_TTL);
+      log.debug("[ChatRedis] 히스토리 저장. sessionId={}, size={}", sessionId, history.size());
+    } catch (Exception e) {
+      // 저장 실패해도 이미 응답은 반환됐으므로 로그만
+      log.error("[ChatRedis] 히스토리 저장 실패. sessionId={}", sessionId, e);
     }
+  }
 
-    private String buildKey(String sessionId) {
-        return SESSION_KEY_PREFIX + sessionId;
-    }
+  /** TTL 갱신 (응답 성공 시 세션 연장) */
+  public void refreshTtl(String sessionId) {
+    redisTemplate.expire(buildKey(sessionId), SESSION_TTL);
+  }
+
+  private String buildKey(String sessionId) {
+    return SESSION_KEY_PREFIX + sessionId;
+  }
 }

--- a/src/main/java/com/gachi/be/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/ChatService.java
@@ -1,0 +1,60 @@
+package com.gachi.be.domain.chat.service;
+
+import com.gachi.be.domain.chat.client.AiChatClient;
+import com.gachi.be.domain.chat.dto.request.ChatMessageRequest;
+import com.gachi.be.domain.chat.dto.response.ChatMessageResponse;
+import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.repository.UserRepository;
+import com.gachi.be.global.code.ErrorCode;
+import com.gachi.be.global.exception.BusinessException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**채팅 서비스.*/
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final AiChatClient aiChatClient;
+    private final ChatRedisService chatRedisService;
+    private final UserRepository userRepository;
+
+    // chatType 기본값: GENERAL TODO: 나중에 문서 챗봇 생성되면... 그때 확인
+    private static final String DEFAULT_CHAT_TYPE = "GENERAL";
+
+    public ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request) {
+        // sessionId 없으면 신규 생성
+        String sessionId = (request.sessionId() != null && !request.sessionId().isBlank())
+            ? request.sessionId()
+            : UUID.randomUUID().toString();
+
+        // 사용자 languageCode 조회 (AI 서버 응답 언어 결정)
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        String language = user.getLanguageCode().name();
+
+        // chatType 기본값 처리
+        String chatType = (request.chatType() != null && !request.chatType().isBlank())
+            ? request.chatType()
+            : DEFAULT_CHAT_TYPE;
+
+        // Redis에서 이전 히스토리 조회
+        List<Map<String, String>> history = chatRedisService.getHistory(sessionId);
+
+        log.info("[ChatService] 채팅 요청. userId={}, sessionId={}, chatType={}, historySize={}",
+            userId, sessionId, chatType, history.size());
+
+        // AI 서버 호출
+        String reply = aiChatClient.chat(request.message(), history, language, chatType);
+
+        // Redis 히스토리 업데이트 (유저 메시지 + AI 응답 추가)
+        chatRedisService.appendAndSave(sessionId, request.message(), reply);
+
+        return new ChatMessageResponse(sessionId, reply);
+    }
+}

--- a/src/main/java/com/gachi/be/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/ChatService.java
@@ -36,7 +36,7 @@ public class ChatService {
         // 사용자 languageCode 조회 (AI 서버 응답 언어 결정)
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        String language = user.getLanguageCode().name();
+        String language = user.getLanguageCode();
 
         // chatType 기본값 처리
         String chatType = (request.chatType() != null && !request.chatType().isBlank())

--- a/src/main/java/com/gachi/be/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/ChatService.java
@@ -1,60 +1,10 @@
 package com.gachi.be.domain.chat.service;
 
-import com.gachi.be.domain.chat.client.AiChatClient;
 import com.gachi.be.domain.chat.dto.request.ChatMessageRequest;
 import com.gachi.be.domain.chat.dto.response.ChatMessageResponse;
-import com.gachi.be.domain.user.entity.User;
-import com.gachi.be.domain.user.repository.UserRepository;
-import com.gachi.be.global.code.ErrorCode;
-import com.gachi.be.global.exception.BusinessException;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
-/**채팅 서비스.*/
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class ChatService {
+public interface ChatService {
 
-    private final AiChatClient aiChatClient;
-    private final ChatRedisService chatRedisService;
-    private final UserRepository userRepository;
-
-    // chatType 기본값: GENERAL TODO: 나중에 문서 챗봇 생성되면... 그때 확인
-    private static final String DEFAULT_CHAT_TYPE = "GENERAL";
-
-    public ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request) {
-        // sessionId 없으면 신규 생성
-        String sessionId = (request.sessionId() != null && !request.sessionId().isBlank())
-            ? request.sessionId()
-            : UUID.randomUUID().toString();
-
-        // 사용자 languageCode 조회 (AI 서버 응답 언어 결정)
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        String language = user.getLanguageCode();
-
-        // chatType 기본값 처리
-        String chatType = (request.chatType() != null && !request.chatType().isBlank())
-            ? request.chatType()
-            : DEFAULT_CHAT_TYPE;
-
-        // Redis에서 이전 히스토리 조회
-        List<Map<String, String>> history = chatRedisService.getHistory(sessionId);
-
-        log.info("[ChatService] 채팅 요청. userId={}, sessionId={}, chatType={}, historySize={}",
-            userId, sessionId, chatType, history.size());
-
-        // AI 서버 호출
-        String reply = aiChatClient.chat(request.message(), history, language, chatType);
-
-        // Redis 히스토리 업데이트 (유저 메시지 + AI 응답 추가)
-        chatRedisService.appendAndSave(sessionId, request.message(), reply);
-
-        return new ChatMessageResponse(sessionId, reply);
-    }
+    /**채팅 메시지 전송 및 AI 응답 반환. */
+    ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request);
 }

--- a/src/main/java/com/gachi/be/domain/chat/service/ChatService.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/ChatService.java
@@ -5,6 +5,6 @@ import com.gachi.be.domain.chat.dto.response.ChatMessageResponse;
 
 public interface ChatService {
 
-    /**채팅 메시지 전송 및 AI 응답 반환. */
-    ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request);
+  /** 채팅 메시지 전송 및 AI 응답 반환. */
+  ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request);
 }

--- a/src/main/java/com/gachi/be/domain/chat/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/impl/ChatServiceImpl.java
@@ -1,0 +1,4 @@
+package com.gachi.be.domain.chat.service.impl;
+
+public class ChatServiceImpl {
+}

--- a/src/main/java/com/gachi/be/domain/chat/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/impl/ChatServiceImpl.java
@@ -11,6 +11,7 @@ import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.exception.BusinessException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -70,7 +71,7 @@ public class ChatServiceImpl implements ChatService {
     String reply = aiChatClient.chat(request.message(), history, language, chatType);
 
     // AI 응답 시간 (KST)
-    String sentAt = ZonedDateTime.now(KST).toString();
+      String sentAt = ZonedDateTime.now(KST).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 
     // Redis 히스토리 업데이트 (유저 메시지 + AI 응답 추가)
     chatRedisService.appendAndSave(sessionId, request.message(), reply);

--- a/src/main/java/com/gachi/be/domain/chat/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/impl/ChatServiceImpl.java
@@ -71,7 +71,7 @@ public class ChatServiceImpl implements ChatService {
     String reply = aiChatClient.chat(request.message(), history, language, chatType);
 
     // AI 응답 시간 (KST)
-      String sentAt = ZonedDateTime.now(KST).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    String sentAt = ZonedDateTime.now(KST).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 
     // Redis 히스토리 업데이트 (유저 메시지 + AI 응답 추가)
     chatRedisService.appendAndSave(sessionId, request.message(), reply);

--- a/src/main/java/com/gachi/be/domain/chat/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/impl/ChatServiceImpl.java
@@ -18,57 +18,65 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-/**채팅 서비스 구현체.*/
+/** 채팅 서비스 구현체. */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatServiceImpl implements ChatService {
 
-    private final AiChatClient aiChatClient;
-    private final ChatRedisService chatRedisService;
-    private final UserRepository userRepository;
+  private final AiChatClient aiChatClient;
+  private final ChatRedisService chatRedisService;
+  private final UserRepository userRepository;
 
-    // chatType 기본값: GENERAL (추후 DOCUMENT 추가 시 분기)
-    private static final String DEFAULT_CHAT_TYPE = "GENERAL";
+  // chatType 기본값: GENERAL (추후 DOCUMENT 추가 시 분기)
+  private static final String DEFAULT_CHAT_TYPE = "GENERAL";
 
-    // 응답 시간 KST 기준
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+  // 응답 시간 KST 기준
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
-    @Override
-    public ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request) {
+  @Override
+  public ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request) {
 
-        // sessionId 없으면 신규 생성 (앱 진입 시 첫 메시지)
-        String sessionId = (request.sessionId() != null && !request.sessionId().isBlank())
+    // sessionId 없으면 신규 생성 (앱 진입 시 첫 메시지)
+    String sessionId =
+        (request.sessionId() != null && !request.sessionId().isBlank())
             ? request.sessionId()
             : UUID.randomUUID().toString();
 
-        // 사용자 languageCode 조회 → AI 응답 언어 결정
-        User user = userRepository.findById(userId)
+    // 사용자 languageCode 조회 → AI 응답 언어 결정
+    User user =
+        userRepository
+            .findById(userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        String language = user.getLanguageCode(); // String 타입
+    String language = user.getLanguageCode(); // String 타입
 
-        // chatType 기본값 처리
-        String chatType = (request.chatType() != null && !request.chatType().isBlank())
+    // chatType 기본값 처리
+    String chatType =
+        (request.chatType() != null && !request.chatType().isBlank())
             ? request.chatType()
             : DEFAULT_CHAT_TYPE;
 
-        // Redis에서 이전 히스토리 조회
-        List<Map<String, String>> history = chatRedisService.getHistory(sessionId);
+    // Redis에서 이전 히스토리 조회
+    List<Map<String, String>> history = chatRedisService.getHistory(sessionId);
 
-        log.info("[ChatService] 채팅 요청. userId={}, sessionId={}, chatType={}, historySize={}",
-            userId, sessionId, chatType, history.size());
+    log.info(
+        "[ChatService] 채팅 요청. userId={}, sessionId={}, chatType={}, historySize={}",
+        userId,
+        sessionId,
+        chatType,
+        history.size());
 
-        // AI 서버 호출
-        String reply = aiChatClient.chat(request.message(), history, language, chatType);
+    // AI 서버 호출
+    String reply = aiChatClient.chat(request.message(), history, language, chatType);
 
-        // AI 응답 시간 (KST)
-        String sentAt = ZonedDateTime.now(KST).toString();
+    // AI 응답 시간 (KST)
+    String sentAt = ZonedDateTime.now(KST).toString();
 
-        // Redis 히스토리 업데이트 (유저 메시지 + AI 응답 추가)
-        chatRedisService.appendAndSave(sessionId, request.message(), reply);
+    // Redis 히스토리 업데이트 (유저 메시지 + AI 응답 추가)
+    chatRedisService.appendAndSave(sessionId, request.message(), reply);
 
-        log.info("[ChatService] 채팅 응답 완료. userId={}, sessionId={}", userId, sessionId);
+    log.info("[ChatService] 채팅 응답 완료. userId={}, sessionId={}", userId, sessionId);
 
-        return new ChatMessageResponse(sessionId, reply, sentAt);
-    }
+    return new ChatMessageResponse(sessionId, reply, sentAt);
+  }
 }

--- a/src/main/java/com/gachi/be/domain/chat/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/chat/service/impl/ChatServiceImpl.java
@@ -1,4 +1,74 @@
 package com.gachi.be.domain.chat.service.impl;
 
-public class ChatServiceImpl {
+import com.gachi.be.domain.chat.client.AiChatClient;
+import com.gachi.be.domain.chat.dto.request.ChatMessageRequest;
+import com.gachi.be.domain.chat.dto.response.ChatMessageResponse;
+import com.gachi.be.domain.chat.service.ChatRedisService;
+import com.gachi.be.domain.chat.service.ChatService;
+import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.repository.UserRepository;
+import com.gachi.be.global.code.ErrorCode;
+import com.gachi.be.global.exception.BusinessException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**채팅 서비스 구현체.*/
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+    private final AiChatClient aiChatClient;
+    private final ChatRedisService chatRedisService;
+    private final UserRepository userRepository;
+
+    // chatType 기본값: GENERAL (추후 DOCUMENT 추가 시 분기)
+    private static final String DEFAULT_CHAT_TYPE = "GENERAL";
+
+    // 응답 시간 KST 기준
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Override
+    public ChatMessageResponse sendMessage(Long userId, ChatMessageRequest request) {
+
+        // sessionId 없으면 신규 생성 (앱 진입 시 첫 메시지)
+        String sessionId = (request.sessionId() != null && !request.sessionId().isBlank())
+            ? request.sessionId()
+            : UUID.randomUUID().toString();
+
+        // 사용자 languageCode 조회 → AI 응답 언어 결정
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        String language = user.getLanguageCode(); // String 타입
+
+        // chatType 기본값 처리
+        String chatType = (request.chatType() != null && !request.chatType().isBlank())
+            ? request.chatType()
+            : DEFAULT_CHAT_TYPE;
+
+        // Redis에서 이전 히스토리 조회
+        List<Map<String, String>> history = chatRedisService.getHistory(sessionId);
+
+        log.info("[ChatService] 채팅 요청. userId={}, sessionId={}, chatType={}, historySize={}",
+            userId, sessionId, chatType, history.size());
+
+        // AI 서버 호출
+        String reply = aiChatClient.chat(request.message(), history, language, chatType);
+
+        // AI 응답 시간 (KST)
+        String sentAt = ZonedDateTime.now(KST).toString();
+
+        // Redis 히스토리 업데이트 (유저 메시지 + AI 응답 추가)
+        chatRedisService.appendAndSave(sessionId, request.message(), reply);
+
+        log.info("[ChatService] 채팅 응답 완료. userId={}, sessionId={}", userId, sessionId);
+
+        return new ChatMessageResponse(sessionId, reply, sentAt);
+    }
 }

--- a/src/main/java/com/gachi/be/global/code/ErrorCode.java
+++ b/src/main/java/com/gachi/be/global/code/ErrorCode.java
@@ -236,6 +236,13 @@ public enum ErrorCode {
       "notificationId에 해당하는 알림이 없거나 소유권이 일치하지 않음",
       ErrorLogLevel.INFO),
 
+  CHAT_AI_ERROR(
+      HttpStatus.BAD_GATEWAY,
+      "CHAT5021",
+      "채팅 AI 서버 오류가 발생했습니다.",
+      "AI 서버 /ai/chat/messages 호출 실패",
+      ErrorLogLevel.ERROR),
+
   EXTERNAL_API_ERROR(
       HttpStatus.BAD_GATEWAY,
       "EXT5021",

--- a/src/main/java/com/gachi/be/global/code/SuccessCode.java
+++ b/src/main/java/com/gachi/be/global/code/SuccessCode.java
@@ -46,7 +46,8 @@ public enum SuccessCode {
   NOTIFICATION_UNREAD_COUNT_SUCCESS(HttpStatus.OK, "NOTI2002", "미읽음 알림 수 조회에 성공하였습니다."),
   NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "NOTI2003", "알림 읽음 처리에 성공하였습니다."),
   NOTIFICATION_PUSH_TOKEN_REGISTERED(HttpStatus.OK, "NOTI2004", "푸시 토큰 등록에 성공하였습니다."),
-  NOTIFICATION_PUSH_TOKEN_DELETED(HttpStatus.OK, "NOTI2005", "푸시 토큰 삭제에 성공하였습니다.");
+  NOTIFICATION_PUSH_TOKEN_DELETED(HttpStatus.OK, "NOTI2005", "푸시 토큰 삭제에 성공하였습니다."),
+  CHAT_MESSAGE_SUCCESS(HttpStatus.OK, "CHAT2001", "채팅 응답에 성공하였습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - AI 서버의 채팅 API를 호출하는 챗봇 메시지 전송 API 구현
  - Redis 기반 채팅 세션 및 대화 이력 저장
  - 채팅 세션 TTL 적용
  - 사용자 언어 설정을 AI 요청에 반영
  - AI 서버 호출 실패 시 `CHAT5021` 오류 응답 추가
  - 에러코드 스냅샷: [error-code-v11](https://docs.google.com/spreadsheets/d/1sUG_JJsVl6a8nR6k8jO_b7UrIEZzuvQdPB6S2S6fqgo/edit?gid=1896779807#gid=1896779807)
  - 커밋 해시: 80e4114
- 관련 이슈: closes #91 

## 🌿 브랜치 정보

- **Source**: `feat/#91-chatbot`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI 기반 채팅 메시징 기능 추가
  * 채팅 세션 관리 및 대화 히스토리 저장 기능 추가
  * 사용자 언어 설정에 따른 다국어 채팅 지원
  * 채팅 세션별 자동 TTL 관리로 메모리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->