### PR TITLE
feat: 아이디 찾기 API 구현

### DIFF
--- a/docs/auth-rate-limit.md
+++ b/docs/auth-rate-limit.md
@@ -7,6 +7,7 @@
 ## 대상 엔드포인트
 
 - `POST /api/v1/auth/email/send`
+- `POST /api/v1/auth/find-login-id/email/send`
 - `POST /api/v1/auth/login`
 
 ## 클라이언트 IP 추출 규칙
@@ -20,7 +21,8 @@
 
 ## 식별자 정책
 
-- 이메일 발송 제한(`email/send`): `clientIp + HMAC_SHA256(normalizedEmail)`
+- 회원가입 이메일 발송 제한(`email/send`): `clientIp + HMAC_SHA256(normalizedEmail)`
+- 아이디 찾기 이메일 발송 제한(`find-login-id/email/send`): `clientIp + HMAC_SHA256(normalizedEmail)`
 - 로그인 제한(`login`): `clientIp`
 - `normalizedEmail`: `trim + lowercase(Locale.ROOT)`
 
@@ -30,6 +32,8 @@
 
 - 이메일 발송:
   - 패턴: `{prefix}email-send:{clientIp}:{emailHash}`
+- 아이디 찾기 이메일 발송:
+  - 패턴: `{prefix}find-login-id-email-send:{clientIp}:{emailHash}`
 - 로그인:
   - 패턴: `{prefix}login:{clientIp}`
 

