### PR TITLE
feat: 자녀 정보 수정·삭제 API 구현

### DIFF
--- a/src/main/java/com/gachi/be/domain/calendar/repository/CalendarEventRepository.java
+++ b/src/main/java/com/gachi/be/domain/calendar/repository/CalendarEventRepository.java
@@ -5,6 +5,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -68,4 +69,33 @@ public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Lo
         """)
   List<Long> findRegisteredNewsletterIds(
       @Param("userId") Long userId, @Param("newsletterIds") List<Long> newsletterIds);
+
+    // 자녀 이름 변경 시 calendar_events.child_name 일괄 동기화
+    @Modifying
+    @Query(
+        """
+        UPDATE CalendarEvent e
+        SET e.childName = :newName
+        WHERE e.userId = :userId AND e.childName = :oldName
+        """)
+    void updateChildNameByUserIdAndOldName(
+        @Param("userId") Long userId,
+        @Param("oldName") String oldName,
+        @Param("newName") String newName);
+
+    // 자녀 색상 변경 시 calendar_events.child_color 일괄 동기화
+    @Modifying
+    @Query(
+        """
+        UPDATE CalendarEvent e
+        SET e.childColor = :newColor
+        WHERE e.userId = :userId AND e.childName = :childName
+        """)
+    void updateChildColorByUserIdAndChildName(
+        @Param("userId") Long userId,
+        @Param("childName") String childName,
+        @Param("newColor") String newColor);
+
+    // 자녀 삭제 시 해당 자녀의 모든 calendar_events 삭제
+    void deleteAllByUserIdAndChildName(Long userId, String childName);
 }

--- a/src/main/java/com/gachi/be/domain/calendar/repository/CalendarEventRepository.java
+++ b/src/main/java/com/gachi/be/domain/calendar/repository/CalendarEventRepository.java
@@ -70,32 +70,32 @@ public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Lo
   List<Long> findRegisteredNewsletterIds(
       @Param("userId") Long userId, @Param("newsletterIds") List<Long> newsletterIds);
 
-    // 자녀 이름 변경 시 calendar_events.child_name 일괄 동기화
-    @Modifying
-    @Query(
-        """
+  // 자녀 이름 변경 시 calendar_events.child_name 일괄 동기화
+  @Modifying
+  @Query(
+      """
         UPDATE CalendarEvent e
         SET e.childName = :newName
         WHERE e.userId = :userId AND e.childName = :oldName
         """)
-    void updateChildNameByUserIdAndOldName(
-        @Param("userId") Long userId,
-        @Param("oldName") String oldName,
-        @Param("newName") String newName);
+  void updateChildNameByUserIdAndOldName(
+      @Param("userId") Long userId,
+      @Param("oldName") String oldName,
+      @Param("newName") String newName);
 
