### PR TITLE
fix: 삭제된 자녀가 목록 조회에 노출되는 문제 수정

### DIFF
--- a/src/main/java/com/gachi/be/domain/child/repository/ChildRepository.java
+++ b/src/main/java/com/gachi/be/domain/child/repository/ChildRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ChildRepository extends JpaRepository<Child, Long> {
   List<Child> findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long userId);
 
-  long countByUserId(Long userId);
+  long countByUserIdAndDeletedAtIsNull(Long userId);
 
   List<Child> findByUserIdAndDeletedAtIsNull(Long userId);
 

--- a/src/main/java/com/gachi/be/domain/child/repository/ChildRepository.java
+++ b/src/main/java/com/gachi/be/domain/child/repository/ChildRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChildRepository extends JpaRepository<Child, Long> {
-    List<Child> findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long userId);
+  List<Child> findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long userId);
 
   long countByUserId(Long userId);
 

--- a/src/main/java/com/gachi/be/domain/child/repository/ChildRepository.java
+++ b/src/main/java/com/gachi/be/domain/child/repository/ChildRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChildRepository extends JpaRepository<Child, Long> {
-  List<Child> findAllByUserIdOrderByCreatedAtAsc(Long userId);
+    List<Child> findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtAsc(Long userId);
 
   long countByUserId(Long userId);
 

--- a/src/main/java/com/gachi/be/domain/child/service/ChildService.java
+++ b/src/main/java/com/gachi/be/domain/child/service/ChildService.java
@@ -61,10 +61,12 @@ public class ChildService {
 
   @Transactional(readOnly = true)
   public List<ChildResponse> getChildren(String authorizationHeader) {
-      User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
-      return childRepository.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtAsc(user.getId()).stream()
-          .map(this::toResponse)
-          .toList();
+    User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
+    return childRepository
+        .findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtAsc(user.getId())
+        .stream()
+        .map(this::toResponse)
+        .toList();
   }
 
   private ChildResponse toResponse(Child child) {

--- a/src/main/java/com/gachi/be/domain/child/service/ChildService.java
+++ b/src/main/java/com/gachi/be/domain/child/service/ChildService.java
@@ -61,10 +61,10 @@ public class ChildService {
 
   @Transactional(readOnly = true)
   public List<ChildResponse> getChildren(String authorizationHeader) {
-    User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
-    return childRepository.findAllByUserIdOrderByCreatedAtAsc(user.getId()).stream()
-        .map(this::toResponse)
-        .toList();
+      User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
+      return childRepository.findAllByUserIdAndDeletedAtIsNullOrderByCreatedAtAsc(user.getId()).stream()
+          .map(this::toResponse)
+          .toList();
   }
 
   private ChildResponse toResponse(Child child) {

--- a/src/main/java/com/gachi/be/domain/child/service/ChildService.java
+++ b/src/main/java/com/gachi/be/domain/child/service/ChildService.java
@@ -38,7 +38,7 @@ public class ChildService {
   @Transactional
   public ChildResponse createChild(String authorizationHeader, ChildCreateRequest request) {
     User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
-    long childrenCount = childRepository.countByUserId(user.getId());
+    long childrenCount = childRepository.countByUserIdAndDeletedAtIsNull(user.getId());
     if (childrenCount >= DEFAULT_MAX_CHILDREN_PER_USER) {
       // 정책은 무제한처럼 보이더라도 서버 보호를 위해 내부 가드레일을 둔다.
       throw new BusinessException(ErrorCode.BUSINESS_RULE_VIOLATION);


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - soft delete된 자녀가 목록 조회에 포함되던 문제 수정
  - 사용자별 자녀 목록 조회 조건에 활성 상태 필터 추가
  - 삭제된 자녀는 조회 결과에서 제외하고 활성 자녀만 반환
- 관련 이슈: closes #112 

## 🌿 브랜치 정보

- **Source**: `fix-#112-child-delete`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

- 자녀 삭제 후 목록 조회 시 삭제된 자녀가 응답에서 제외되는 것을 확인
<img width="1421" height="544" alt="image" src="https://github.com/user-attachments/assets/61342cd7-d74c-4b92-8bdd-10c31f1f2b0d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 자녀 정보 조회 시 삭제 처리된 항목이 결과에서 제외되도록 조건이 추가되었습니다. 사용자별 자녀 목록 조회 쿼리가 업데이트되어 활성 상태인 자녀 정보만 반환하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->