--- a/src/main/java/com/gachi/be/domain/auth/api/controller/AuthController.java
+++ b/src/main/java/com/gachi/be/domain/auth/api/controller/AuthController.java
@@ -111,7 +111,8 @@ public class AuthController {
   @PostMapping("/find-login-id/email/send")
   public ApiResponse<EmailSendResponse> sendFindLoginIdEmailVerificationCode(
       @Valid @RequestBody FindLoginIdEmailSendRequest request, HttpServletRequest servletRequest) {
-    authRateLimitService.checkEmailSendRateLimit(extractClientIp(servletRequest), request.email());
+    authRateLimitService.checkFindLoginIdEmailSendRateLimit(
+        extractClientIp(servletRequest), request.email());
     return ApiResponse.success(
         SuccessCode.AUTH_FIND_LOGIN_ID_EMAIL_CODE_SENT,
         authService.sendFindLoginIdEmailVerificationCode(request));

--- a/src/main/java/com/gachi/be/domain/auth/api/controller/AuthController.java
+++ b/src/main/java/com/gachi/be/domain/auth/api/controller/AuthController.java
@@ -6,12 +6,15 @@ import com.gachi.be.domain.auth.dto.request.CheckLoginIdRequest;
 import com.gachi.be.domain.auth.dto.request.CheckPhoneNumberRequest;
 import com.gachi.be.domain.auth.dto.request.EmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.EmailVerifyRequest;
+import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailSendRequest;
+import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.LoginRequest;
 import com.gachi.be.domain.auth.dto.request.ReissueRequest;
 import com.gachi.be.domain.auth.dto.request.SignupRequest;
 import com.gachi.be.domain.auth.dto.response.AuthTokenResponse;
 import com.gachi.be.domain.auth.dto.response.DuplicateCheckResponse;
 import com.gachi.be.domain.auth.dto.response.EmailSendResponse;
+import com.gachi.be.domain.auth.dto.response.FindLoginIdResponse;
 import com.gachi.be.domain.auth.dto.response.SignupResponse;
 import com.gachi.be.domain.auth.service.AuthRateLimitService;
 import com.gachi.be.domain.auth.service.AuthService;
@@ -103,6 +106,22 @@ public class AuthController {
   public ApiResponse<Void> verifyEmailCode(@Valid @RequestBody EmailVerifyRequest request) {
     authService.verifyEmailCode(request);
     return ApiResponse.success(SuccessCode.AUTH_EMAIL_VERIFIED, null);
+  }
+
+  @PostMapping("/find-login-id/email/send")
+  public ApiResponse<EmailSendResponse> sendFindLoginIdEmailVerificationCode(
+      @Valid @RequestBody FindLoginIdEmailSendRequest request, HttpServletRequest servletRequest) {
+    authRateLimitService.checkEmailSendRateLimit(extractClientIp(servletRequest), request.email());
+    return ApiResponse.success(
+        SuccessCode.AUTH_FIND_LOGIN_ID_EMAIL_CODE_SENT,
+        authService.sendFindLoginIdEmailVerificationCode(request));
+  }
+
+  @PostMapping("/find-login-id/email/verify")
+  public ApiResponse<FindLoginIdResponse> verifyFindLoginIdEmailCode(
+      @Valid @RequestBody FindLoginIdEmailVerifyRequest request) {
+    return ApiResponse.success(
+        SuccessCode.AUTH_FIND_LOGIN_ID_SUCCESS, authService.verifyFindLoginIdEmailCode(request));
   }
 
   private String extractDeviceInfo(HttpServletRequest request) {

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/FindLoginIdEmailSendRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/FindLoginIdEmailSendRequest.java
@@ -1,0 +1,6 @@
+package com.gachi.be.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record FindLoginIdEmailSendRequest(@NotBlank @Email String email) {}

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/FindLoginIdEmailVerifyRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/FindLoginIdEmailVerifyRequest.java
@@ -1,0 +1,9 @@
+package com.gachi.be.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record FindLoginIdEmailVerifyRequest(
+    @NotBlank @Email String email,
+    @NotBlank @Pattern(regexp = "^[0-9]{6}$", message = "인증 코드는 6자리 숫자여야 합니다.") String code) {}

--- a/src/main/java/com/gachi/be/domain/auth/dto/response/FindLoginIdResponse.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/response/FindLoginIdResponse.java
@@ -1,0 +1,3 @@
+package com.gachi.be.domain.auth.dto.response;
+
+public record FindLoginIdResponse(String loginId) {}

--- a/src/main/java/com/gachi/be/domain/auth/service/AuthRateLimitService.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/AuthRateLimitService.java
@@ -27,6 +27,7 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class AuthRateLimitService {
   private static final String EMAIL_SEND_SCOPE = "email-send";
+  private static final String FIND_LOGIN_ID_EMAIL_SEND_SCOPE = "find-login-id-email-send";
   private static final String LOGIN_SCOPE = "login";
   private static final RedisScript<List<Long>> FIXED_WINDOW_RATE_LIMIT_SCRIPT =
       createFixedWindowRateLimitScript();
@@ -43,9 +44,25 @@ public class AuthRateLimitService {
     if (!isRateLimitEnabled()) {
       return;
     }
+    checkEmailSendRateLimit(clientIp, email, EMAIL_SEND_SCOPE);
+  }
+
+  /**
+   * 아이디 찾기 인증코드 발송 엔드포인트 호출 한도를 점검한다.
+   *
+   * <p>회원가입 이메일 인증과 UX가 서로 막히지 않도록 별도 scope를 사용한다.
+   */
+  public void checkFindLoginIdEmailSendRateLimit(String clientIp, String email) {
+    if (!isRateLimitEnabled()) {
+      return;
+    }
+    checkEmailSendRateLimit(clientIp, email, FIND_LOGIN_ID_EMAIL_SEND_SCOPE);
+  }
+
+  private void checkEmailSendRateLimit(String clientIp, String email, String scope) {
     String normalizedEmail = normalizeEmail(email);
     String hashedEmail = hmacSha256Hex(normalizedEmail);
-    String key = buildKey(EMAIL_SEND_SCOPE, normalizeIp(clientIp) + ":" + hashedEmail);
+    String key = buildKey(scope, normalizeIp(clientIp) + ":" + hashedEmail);
     enforceOrThrow(
         key, authProperties.getRateLimit().getEmailSend(), ErrorCode.AUTH_EMAIL_SEND_RATE_LIMITED);
   }

--- a/src/main/java/com/gachi/be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/AuthService.java
@@ -5,12 +5,15 @@ import com.gachi.be.domain.auth.dto.request.CheckLoginIdRequest;
 import com.gachi.be.domain.auth.dto.request.CheckPhoneNumberRequest;
 import com.gachi.be.domain.auth.dto.request.EmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.EmailVerifyRequest;
+import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailSendRequest;
+import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.LoginRequest;
 import com.gachi.be.domain.auth.dto.request.ReissueRequest;
 import com.gachi.be.domain.auth.dto.request.SignupRequest;
 import com.gachi.be.domain.auth.dto.response.AuthTokenResponse;
 import com.gachi.be.domain.auth.dto.response.DuplicateCheckResponse;
 import com.gachi.be.domain.auth.dto.response.EmailSendResponse;
+import com.gachi.be.domain.auth.dto.response.FindLoginIdResponse;
 import com.gachi.be.domain.auth.dto.response.SignupResponse;
 
 /** 인증 유스케이스 진입점. */
@@ -30,4 +33,8 @@ public interface AuthService {
   EmailSendResponse sendEmailVerificationCode(EmailSendRequest request);
 
   void verifyEmailCode(EmailVerifyRequest request);
+
+  EmailSendResponse sendFindLoginIdEmailVerificationCode(FindLoginIdEmailSendRequest request);
+
+  FindLoginIdResponse verifyFindLoginIdEmailCode(FindLoginIdEmailVerifyRequest request);
 }

--- a/src/main/java/com/gachi/be/domain/auth/service/EmailVerificationPurpose.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/EmailVerificationPurpose.java
@@ -1,0 +1,17 @@
+package com.gachi.be.domain.auth.service;
+
+/** 이메일 인증 코드가 어떤 사용자 흐름에서 쓰이는지 구분한다. */
+public enum EmailVerificationPurpose {
+  SIGNUP("signup"),
+  FIND_LOGIN_ID("find-login-id");
+
+  private final String keySegment;
+
+  EmailVerificationPurpose(String keySegment) {
+    this.keySegment = keySegment;
+  }
+
+  public String keySegment() {
+    return keySegment;
+  }
+}

--- a/src/main/java/com/gachi/be/domain/auth/service/EmailVerificationStore.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/EmailVerificationStore.java
@@ -4,13 +4,28 @@ package com.gachi.be.domain.auth.service;
 public interface EmailVerificationStore {
 
   /** 인증 코드를 발급한다. */
-  String issueCode(String email);
+  default String issueCode(String email) {
+    return issueCode(email, EmailVerificationPurpose.SIGNUP);
+  }
+
+  /** 인증 목적별로 분리된 인증 코드를 발급한다. */
+  String issueCode(String email, EmailVerificationPurpose purpose);
 
   /** 메일 발송 실패 시 발급된 인증 정보를 되돌린다. */
-  void rollbackIssuedCode(String email);
+  default void rollbackIssuedCode(String email) {
+    rollbackIssuedCode(email, EmailVerificationPurpose.SIGNUP);
+  }
+
+  /** 메일 발송 실패 시 인증 목적별로 발급된 인증 정보를 되돌린다. */
+  void rollbackIssuedCode(String email, EmailVerificationPurpose purpose);
 
   /** 입력된 인증 코드를 검증한다. */
-  void verifyCode(String email, String code);
+  default void verifyCode(String email, String code) {
+    verifyCode(email, code, EmailVerificationPurpose.SIGNUP);
+  }
+
+  /** 인증 목적별로 분리된 인증 코드를 검증한다. */
+  void verifyCode(String email, String code, EmailVerificationPurpose purpose);
 
   /** 이메일 인증 완료 여부를 조회한다. */
   boolean isEmailVerified(String email);

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -239,7 +239,9 @@ public class AuthServiceImpl implements AuthService {
   @Transactional
   public void verifyEmailCode(EmailVerifyRequest request) {
     emailVerificationStore.verifyCode(
-        normalizeEmail(request.email()), normalizeText(request.code()));
+        normalizeEmail(request.email()),
+        normalizeText(request.code()),
+        EmailVerificationPurpose.SIGNUP);
   }
 
   @Override

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -6,17 +6,21 @@ import com.gachi.be.domain.auth.dto.request.CheckLoginIdRequest;
 import com.gachi.be.domain.auth.dto.request.CheckPhoneNumberRequest;
 import com.gachi.be.domain.auth.dto.request.EmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.EmailVerifyRequest;
+import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailSendRequest;
+import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.LoginRequest;
 import com.gachi.be.domain.auth.dto.request.ReissueRequest;
 import com.gachi.be.domain.auth.dto.request.SignupRequest;
 import com.gachi.be.domain.auth.dto.response.AuthTokenResponse;
 import com.gachi.be.domain.auth.dto.response.DuplicateCheckResponse;
 import com.gachi.be.domain.auth.dto.response.EmailSendResponse;
+import com.gachi.be.domain.auth.dto.response.FindLoginIdResponse;
 import com.gachi.be.domain.auth.dto.response.SignupResponse;
 import com.gachi.be.domain.auth.entity.AuthRefreshToken;
 import com.gachi.be.domain.auth.repository.AuthRefreshTokenRepository;
 import com.gachi.be.domain.auth.service.AuthMailService;
 import com.gachi.be.domain.auth.service.AuthService;
+import com.gachi.be.domain.auth.service.EmailVerificationPurpose;
 import com.gachi.be.domain.auth.service.EmailVerificationStore;
 import com.gachi.be.domain.auth.service.JwtTokenProvider;
 import com.gachi.be.domain.auth.service.TokenHashService;
@@ -228,14 +232,47 @@ public class AuthServiceImpl implements AuthService {
       throw new BusinessException(ErrorCode.AUTH_DUPLICATE_EMAIL);
     }
 
-    String code = emailVerificationStore.issueCode(email);
+    return issueAndSendEmailCode(email, EmailVerificationPurpose.SIGNUP);
+  }
+
+  @Override
+  @Transactional
+  public void verifyEmailCode(EmailVerifyRequest request) {
+    emailVerificationStore.verifyCode(
+        normalizeEmail(request.email()), normalizeText(request.code()));
+  }
+
+  @Override
+  @Transactional
+  public EmailSendResponse sendFindLoginIdEmailVerificationCode(
+      FindLoginIdEmailSendRequest request) {
+    String email = normalizeEmail(request.email());
+    User user = findUserByEmailOrThrow(email);
+    ensureActiveAccount(user);
+    return issueAndSendEmailCode(email, EmailVerificationPurpose.FIND_LOGIN_ID);
+  }
+
+  @Override
+  @Transactional
+  public FindLoginIdResponse verifyFindLoginIdEmailCode(FindLoginIdEmailVerifyRequest request) {
+    String email = normalizeEmail(request.email());
+    User user = findUserByEmailOrThrow(email);
+    ensureActiveAccount(user);
+
+    emailVerificationStore.verifyCode(
+        email, normalizeText(request.code()), EmailVerificationPurpose.FIND_LOGIN_ID);
+    return new FindLoginIdResponse(user.getLoginId());
+  }
+
+  private EmailSendResponse issueAndSendEmailCode(String email, EmailVerificationPurpose purpose) {
+    String code = emailVerificationStore.issueCode(email, purpose);
     try {
       authMailService.sendVerificationCode(email, code);
     } catch (AppException e) {
-      rollbackIssuedCodeSafely(email);
+      rollbackIssuedCodeSafely(email, purpose);
       throw e;
     } catch (Exception e) {
-      rollbackIssuedCodeSafely(email);
+      rollbackIssuedCodeSafely(email, purpose);
       throw new ExternalApiException(
           ErrorCode.EXTERNAL_API_ERROR, "Failed to send verification code.");
     }
@@ -246,11 +283,16 @@ public class AuthServiceImpl implements AuthService {
         shouldExposeVerificationCodeForLocalTest() ? code : null);
   }
 
-  @Override
-  @Transactional
-  public void verifyEmailCode(EmailVerifyRequest request) {
-    emailVerificationStore.verifyCode(
-        normalizeEmail(request.email()), normalizeText(request.code()));
+  private User findUserByEmailOrThrow(String email) {
+    return userRepository
+        .findByEmail(email)
+        .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_EMAIL_NOT_REGISTERED));
+  }
+
+  private void ensureActiveAccount(User user) {
+    if (!user.isActive()) {
+      throw new BusinessException(ErrorCode.AUTH_ACCOUNT_WITHDRAWN);
+    }
   }
 
   /** 로그인/재발급 공통 토큰 발급 + refresh token 세션 저장 로직. */
@@ -484,9 +526,9 @@ public class AuthServiceImpl implements AuthService {
     }
   }
 
-  private void rollbackIssuedCodeSafely(String email) {
+  private void rollbackIssuedCodeSafely(String email, EmailVerificationPurpose purpose) {
     try {
-      emailVerificationStore.rollbackIssuedCode(email);
+      emailVerificationStore.rollbackIssuedCode(email, purpose);
     } catch (Exception rollbackException) {
       log.warn("Failed to rollback issued email verification code.", rollbackException);
     }

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/InMemoryEmailVerificationStore.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/InMemoryEmailVerificationStore.java
@@ -1,6 +1,7 @@
 package com.gachi.be.domain.auth.service.impl;
 
 import com.gachi.be.domain.auth.config.AuthProperties;
+import com.gachi.be.domain.auth.service.EmailVerificationPurpose;
 import com.gachi.be.domain.auth.service.EmailVerificationStore;
 import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.exception.BusinessException;
@@ -21,19 +22,23 @@ public class InMemoryEmailVerificationStore implements EmailVerificationStore {
   private static final int LOCK_STRIPE_COUNT = 256;
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-  private final Map<String, ExpiringValue<String>> codeStore = new ConcurrentHashMap<>();
-  private final Map<String, ExpiringValue<Integer>> attemptStore = new ConcurrentHashMap<>();
-  private final Map<String, ExpiringValue<Boolean>> cooldownStore = new ConcurrentHashMap<>();
-  private final Map<String, ExpiringValue<Boolean>> verifiedStore = new ConcurrentHashMap<>();
+  private final Map<VerificationKey, ExpiringValue<String>> codeStore = new ConcurrentHashMap<>();
+  private final Map<VerificationKey, ExpiringValue<Integer>> attemptStore =
+      new ConcurrentHashMap<>();
+  private final Map<VerificationKey, ExpiringValue<Boolean>> cooldownStore =
+      new ConcurrentHashMap<>();
+  private final Map<VerificationKey, ExpiringValue<Boolean>> verifiedStore =
+      new ConcurrentHashMap<>();
   private final Object[] emailLocks = initializeLocks();
   private final AuthProperties authProperties;
 
   @Override
-  public String issueCode(String email) {
+  public String issueCode(String email, EmailVerificationPurpose purpose) {
     String normalizedEmail = normalizeEmail(email);
+    VerificationKey key = new VerificationKey(normalizedEmail, purpose);
     // 메모리 스토어도 동시 요청에서 정책 우회를 막기 위해 이메일 단위로 직렬화한다.
     synchronized (lockFor(normalizedEmail)) {
-      if (isValid(cooldownStore.get(normalizedEmail))) {
+      if (isValid(cooldownStore.get(key))) {
         throw new BusinessException(ErrorCode.AUTH_EMAIL_SEND_COOLDOWN);
       }
 
@@ -43,34 +48,36 @@ public class InMemoryEmailVerificationStore implements EmailVerificationStore {
       OffsetDateTime cooldownExpiresAt =
           OffsetDateTime.now().plusSeconds(authProperties.getEmail().getResendCooldownSeconds());
 
-      codeStore.put(normalizedEmail, new ExpiringValue<>(code, codeExpiresAt));
-      attemptStore.put(normalizedEmail, new ExpiringValue<>(0, codeExpiresAt));
-      cooldownStore.put(normalizedEmail, new ExpiringValue<>(Boolean.TRUE, cooldownExpiresAt));
+      codeStore.put(key, new ExpiringValue<>(code, codeExpiresAt));
+      attemptStore.put(key, new ExpiringValue<>(0, codeExpiresAt));
+      cooldownStore.put(key, new ExpiringValue<>(Boolean.TRUE, cooldownExpiresAt));
       return code;
     }
   }
 
   @Override
-  public void rollbackIssuedCode(String email) {
+  public void rollbackIssuedCode(String email, EmailVerificationPurpose purpose) {
     String normalizedEmail = normalizeEmail(email);
+    VerificationKey key = new VerificationKey(normalizedEmail, purpose);
     synchronized (lockFor(normalizedEmail)) {
-      codeStore.remove(normalizedEmail);
-      attemptStore.remove(normalizedEmail);
-      cooldownStore.remove(normalizedEmail);
+      codeStore.remove(key);
+      attemptStore.remove(key);
+      cooldownStore.remove(key);
     }
   }
 
   @Override
-  public void verifyCode(String email, String code) {
+  public void verifyCode(String email, String code, EmailVerificationPurpose purpose) {
     String normalizedEmail = normalizeEmail(email);
+    VerificationKey key = new VerificationKey(normalizedEmail, purpose);
     synchronized (lockFor(normalizedEmail)) {
-      ExpiringValue<String> storedCode = codeStore.get(normalizedEmail);
+      ExpiringValue<String> storedCode = codeStore.get(key);
       if (!isValid(storedCode)) {
-        cleanupExpired(normalizedEmail);
+        cleanupExpired(key);
         throw new BusinessException(ErrorCode.AUTH_EMAIL_CODE_EXPIRED);
       }
 
-      ExpiringValue<Integer> attemptsValue = attemptStore.get(normalizedEmail);
+      ExpiringValue<Integer> attemptsValue = attemptStore.get(key);
       int attempts = isValid(attemptsValue) ? attemptsValue.value : 0;
       if (attempts >= authProperties.getEmail().getMaxAttempts()) {
         throw new BusinessException(ErrorCode.AUTH_EMAIL_CODE_ATTEMPT_EXCEEDED);
@@ -78,7 +85,7 @@ public class InMemoryEmailVerificationStore implements EmailVerificationStore {
 
       if (!storedCode.value.equals(code)) {
         int nextAttempts = attempts + 1;
-        attemptStore.put(normalizedEmail, new ExpiringValue<>(nextAttempts, storedCode.expiresAt));
+        attemptStore.put(key, new ExpiringValue<>(nextAttempts, storedCode.expiresAt));
         if (nextAttempts >= authProperties.getEmail().getMaxAttempts()) {
           throw new BusinessException(ErrorCode.AUTH_EMAIL_CODE_ATTEMPT_EXCEEDED);
         }
@@ -87,19 +94,20 @@ public class InMemoryEmailVerificationStore implements EmailVerificationStore {
 
       OffsetDateTime verifiedExpiresAt =
           OffsetDateTime.now().plusSeconds(authProperties.getEmail().getVerifiedTtlSeconds());
-      verifiedStore.put(normalizedEmail, new ExpiringValue<>(Boolean.TRUE, verifiedExpiresAt));
-      codeStore.remove(normalizedEmail);
-      attemptStore.remove(normalizedEmail);
+      verifiedStore.put(key, new ExpiringValue<>(Boolean.TRUE, verifiedExpiresAt));
+      codeStore.remove(key);
+      attemptStore.remove(key);
     }
   }
 
   @Override
   public boolean isEmailVerified(String email) {
     String normalizedEmail = normalizeEmail(email);
+    VerificationKey key = new VerificationKey(normalizedEmail, EmailVerificationPurpose.SIGNUP);
     synchronized (lockFor(normalizedEmail)) {
-      ExpiringValue<Boolean> verified = verifiedStore.get(normalizedEmail);
+      ExpiringValue<Boolean> verified = verifiedStore.get(key);
       if (!isValid(verified)) {
-        verifiedStore.remove(normalizedEmail);
+        verifiedStore.remove(key);
         return false;
       }
       return Boolean.TRUE.equals(verified.value);
@@ -109,14 +117,15 @@ public class InMemoryEmailVerificationStore implements EmailVerificationStore {
   @Override
   public void consumeVerifiedEmail(String email) {
     String normalizedEmail = normalizeEmail(email);
+    VerificationKey key = new VerificationKey(normalizedEmail, EmailVerificationPurpose.SIGNUP);
     synchronized (lockFor(normalizedEmail)) {
-      verifiedStore.remove(normalizedEmail);
+      verifiedStore.remove(key);
     }
   }
 
-  private void cleanupExpired(String email) {
-    codeStore.remove(email);
-    attemptStore.remove(email);
+  private void cleanupExpired(VerificationKey key) {
+    codeStore.remove(key);
+    attemptStore.remove(key);
   }
 
   private boolean isValid(ExpiringValue<?> value) {
@@ -154,4 +163,6 @@ public class InMemoryEmailVerificationStore implements EmailVerificationStore {
       this.expiresAt = expiresAt;
     }
   }
+
+  private record VerificationKey(String email, EmailVerificationPurpose purpose) {}
 }

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/RedisEmailVerificationStore.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/RedisEmailVerificationStore.java
@@ -1,6 +1,7 @@
 package com.gachi.be.domain.auth.service.impl;
 
 import com.gachi.be.domain.auth.config.AuthProperties;
+import com.gachi.be.domain.auth.service.EmailVerificationPurpose;
 import com.gachi.be.domain.auth.service.EmailVerificationStore;
 import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.exception.BusinessException;
@@ -63,9 +64,9 @@ public class RedisEmailVerificationStore implements EmailVerificationStore {
   private final AuthProperties authProperties;
 
   @Override
-  public String issueCode(String email) {
+  public String issueCode(String email, EmailVerificationPurpose purpose) {
     String normalizedEmail = normalizeEmail(email);
-    String cooldownKey = cooldownKey(normalizedEmail);
+    String cooldownKey = cooldownKey(normalizedEmail, purpose);
     Duration cooldownTtl = Duration.ofSeconds(authProperties.getEmail().getResendCooldownSeconds());
     Boolean acquired = redisTemplate.opsForValue().setIfAbsent(cooldownKey, "1", cooldownTtl);
     if (!Boolean.TRUE.equals(acquired)) {
@@ -75,30 +76,30 @@ public class RedisEmailVerificationStore implements EmailVerificationStore {
     String code = generateCode();
     Duration codeTtl = Duration.ofSeconds(authProperties.getEmail().getCodeTtlSeconds());
 
-    redisTemplate.opsForValue().set(codeKey(normalizedEmail), code, codeTtl);
-    redisTemplate.opsForValue().set(attemptKey(normalizedEmail), "0", codeTtl);
+    redisTemplate.opsForValue().set(codeKey(normalizedEmail, purpose), code, codeTtl);
+    redisTemplate.opsForValue().set(attemptKey(normalizedEmail, purpose), "0", codeTtl);
     return code;
   }
 
   @Override
-  public void rollbackIssuedCode(String email) {
+  public void rollbackIssuedCode(String email, EmailVerificationPurpose purpose) {
     String normalizedEmail = normalizeEmail(email);
-    redisTemplate.delete(codeKey(normalizedEmail));
-    redisTemplate.delete(attemptKey(normalizedEmail));
-    redisTemplate.delete(cooldownKey(normalizedEmail));
+    redisTemplate.delete(codeKey(normalizedEmail, purpose));
+    redisTemplate.delete(attemptKey(normalizedEmail, purpose));
+    redisTemplate.delete(cooldownKey(normalizedEmail, purpose));
   }
 
   @Override
-  public void verifyCode(String email, String code) {
+  public void verifyCode(String email, String code, EmailVerificationPurpose purpose) {
     String normalizedEmail = normalizeEmail(email);
     // 검증/시도횟수 증가/성공 소모를 한 번에 처리해 병렬 요청 우회를 방지한다.
     Long result =
         redisTemplate.execute(
             VERIFY_CODE_SCRIPT,
             List.of(
-                codeKey(normalizedEmail),
-                attemptKey(normalizedEmail),
-                verifiedKey(normalizedEmail)),
+                codeKey(normalizedEmail, purpose),
+                attemptKey(normalizedEmail, purpose),
+                verifiedKey(normalizedEmail, purpose)),
             code,
             String.valueOf(authProperties.getEmail().getMaxAttempts()),
             String.valueOf(authProperties.getEmail().getVerifiedTtlSeconds()));
@@ -120,12 +121,15 @@ public class RedisEmailVerificationStore implements EmailVerificationStore {
 
   @Override
   public boolean isEmailVerified(String email) {
-    return StringUtils.hasText(redisTemplate.opsForValue().get(verifiedKey(normalizeEmail(email))));
+    return StringUtils.hasText(
+        redisTemplate
+            .opsForValue()
+            .get(verifiedKey(normalizeEmail(email), EmailVerificationPurpose.SIGNUP)));
   }
 
   @Override
   public void consumeVerifiedEmail(String email) {
-    redisTemplate.delete(verifiedKey(normalizeEmail(email)));
+    redisTemplate.delete(verifiedKey(normalizeEmail(email), EmailVerificationPurpose.SIGNUP));
   }
 
   private String generateCode() {
@@ -137,19 +141,26 @@ public class RedisEmailVerificationStore implements EmailVerificationStore {
     return email.trim().toLowerCase(Locale.ROOT);
   }
 
-  private String codeKey(String email) {
-    return KEY_PREFIX + "code:" + email;
+  private String codeKey(String email, EmailVerificationPurpose purpose) {
+    return purposePrefix(purpose) + "code:" + email;
   }
 
-  private String attemptKey(String email) {
-    return KEY_PREFIX + "attempt:" + email;
+  private String attemptKey(String email, EmailVerificationPurpose purpose) {
+    return purposePrefix(purpose) + "attempt:" + email;
   }
 
-  private String cooldownKey(String email) {
-    return KEY_PREFIX + "cooldown:" + email;
+  private String cooldownKey(String email, EmailVerificationPurpose purpose) {
+    return purposePrefix(purpose) + "cooldown:" + email;
   }
 
-  private String verifiedKey(String email) {
-    return KEY_PREFIX + "verified:" + email;
+  private String verifiedKey(String email, EmailVerificationPurpose purpose) {
+    return purposePrefix(purpose) + "verified:" + email;
+  }
+
+  private String purposePrefix(EmailVerificationPurpose purpose) {
+    if (purpose == EmailVerificationPurpose.SIGNUP) {
+      return KEY_PREFIX;
+    }
+    return KEY_PREFIX + purpose.keySegment() + ":";
   }
 }

--- a/src/main/java/com/gachi/be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gachi/be/domain/user/repository/UserRepository.java
@@ -15,6 +15,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByLoginId(String loginId);
 
+  Optional<User> findByEmail(String email);
+
   Optional<User> findByIdAndStatus(Long id, UserStatus status);
 
   List<User> findAllByStatus(UserStatus status);

--- a/src/main/java/com/gachi/be/global/code/ErrorCode.java
+++ b/src/main/java/com/gachi/be/global/code/ErrorCode.java
@@ -35,6 +35,12 @@ public enum ErrorCode {
       HttpStatus.CONFLICT, "AUTH4092", "이미 사용 중인 아이디입니다.", "회원가입 login_id 중복", ErrorLogLevel.WARN),
   AUTH_DUPLICATE_PHONE_NUMBER(
       HttpStatus.CONFLICT, "AUTH4093", "이미 사용 중인 전화번호입니다.", "회원가입 전화번호 중복", ErrorLogLevel.WARN),
+  AUTH_EMAIL_NOT_REGISTERED(
+      HttpStatus.NOT_FOUND,
+      "AUTH4041",
+      "가입된 이메일을 찾을 수 없습니다.",
+      "아이디 찾기 요청 이메일에 해당하는 계정 없음",
+      ErrorLogLevel.INFO),
   AUTH_EMAIL_NOT_VERIFIED(
       HttpStatus.BAD_REQUEST,
       "AUTH4001",

--- a/src/main/java/com/gachi/be/global/code/SuccessCode.java
+++ b/src/main/java/com/gachi/be/global/code/SuccessCode.java
@@ -17,6 +17,8 @@ public enum SuccessCode {
   AUTH_CHECK_LOGIN_ID_AVAILABLE(HttpStatus.OK, "AUTH2005", "사용 가능한 아이디입니다."),
   AUTH_CHECK_EMAIL_AVAILABLE(HttpStatus.OK, "AUTH2006", "사용 가능한 이메일입니다."),
   AUTH_CHECK_PHONE_NUMBER_AVAILABLE(HttpStatus.OK, "AUTH2007", "사용 가능한 전화번호입니다."),
+  AUTH_FIND_LOGIN_ID_EMAIL_CODE_SENT(HttpStatus.OK, "AUTH2008", "아이디 찾기 인증 코드가 발송되었습니다."),
+  AUTH_FIND_LOGIN_ID_SUCCESS(HttpStatus.OK, "AUTH2009", "아이디 찾기에 성공하였습니다."),
   CHILD_CREATE_SUCCESS(HttpStatus.CREATED, "CHILD2011", "자녀 정보 등록에 성공하였습니다."),
   CHILD_GET_LIST_SUCCESS(HttpStatus.OK, "CHILD2001", "내 자녀 목록 조회에 성공하였습니다."),
   CHILD_UPDATE_SUCCESS(HttpStatus.OK, "CHILD2002", "자녀 정보 수정에 성공하였습니다."),

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gachi.be.domain.auth.service.AuthMailService;
 import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.entity.enums.NotificationPreference;
 import com.gachi.be.domain.user.entity.enums.UserStatus;
 import com.gachi.be.domain.user.repository.UserRepository;
 import java.time.OffsetDateTime;
@@ -794,10 +795,13 @@ class AuthControllerIntegrationTest {
             .name("find-login-id-user")
             .phoneNumber(phoneNumber)
             .status(status)
+            .languageCode("KO")
+            .notificationPreference(NotificationPreference.IMPORTANT)
             .emailVerifiedAt(now)
             .consentAgreedAt(now)
             .consentVersion("2026-04-v1")
             .passwordUpdatedAt(now)
+            .passwordChangeRequired(false)
             .build());
   }
 

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
@@ -8,6 +8,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gachi.be.domain.auth.service.AuthMailService;
+import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.entity.enums.UserStatus;
+import com.gachi.be.domain.user.repository.UserRepository;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -20,6 +23,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -47,6 +51,8 @@ class AuthControllerIntegrationTest {
   private MockMvc mockMvc;
   @Autowired private WebApplicationContext webApplicationContext;
   @Autowired private CapturingAuthMailService capturingAuthMailService;
+  @Autowired private UserRepository userRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
 
   @BeforeEach
   void setUp() {
@@ -608,6 +614,68 @@ class AuthControllerIntegrationTest {
         .andExpect(jsonPath("$.code").value("AUTH2011"));
   }
 
+  @Test
+  void findLoginIdSendsCodeAndReturnsLoginIdWhenCodeMatches() throws Exception {
+    String email = "find-login-id@gachi.com";
+    String loginId = "find_login_user";
+    verifyEmailForSignup(email);
+    signup(
+            signupPayload(
+                "find-login", email, loginId, "Policy12!", "Policy12!", "01010101010", true))
+        .andExpect(status().isCreated());
+
+    sendFindLoginIdEmail(email)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("AUTH2008"));
+    String code = capturingAuthMailService.getCode(email);
+    assertThat(code).isNotBlank();
+
+    verifyFindLoginIdEmail(email, code)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("AUTH2009"))
+        .andExpect(jsonPath("$.result.loginId").value(loginId));
+  }
+
+  @Test
+  void findLoginIdRejectsUnregisteredEmail() throws Exception {
+    sendFindLoginIdEmail("not-registered@gachi.com")
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("AUTH4041"));
+  }
+
+  @Test
+  void findLoginIdRejectsWithdrawnAccount() throws Exception {
+    createUser(
+        "withdrawn_login_user", "withdrawn-find@gachi.com", "01010101011", UserStatus.WITHDRAWN);
+
+    sendFindLoginIdEmail("withdrawn-find@gachi.com")
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("AUTH4031"));
+  }
+
+  @Test
+  void findLoginIdRejectsMismatchedCode() throws Exception {
+    createUser("mismatch_login_user", "mismatch-find@gachi.com", "01010101012", UserStatus.ACTIVE);
+    sendFindLoginIdEmail("mismatch-find@gachi.com").andExpect(status().isOk());
+
+    verifyFindLoginIdEmail("mismatch-find@gachi.com", "000000")
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4002"));
+  }
+
+  @Test
+  void findLoginIdCodeDoesNotVerifySignupEmailFlow() throws Exception {
+    String email = "purpose-separated@gachi.com";
+    createUser("purpose_login_user", email, "01010101013", UserStatus.ACTIVE);
+    sendFindLoginIdEmail(email).andExpect(status().isOk());
+    String findLoginIdCode = capturingAuthMailService.getCode(email);
+    assertThat(findLoginIdCode).isNotBlank();
+
+    verifyEmail(email, findLoginIdCode)
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4003"));
+  }
+
   private org.springframework.test.web.servlet.ResultActions sendEmail(String email)
       throws Exception {
     return mockMvc.perform(
@@ -620,6 +688,22 @@ class AuthControllerIntegrationTest {
       throws Exception {
     return mockMvc.perform(
         post("/api/v1/auth/email/verify")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(Map.of("email", email, "code", code))));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions sendFindLoginIdEmail(String email)
+      throws Exception {
+    return mockMvc.perform(
+        post("/api/v1/auth/find-login-id/email/send")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(Map.of("email", email))));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions verifyFindLoginIdEmail(
+      String email, String code) throws Exception {
+    return mockMvc.perform(
+        post("/api/v1/auth/find-login-id/email/verify")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(Map.of("email", email, "code", code))));
   }
@@ -698,6 +782,23 @@ class AuthControllerIntegrationTest {
 
   private JsonNode readBody(MvcResult result) throws Exception {
     return objectMapper.readTree(result.getResponse().getContentAsString());
+  }
+
+  private void createUser(String loginId, String email, String phoneNumber, UserStatus status) {
+    OffsetDateTime now = OffsetDateTime.now();
+    userRepository.saveAndFlush(
+        User.builder()
+            .email(email)
+            .loginId(loginId)
+            .passwordHash(passwordEncoder.encode("Policy12!"))
+            .name("find-login-id-user")
+            .phoneNumber(phoneNumber)
+            .status(status)
+            .emailVerifiedAt(now)
+            .consentAgreedAt(now)
+            .consentVersion("2026-04-v1")
+            .passwordUpdatedAt(now)
+            .build());
   }
 
   @TestConfiguration

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthRateLimitIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthRateLimitIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.entity.enums.NotificationPreference;
 import com.gachi.be.domain.user.entity.enums.UserStatus;
 import com.gachi.be.domain.user.repository.UserRepository;
 import java.time.OffsetDateTime;
@@ -140,6 +141,27 @@ class AuthRateLimitIntegrationTest {
   }
 
   @Test
+  void findLoginIdEmailSendUsesSeparateBucketFromSignupEmailSend() throws Exception {
+    String email = "rate-find-login@gachi.com";
+    String clientIp = "198.51.100.60";
+    createActiveUser("rate_find_login_user", "RateLimit12!", email, "01012345676");
+
+    sendEmailWithForwardedFor(email, clientIp)
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("AUTH4091"));
+    sendEmailWithForwardedFor(email, clientIp)
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("AUTH4091"));
+    sendEmailWithForwardedFor(email, clientIp)
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.code").value("AUTH4294"));
+
+    sendFindLoginIdEmailWithForwardedFor(email, clientIp)
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("AUTH2008"));
+  }
+
+  @Test
   void loginBlocksWhenIpLimitExceeded() throws Exception {
     createActiveUser("ratelimit_login_1", "RateLimit12!", "login-limit-1@gachi.com", "01012345670");
     String realIp = "203.0.113.20";
@@ -225,6 +247,16 @@ class AuthRateLimitIntegrationTest {
             .content(objectMapper.writeValueAsString(Map.of("email", email))));
   }
 
+  private ResultActions sendFindLoginIdEmailWithForwardedFor(String email, String forwardedFor)
+      throws Exception {
+    return mockMvc.perform(
+        post("/api/v1/auth/find-login-id/email/send")
+            .with(remoteAddress("127.0.0.1"))
+            .header("X-Forwarded-For", forwardedFor)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(Map.of("email", email))));
+  }
+
   private ResultActions loginWithRealIp(String loginId, String password, String realIp)
       throws Exception {
     return mockMvc.perform(
@@ -278,10 +310,13 @@ class AuthRateLimitIntegrationTest {
             .name("rate-limit-user")
             .phoneNumber(phoneNumber)
             .status(UserStatus.ACTIVE)
+            .languageCode("KO")
+            .notificationPreference(NotificationPreference.IMPORTANT)
             .emailVerifiedAt(now)
             .consentAgreedAt(now)
             .consentVersion("2026-04-v1")
             .passwordUpdatedAt(now)
+            .passwordChangeRequired(false)
             .build());
   }
 

--- a/src/test/java/com/gachi/be/domain/auth/service/impl/RedisEmailVerificationStoreIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/service/impl/RedisEmailVerificationStoreIntegrationTest.java
@@ -3,6 +3,7 @@ package com.gachi.be.domain.auth.service.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.gachi.be.domain.auth.service.EmailVerificationPurpose;
 import com.gachi.be.domain.auth.service.EmailVerificationStore;
 import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.exception.BusinessException;
@@ -77,5 +78,22 @@ class RedisEmailVerificationStoreIntegrationTest {
 
     String secondCode = emailVerificationStore.issueCode(email);
     assertThat(secondCode).hasSize(6);
+  }
+
+  @Test
+  void purposeSeparatesCooldownAndVerifiedState() {
+    String email = "redis-purpose@gachi.com";
+
+    String signupCode = emailVerificationStore.issueCode(email, EmailVerificationPurpose.SIGNUP);
+    String findLoginIdCode =
+        emailVerificationStore.issueCode(email, EmailVerificationPurpose.FIND_LOGIN_ID);
+
+    assertThat(signupCode).hasSize(6);
+    assertThat(findLoginIdCode).hasSize(6);
+
+    emailVerificationStore.verifyCode(
+        email, findLoginIdCode, EmailVerificationPurpose.FIND_LOGIN_ID);
+
+    assertThat(emailVerificationStore.isEmailVerified(email)).isFalse();
   }
 }


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 가입된 이메일로 아이디 찾기 인증번호를 발송하는 API를 추가
  - 인증번호 검증에 성공하면 해당 계정의 `loginId`를 반환하는 API를 추가
  - 기존 회원가입 이메일 인증과 아이디 찾기 이메일 인증이 섞이지 않도록 인증 목적(`SIGNUP`, `FIND_LOGIN_ID`)을 분리
  - 회원가입 Redis 인증 키는 기존 namespace를 유지하고, 아이디 찾기 인증만 별도 namespace를 사용하도록 처리
  - 관련 request/response DTO, 성공/에러 코드, 통합 테스트를 추가
  - ErrorCode 동기화
    - AUTH4041 (HTTP 404 Not Found): 아이디 찾기 요청 이메일에 해당하는 계정 없음
  - 에러코드 스냅샷 탭: [error-code-v13(gid=1087461730)](https://docs.google.com/spreadsheets/d/1sUG_JJsVl6a8nR6k8jO_b7UrIEZzuvQdPB6S2S6fqgo/edit?gid=1087461730#gid=1087461730)
  - 에러코드 추가 커밋: 3cc0631
- 관련 이슈: closes #116 

## 🌿 브랜치 정보

- **Source**: `feat/#116-find-login-id-api`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

| 가입된 이메일 인증번호 발송 |
| --- |
| ![가입된 이메일 인증번호 발송](https://github.com/user-attachments/assets/2e193f1c-0a0b-4157-94c2-ad6eebfe1cb8) |

| 인증번호 검증 후 `loginId` 반환 |
| --- |
| ![인증번호 검증 후 `loginId` 반환](https://github.com/user-attachments/assets/8a858430-7545-44c3-a553-731e8ac89147) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이메일 인증을 통한 로그인 아이디 찾기 기능이 추가되었습니다. 인증 코드 요청 및 검증으로 가입된 로그인 아이디를 확인할 수 있습니다.

* **개선**
  * 이메일 인증 시스템이 목적별(SIGNUP vs FIND_LOGIN_ID)으로 분리되어 목적에 따라 코드·쿨다운·검증 상태가 별도 관리됩니다.
  * 아이디 찾기 전용 이메일 발송 레이트리밋이 도입되었습니다.

* **테스트**
  * 아이디 찾기 흐름과 목적별 인증 상태 분리에 대한 통합 테스트가 추가되었습니다.

* **문서**
  * 레이트리밋 정책 문서에 아이디 찾기 엔드포인트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->