-    // 자녀 색상 변경 시 calendar_events.child_color 일괄 동기화
-    @Modifying
-    @Query(
-        """
+  // 자녀 색상 변경 시 calendar_events.child_color 일괄 동기화
+  @Modifying
+  @Query(
+      """
         UPDATE CalendarEvent e
         SET e.childColor = :newColor
         WHERE e.userId = :userId AND e.childName = :childName
         """)
-    void updateChildColorByUserIdAndChildName(
-        @Param("userId") Long userId,
-        @Param("childName") String childName,
-        @Param("newColor") String newColor);
+  void updateChildColorByUserIdAndChildName(
+      @Param("userId") Long userId,
+      @Param("childName") String childName,
+      @Param("newColor") String newColor);
 
-    // 자녀 삭제 시 해당 자녀의 모든 calendar_events 삭제
-    void deleteAllByUserIdAndChildName(Long userId, String childName);
+  // 자녀 삭제 시 해당 자녀의 모든 calendar_events 삭제
+  void deleteAllByUserIdAndChildName(Long userId, String childName);
 }

--- a/src/main/java/com/gachi/be/domain/child/api/controller/ChildController.java
+++ b/src/main/java/com/gachi/be/domain/child/api/controller/ChildController.java
@@ -40,15 +40,15 @@ public class ChildController {
       @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
       @PathVariable Long childId,
       @Valid @RequestBody ChildUpdateRequest request) {
-      childService.updateChild(authorizationHeader, childId, request);
-      return ApiResponse.success(SuccessCode.CHILD_UPDATE_SUCCESS, null);
+    childService.updateChild(authorizationHeader, childId, request);
+    return ApiResponse.success(SuccessCode.CHILD_UPDATE_SUCCESS, null);
   }
 
   @DeleteMapping("/{childId}")
   public ApiResponse<Void> deleteChild(
       @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
       @PathVariable Long childId) {
-      childService.deleteChild(authorizationHeader, childId);
-      return ApiResponse.success(SuccessCode.CHILD_DELETE_SUCCESS, null);
+    childService.deleteChild(authorizationHeader, childId);
+    return ApiResponse.success(SuccessCode.CHILD_DELETE_SUCCESS, null);
   }
 }

--- a/src/main/java/com/gachi/be/domain/child/api/controller/ChildController.java
+++ b/src/main/java/com/gachi/be/domain/child/api/controller/ChildController.java
@@ -1,6 +1,7 @@
 package com.gachi.be.domain.child.api.controller;
 
 import com.gachi.be.domain.child.dto.request.ChildCreateRequest;
+import com.gachi.be.domain.child.dto.request.ChildUpdateRequest;
 import com.gachi.be.domain.child.dto.response.ChildResponse;
 import com.gachi.be.domain.child.service.ChildService;
 import com.gachi.be.global.api.ApiResponse;
@@ -9,13 +10,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /** 자녀 등록 및 내 자녀 목록 조회 API를 제공한다. */
 @RestController
@@ -38,5 +33,22 @@ public class ChildController {
       @RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
     return ApiResponse.success(
         SuccessCode.CHILD_GET_LIST_SUCCESS, childService.getChildren(authorizationHeader));
+  }
+
+  @PatchMapping("/{childId}")
+  public ApiResponse<Void> updateChild(
+      @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+      @PathVariable Long childId,
+      @Valid @RequestBody ChildUpdateRequest request) {
+      childService.updateChild(authorizationHeader, childId, request);
+      return ApiResponse.success(SuccessCode.CHILD_UPDATE_SUCCESS, null);
+  }
+
+  @DeleteMapping("/{childId}")
+  public ApiResponse<Void> deleteChild(
+      @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+      @PathVariable Long childId) {
+      childService.deleteChild(authorizationHeader, childId);
+      return ApiResponse.success(SuccessCode.CHILD_DELETE_SUCCESS, null);
   }
 }

--- a/src/main/java/com/gachi/be/domain/child/dto/request/ChildUpdateRequest.java
+++ b/src/main/java/com/gachi/be/domain/child/dto/request/ChildUpdateRequest.java
@@ -11,7 +11,5 @@ public record ChildUpdateRequest(
     @Size(max = 64) String schoolCode,
     @Size(max = 20) String officeCode,
     @Min(1) @Max(6) Integer grade,
-    @Pattern(
-        regexp = "^#[A-Fa-f0-9]{6}$",
-        message = "colorCode는 #RRGGBB 형식(예: #FF5A5A)만 허용합니다.")
-    String colorCode) {}
+    @Pattern(regexp = "^#[A-Fa-f0-9]{6}$", message = "colorCode는 #RRGGBB 형식(예: #FF5A5A)만 허용합니다.")
+        String colorCode) {}

--- a/src/main/java/com/gachi/be/domain/child/dto/request/ChildUpdateRequest.java
+++ b/src/main/java/com/gachi/be/domain/child/dto/request/ChildUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.gachi.be.domain.child.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ChildUpdateRequest(
+    @Size(max = 50) String name,
+    @Size(max = 120) String schoolName,
+    @Size(max = 64) String schoolCode,
+    @Size(max = 20) String officeCode,
+    @Min(1) @Max(6) Integer grade,
+    @Pattern(
+        regexp = "^#[A-Fa-f0-9]{6}$",
+        message = "colorCode는 #RRGGBB 형식(예: #FF5A5A)만 허용합니다.")
+    String colorCode) {}

--- a/src/main/java/com/gachi/be/domain/child/dto/request/ChildUpdateRequest.java
+++ b/src/main/java/com/gachi/be/domain/child/dto/request/ChildUpdateRequest.java
@@ -6,10 +6,13 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record ChildUpdateRequest(
-    @Size(max = 50) String name,
-    @Size(max = 120) String schoolName,
-    @Size(max = 64) String schoolCode,
-    @Size(max = 20) String officeCode,
+    @Size(max = 50) @Pattern(regexp = ".*\\S.*", message = "name은 공백만 입력할 수 없습니다.") String name,
+    @Size(max = 120) @Pattern(regexp = ".*\\S.*", message = "schoolName은 공백만 입력할 수 없습니다.")
+        String schoolName,
+    @Size(max = 64) @Pattern(regexp = ".*\\S.*", message = "schoolCode는 공백만 입력할 수 없습니다.")
+        String schoolCode,
+    @Size(max = 20) @Pattern(regexp = ".*\\S.*", message = "officeCode는 공백만 입력할 수 없습니다.")
+        String officeCode,
     @Min(1) @Max(6) Integer grade,
     @Pattern(regexp = "^#[A-Fa-f0-9]{6}$", message = "colorCode는 #RRGGBB 형식(예: #FF5A5A)만 허용합니다.")
         String colorCode) {}

--- a/src/main/java/com/gachi/be/domain/child/entity/Child.java
+++ b/src/main/java/com/gachi/be/domain/child/entity/Child.java
@@ -107,11 +107,11 @@ public class Child {
       String officeCode,
       Integer grade,
       String colorCode) {
-      if (name != null) this.name = name;
-      if (schoolName != null) this.schoolName = schoolName;
-      if (schoolCode != null) this.schoolCode = schoolCode;
-      if (officeCode != null) this.officeCode = officeCode;
-      if (grade != null) this.grade = grade;
-      if (colorCode != null) this.colorCode = colorCode;
+    if (name != null) this.name = name;
+    if (schoolName != null) this.schoolName = schoolName;
+    if (schoolCode != null) this.schoolCode = schoolCode;
+    if (officeCode != null) this.officeCode = officeCode;
+    if (grade != null) this.grade = grade;
+    if (colorCode != null) this.colorCode = colorCode;
   }
 }

--- a/src/main/java/com/gachi/be/domain/child/entity/Child.java
+++ b/src/main/java/com/gachi/be/domain/child/entity/Child.java
@@ -99,4 +99,19 @@ public class Child {
   public void updateColorCode(String newColorCode) {
     this.colorCode = newColorCode;
   }
+
+  public void update(
+      String name,
+      String schoolName,
+      String schoolCode,
+      String officeCode,
+      Integer grade,
+      String colorCode) {
+      if (name != null) this.name = name;
+      if (schoolName != null) this.schoolName = schoolName;
+      if (schoolCode != null) this.schoolCode = schoolCode;
+      if (officeCode != null) this.officeCode = officeCode;
+      if (grade != null) this.grade = grade;
+      if (colorCode != null) this.colorCode = colorCode;
+  }
 }

--- a/src/main/java/com/gachi/be/domain/child/service/ChildService.java
+++ b/src/main/java/com/gachi/be/domain/child/service/ChildService.java
@@ -1,5 +1,6 @@
 package com.gachi.be.domain.child.service;
 
+// import 추가 (파일 상단)
 import com.gachi.be.domain.auth.service.AuthenticatedUserResolver;
 import com.gachi.be.domain.calendar.repository.CalendarEventRepository;
 import com.gachi.be.domain.child.dto.request.ChildCreateRequest;
@@ -18,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.StringUtils;
 
 /** 자녀 등록/조회 비즈니스 로직을 담당한다. */
@@ -89,6 +92,7 @@ public class ChildService {
             .orElseThrow(() -> new BusinessException(ErrorCode.CHILD_NOT_FOUND));
 
     String oldName = child.getName();
+    String oldColorCode = child.getColorCode();
     String newName = request.name() != null ? request.name().trim() : null;
     String newColorCode =
         request.colorCode() != null ? request.colorCode().trim().toUpperCase() : null;
@@ -113,7 +117,7 @@ public class ChildService {
     }
 
     // 색상이 변경된 경우 → newsletter, calendar_events child_color 일괄 동기화
-    if (newColorCode != null && !newColorCode.equals(child.getColorCode())) {
+    if (newColorCode != null && !newColorCode.equals(oldColorCode)) {
       String syncTargetName = (newName != null) ? newName : oldName;
       newsletterRepository.updateChildColorByUserIdAndChildName(
           user.getId(), syncTargetName, newColorCode);
@@ -156,19 +160,32 @@ public class ChildService {
         childName,
         newsletters.size());
 
-    // S3 파일 삭제 (DB 삭제 성공 후 실행)
-    for (String fileKey : fileKeys) {
-      try {
-        s3FileService.deleteFile(fileKey);
-      } catch (Exception e) {
-        // S3 삭제 실패는 로그만 남기고 계속 진행 (DB 삭제가 이미 완료됐으므로 롤백 불가)
-        log.error("[Child] S3 파일 삭제 실패. fileKey={}, error={}", fileKey, e.getMessage());
-      }
-    }
-
     // 자녀 soft delete
     child.softDelete();
     log.info("[Child] 자녀 삭제 완료. userId={}, childId={}, childName={}", userId, childId, childName);
+
+    // S3 삭제를 트랜잭션 커밋 이후 실행으로 분리
+    // 트랜잭션 내부에서 외부 네트워크 호출 시 느린 S3 응답이 DB 커넥션을 불필요하게 점유하고,
+    // S3 장애가 DB 롤백을 유발하는 리스크를 제거하기 위해 afterCommit으로 분리
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            for (String fileKey : fileKeys) {
+              try {
+                s3FileService.deleteFile(fileKey);
+              } catch (Exception e) {
+                // S3 삭제 실패는 로그만 남기고 계속 진행 (DB 삭제가 이미 커밋됐으므로 롤백 불가)
+                log.error("[Child] S3 파일 삭제 실패. fileKey={}, error={}", fileKey, e.getMessage());
+              }
+            }
+            log.debug(
+                "[Child] S3 파일 삭제 완료. userId={}, childName={}, count={}",
+                userId,
+                childName,
+                fileKeys.size());
+          }
+        });
   }
 
   private String normalizeRequiredText(String value) {

--- a/src/main/java/com/gachi/be/domain/child/service/ChildService.java
+++ b/src/main/java/com/gachi/be/domain/child/service/ChildService.java
@@ -1,20 +1,27 @@
 package com.gachi.be.domain.child.service;
 
 import com.gachi.be.domain.auth.service.AuthenticatedUserResolver;
+import com.gachi.be.domain.calendar.repository.CalendarEventRepository;
 import com.gachi.be.domain.child.dto.request.ChildCreateRequest;
+import com.gachi.be.domain.child.dto.request.ChildUpdateRequest;
 import com.gachi.be.domain.child.dto.response.ChildResponse;
 import com.gachi.be.domain.child.entity.Child;
 import com.gachi.be.domain.child.repository.ChildRepository;
+import com.gachi.be.domain.newsletter.entity.Newsletter;
+import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
 import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.file.service.S3FileService;
 import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.exception.BusinessException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 /** 자녀 등록/조회 비즈니스 로직을 담당한다. */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChildService {
@@ -22,6 +29,9 @@ public class ChildService {
 
   private final ChildRepository childRepository;
   private final AuthenticatedUserResolver authenticatedUserResolver;
+  private final NewsletterRepository newsletterRepository;
+  private final CalendarEventRepository calendarEventRepository;
+  private final S3FileService s3FileService;
 
   @Transactional
   public ChildResponse createChild(String authorizationHeader, ChildCreateRequest request) {
@@ -65,6 +75,95 @@ public class ChildService {
         child.getGrade(),
         child.getColorCode(),
         child.getCreatedAt());
+  }
+
+  // 자녀 정보 수정
+  @Transactional
+  public void updateChild(String authorizationHeader, Long childId, ChildUpdateRequest request) {
+      User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
+
+      // 소유권 검증 (soft delete된 자녀는 수정 불가)
+      Child child =
+          childRepository
+              .findByIdAndUserIdAndDeletedAtIsNull(childId, user.getId())
+              .orElseThrow(() -> new BusinessException(ErrorCode.CHILD_NOT_FOUND));
+
+      String oldName = child.getName();
+      String newName = request.name() != null ? request.name().trim() : null;
+      String newColorCode =
+          request.colorCode() != null ? request.colorCode().trim().toUpperCase() : null;
+
+      child.update(
+          newName,
+          request.schoolName() != null ? request.schoolName().trim() : null,
+          request.schoolCode() != null ? request.schoolCode().trim() : null,
+          request.officeCode() != null ? request.officeCode().trim() : null,
+          request.grade(),
+          newColorCode);
+
+      // 이름이 변경된 경우 → newsletter, calendar_events child_name 일괄 동기화
+      if (newName != null && !newName.equals(oldName)) {
+          newsletterRepository.updateChildNameByUserIdAndOldName(user.getId(), oldName, newName);
+          calendarEventRepository.updateChildNameByUserIdAndOldName(user.getId(), oldName, newName);
+          log.debug(
+              "[Child] child_name 동기화 완료. userId={}, oldName={}, newName={}",
+              user.getId(), oldName, newName);
+      }
+
+      // 색상이 변경된 경우 → newsletter, calendar_events child_color 일괄 동기화
+      if (newColorCode != null && !newColorCode.equals(child.getColorCode())) {
+          String syncTargetName = (newName != null) ? newName : oldName;
+          newsletterRepository.updateChildColorByUserIdAndChildName(
+              user.getId(), syncTargetName, newColorCode);
+          calendarEventRepository.updateChildColorByUserIdAndChildName(
+              user.getId(), syncTargetName, newColorCode);
+          log.debug(
+              "[Child] child_color 동기화 완료. userId={}, childName={}, newColor={}",
+              user.getId(), syncTargetName, newColorCode);
+      }
+  }
+
+  //자녀 삭제 - 연관된 모든 데이터 삭제
+  @Transactional
+  public void deleteChild(String authorizationHeader, Long childId) {
+      User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
+
+      // 소유권 검증
+      Child child =
+          childRepository
+              .findByIdAndUserIdAndDeletedAtIsNull(childId, user.getId())
+              .orElseThrow(() -> new BusinessException(ErrorCode.CHILD_NOT_FOUND));
+
+      String childName = child.getName();
+      Long userId = user.getId();
+
+      // 해당 자녀의 newsletter 목록 조회 → S3 fileKey 수집
+      List<Newsletter> newsletters =
+          newsletterRepository.findAllByUserIdAndChildName(userId, childName);
+      List<String> fileKeys = newsletters.stream().map(Newsletter::getFileKey).toList();
+
+      calendarEventRepository.deleteAllByUserIdAndChildName(userId, childName);
+      log.debug(
+          "[Child] calendar_events 삭제 완료. userId={}, childName={}", userId, childName);
+
+      newsletterRepository.deleteAllByUserIdAndChildName(userId, childName);
+      log.debug(
+          "[Child] newsletter 삭제 완료. userId={}, childName={}, count={}",
+          userId, childName, newsletters.size());
+
+      // S3 파일 삭제 (DB 삭제 성공 후 실행)
+      for (String fileKey : fileKeys) {
+          try {
+              s3FileService.deleteFile(fileKey);
+          } catch (Exception e) {
+              // S3 삭제 실패는 로그만 남기고 계속 진행 (DB 삭제가 이미 완료됐으므로 롤백 불가)
+              log.error("[Child] S3 파일 삭제 실패. fileKey={}, error={}", fileKey, e.getMessage());
+          }
+      }
+
+      // 자녀 soft delete
+      child.softDelete();
+      log.info("[Child] 자녀 삭제 완료. userId={}, childId={}, childName={}", userId, childId, childName);
   }
 
   private String normalizeRequiredText(String value) {

--- a/src/main/java/com/gachi/be/domain/child/service/ChildService.java
+++ b/src/main/java/com/gachi/be/domain/child/service/ChildService.java
@@ -80,90 +80,95 @@ public class ChildService {
   // 자녀 정보 수정
   @Transactional
   public void updateChild(String authorizationHeader, Long childId, ChildUpdateRequest request) {
-      User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
+    User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
 
-      // 소유권 검증 (soft delete된 자녀는 수정 불가)
-      Child child =
-          childRepository
-              .findByIdAndUserIdAndDeletedAtIsNull(childId, user.getId())
-              .orElseThrow(() -> new BusinessException(ErrorCode.CHILD_NOT_FOUND));
+    // 소유권 검증 (soft delete된 자녀는 수정 불가)
+    Child child =
+        childRepository
+            .findByIdAndUserIdAndDeletedAtIsNull(childId, user.getId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.CHILD_NOT_FOUND));
 
-      String oldName = child.getName();
-      String newName = request.name() != null ? request.name().trim() : null;
-      String newColorCode =
-          request.colorCode() != null ? request.colorCode().trim().toUpperCase() : null;
+    String oldName = child.getName();
+    String newName = request.name() != null ? request.name().trim() : null;
+    String newColorCode =
+        request.colorCode() != null ? request.colorCode().trim().toUpperCase() : null;
 
-      child.update(
-          newName,
-          request.schoolName() != null ? request.schoolName().trim() : null,
-          request.schoolCode() != null ? request.schoolCode().trim() : null,
-          request.officeCode() != null ? request.officeCode().trim() : null,
-          request.grade(),
+    child.update(
+        newName,
+        request.schoolName() != null ? request.schoolName().trim() : null,
+        request.schoolCode() != null ? request.schoolCode().trim() : null,
+        request.officeCode() != null ? request.officeCode().trim() : null,
+        request.grade(),
+        newColorCode);
+
+    // 이름이 변경된 경우 → newsletter, calendar_events child_name 일괄 동기화
+    if (newName != null && !newName.equals(oldName)) {
+      newsletterRepository.updateChildNameByUserIdAndOldName(user.getId(), oldName, newName);
+      calendarEventRepository.updateChildNameByUserIdAndOldName(user.getId(), oldName, newName);
+      log.debug(
+          "[Child] child_name 동기화 완료. userId={}, oldName={}, newName={}",
+          user.getId(),
+          oldName,
+          newName);
+    }
+
+    // 색상이 변경된 경우 → newsletter, calendar_events child_color 일괄 동기화
+    if (newColorCode != null && !newColorCode.equals(child.getColorCode())) {
+      String syncTargetName = (newName != null) ? newName : oldName;
+      newsletterRepository.updateChildColorByUserIdAndChildName(
+          user.getId(), syncTargetName, newColorCode);
+      calendarEventRepository.updateChildColorByUserIdAndChildName(
+          user.getId(), syncTargetName, newColorCode);
+      log.debug(
+          "[Child] child_color 동기화 완료. userId={}, childName={}, newColor={}",
+          user.getId(),
+          syncTargetName,
           newColorCode);
-
-      // 이름이 변경된 경우 → newsletter, calendar_events child_name 일괄 동기화
-      if (newName != null && !newName.equals(oldName)) {
-          newsletterRepository.updateChildNameByUserIdAndOldName(user.getId(), oldName, newName);
-          calendarEventRepository.updateChildNameByUserIdAndOldName(user.getId(), oldName, newName);
-          log.debug(
-              "[Child] child_name 동기화 완료. userId={}, oldName={}, newName={}",
-              user.getId(), oldName, newName);
-      }
-
-      // 색상이 변경된 경우 → newsletter, calendar_events child_color 일괄 동기화
-      if (newColorCode != null && !newColorCode.equals(child.getColorCode())) {
-          String syncTargetName = (newName != null) ? newName : oldName;
-          newsletterRepository.updateChildColorByUserIdAndChildName(
-              user.getId(), syncTargetName, newColorCode);
-          calendarEventRepository.updateChildColorByUserIdAndChildName(
-              user.getId(), syncTargetName, newColorCode);
-          log.debug(
-              "[Child] child_color 동기화 완료. userId={}, childName={}, newColor={}",
-              user.getId(), syncTargetName, newColorCode);
-      }
+    }
   }
 
-  //자녀 삭제 - 연관된 모든 데이터 삭제
+  // 자녀 삭제 - 연관된 모든 데이터 삭제
   @Transactional
   public void deleteChild(String authorizationHeader, Long childId) {
-      User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
+    User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
 
-      // 소유권 검증
-      Child child =
-          childRepository
-              .findByIdAndUserIdAndDeletedAtIsNull(childId, user.getId())
-              .orElseThrow(() -> new BusinessException(ErrorCode.CHILD_NOT_FOUND));
+    // 소유권 검증
+    Child child =
+        childRepository
+            .findByIdAndUserIdAndDeletedAtIsNull(childId, user.getId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.CHILD_NOT_FOUND));
 
-      String childName = child.getName();
-      Long userId = user.getId();
+    String childName = child.getName();
+    Long userId = user.getId();
 
-      // 해당 자녀의 newsletter 목록 조회 → S3 fileKey 수집
-      List<Newsletter> newsletters =
-          newsletterRepository.findAllByUserIdAndChildName(userId, childName);
-      List<String> fileKeys = newsletters.stream().map(Newsletter::getFileKey).toList();
+    // 해당 자녀의 newsletter 목록 조회 → S3 fileKey 수집
+    List<Newsletter> newsletters =
+        newsletterRepository.findAllByUserIdAndChildName(userId, childName);
+    List<String> fileKeys = newsletters.stream().map(Newsletter::getFileKey).toList();
 
-      calendarEventRepository.deleteAllByUserIdAndChildName(userId, childName);
-      log.debug(
-          "[Child] calendar_events 삭제 완료. userId={}, childName={}", userId, childName);
+    calendarEventRepository.deleteAllByUserIdAndChildName(userId, childName);
+    log.debug("[Child] calendar_events 삭제 완료. userId={}, childName={}", userId, childName);
 
-      newsletterRepository.deleteAllByUserIdAndChildName(userId, childName);
-      log.debug(
-          "[Child] newsletter 삭제 완료. userId={}, childName={}, count={}",
-          userId, childName, newsletters.size());
+    newsletterRepository.deleteAllByUserIdAndChildName(userId, childName);
+    log.debug(
+        "[Child] newsletter 삭제 완료. userId={}, childName={}, count={}",
+        userId,
+        childName,
+        newsletters.size());
 
-      // S3 파일 삭제 (DB 삭제 성공 후 실행)
-      for (String fileKey : fileKeys) {
-          try {
-              s3FileService.deleteFile(fileKey);
-          } catch (Exception e) {
-              // S3 삭제 실패는 로그만 남기고 계속 진행 (DB 삭제가 이미 완료됐으므로 롤백 불가)
-              log.error("[Child] S3 파일 삭제 실패. fileKey={}, error={}", fileKey, e.getMessage());
-          }
+    // S3 파일 삭제 (DB 삭제 성공 후 실행)
+    for (String fileKey : fileKeys) {
+      try {
+        s3FileService.deleteFile(fileKey);
+      } catch (Exception e) {
+        // S3 삭제 실패는 로그만 남기고 계속 진행 (DB 삭제가 이미 완료됐으므로 롤백 불가)
+        log.error("[Child] S3 파일 삭제 실패. fileKey={}, error={}", fileKey, e.getMessage());
       }
+    }
 
-      // 자녀 soft delete
-      child.softDelete();
-      log.info("[Child] 자녀 삭제 완료. userId={}, childId={}, childName={}", userId, childId, childName);
+    // 자녀 soft delete
+    child.softDelete();
+    log.info("[Child] 자녀 삭제 완료. userId={}, childId={}, childName={}", userId, childId, childName);
   }
 
   private String normalizeRequiredText(String value) {

--- a/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
@@ -35,10 +35,29 @@ public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
       @Param("childName") String childName,
       @Param("newColor") String newColor);
 
+  // 자녀 이름 변경 시 newsletter.child_name 일괄 동기화
+  @Modifying
+  @Query(
+      """
+       UPDATE Newsletter n
+       SET n.childName = :newName
+       WHERE n.userId = :userId AND n.childName = :oldName
+       """)
+  void updateChildNameByUserIdAndOldName(
+      @Param("userId") Long userId,
+      @Param("oldName") String oldName,
+      @Param("newName") String newName);
+
+  // 자녀 삭제 시 해당 자녀의 모든 newsletter 조회 (S3 fileKey 수집용)
+  List<Newsletter> findAllByUserIdAndChildName(Long userId, String childName);
+
+  // 자녀 삭제 시 해당 자녀의 모든 newsletter 삭제
+  void deleteAllByUserIdAndChildName(Long userId, String childName);
+
   /**
    * FAILED 상태인 가정통신문만 PENDING으로 원자적으로 전환합니다.
    *
-   * <p>동시 재시도 요청이 들어와도 첫 요청만 update count 1을 받고, 나머지는 0을 받아 중복 파이프라인 실행을 막습니다.
+   * 동시 재시도 요청이 들어와도 첫 요청만 update count 1을 받고, 나머지는 0을 받아 중복 파이프라인 실행을 막습니다.
    */
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(

--- a/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
@@ -57,7 +57,7 @@ public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
   /**
    * FAILED 상태인 가정통신문만 PENDING으로 원자적으로 전환합니다.
    *
-   * 동시 재시도 요청이 들어와도 첫 요청만 update count 1을 받고, 나머지는 0을 받아 중복 파이프라인 실행을 막습니다.
+   * <p>동시 재시도 요청이 들어와도 첫 요청만 update count 1을 받고, 나머지는 0을 받아 중복 파이프라인 실행을 막습니다.
    */
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(

--- a/src/main/java/com/gachi/be/global/code/SuccessCode.java
+++ b/src/main/java/com/gachi/be/global/code/SuccessCode.java
@@ -19,6 +19,8 @@ public enum SuccessCode {
   AUTH_CHECK_PHONE_NUMBER_AVAILABLE(HttpStatus.OK, "AUTH2007", "사용 가능한 전화번호입니다."),
   CHILD_CREATE_SUCCESS(HttpStatus.CREATED, "CHILD2011", "자녀 정보 등록에 성공하였습니다."),
   CHILD_GET_LIST_SUCCESS(HttpStatus.OK, "CHILD2001", "내 자녀 목록 조회에 성공하였습니다."),
+  CHILD_UPDATE_SUCCESS(HttpStatus.OK, "CHILD2002", "자녀 정보 수정에 성공하였습니다."),
+  CHILD_DELETE_SUCCESS(HttpStatus.OK, "CHILD2003", "자녀 삭제에 성공하였습니다."),
   SCHOOL_SEARCH_SUCCESS(HttpStatus.OK, "SCH2001", "학교 검색 결과 조회에 성공하였습니다."),
   NEWSLETTER_UPLOAD_SUCCESS(HttpStatus.CREATED, "NL2011", "업로드가 시작되었습니다."),
   NEWSLETTER_RETRY_ACCEPTED(HttpStatus.ACCEPTED, "NL2021", "가정통신문 분석 재시도가 시작되었습니다."),


### PR DESCRIPTION
## 📌 작업 요약

- 요약: 
  - 자녀 정보를 수정하고 삭제하는 기능을 구현합니다.
  - 기존에 자녀 이름을 스냅샷으로 저장했던 기능을 변경하여 자녀의 이름이 수정되면 수정된 자녀의 이름으로 모든 정보들을 동기화시킵니다. 
- 관련 이슈: closes #102 

## 🌿 브랜치 정보

- **Source**: `feat/#102-children-info-change`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

<img width="881" height="235" alt="스크린샷 2026-06-04 193458" src="https://github.com/user-attachments/assets/4adeadd2-d59f-4ed7-a07e-7bf684b95315" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 자녀 정보 수정 기능 추가: 자녀의 이름, 학교, 학년, 색상 등을 언제든 수정할 수 있습니다.
  * 자녀 삭제 기능 추가: 더 이상 필요 없는 자녀 정보를 삭제할 수 있습니다.
  * 자동 동기화: 자녀 정보 변경 시 관련된 일정과 뉴스레터의 정보가 자동으로 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->