### PR TITLE
feat: 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/gachi/be/domain/auth/api/controller/AuthController.java
+++ b/src/main/java/com/gachi/be/domain/auth/api/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.gachi.be.domain.auth.dto.request.EmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.LoginRequest;
+import com.gachi.be.domain.auth.dto.request.LogoutRequest;
 import com.gachi.be.domain.auth.dto.request.PasswordResetEmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.PasswordResetEmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.PasswordResetRequest;
@@ -88,6 +89,12 @@ public class AuthController {
             request,
             extractDeviceInfo(servletRequest),
             clientIpExtractor.extractClientIp(servletRequest)));
+  }
+
+  @PostMapping("/logout")
+  public ApiResponse<Void> logout(@Valid @RequestBody LogoutRequest request) {
+    authService.logout(request);
+    return ApiResponse.success(SuccessCode.AUTH_LOGOUT_SUCCESS, null);
   }
 
   @PostMapping("/email/send")

--- a/src/main/java/com/gachi/be/domain/auth/dto/request/LogoutRequest.java
+++ b/src/main/java/com/gachi/be/domain/auth/dto/request/LogoutRequest.java
@@ -1,0 +1,5 @@
+package com.gachi.be.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(@NotBlank String refreshToken) {}

--- a/src/main/java/com/gachi/be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.gachi.be.domain.auth.dto.request.EmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.LoginRequest;
+import com.gachi.be.domain.auth.dto.request.LogoutRequest;
 import com.gachi.be.domain.auth.dto.request.PasswordResetEmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.PasswordResetEmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.PasswordResetRequest;
@@ -32,6 +33,8 @@ public interface AuthService {
   AuthTokenResponse login(LoginRequest request, String deviceInfo, String ipAddress);
 
   AuthTokenResponse reissue(ReissueRequest request, String deviceInfo, String ipAddress);
+
+  void logout(LogoutRequest request);
 
   EmailSendResponse sendEmailVerificationCode(EmailSendRequest request);
 

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -9,6 +9,7 @@ import com.gachi.be.domain.auth.dto.request.EmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.FindLoginIdEmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.LoginRequest;
+import com.gachi.be.domain.auth.dto.request.LogoutRequest;
 import com.gachi.be.domain.auth.dto.request.PasswordResetEmailSendRequest;
 import com.gachi.be.domain.auth.dto.request.PasswordResetEmailVerifyRequest;
 import com.gachi.be.domain.auth.dto.request.PasswordResetRequest;
@@ -230,6 +231,23 @@ public class AuthServiceImpl implements AuthService {
     String nextDeviceInfo = mergeNullable(deviceInfo, existingToken.getDeviceInfo());
     String nextIpAddress = mergeNullable(ipAddress, existingToken.getIpAddress());
     return issueTokens(user, existingToken.isRememberMe(), nextDeviceInfo, nextIpAddress);
+  }
+
+  @Override
+  @Transactional
+  public void logout(LogoutRequest request) {
+    String refreshToken = normalizeText(request.refreshToken());
+    JwtTokenProvider.RefreshTokenClaims claims = jwtTokenProvider.parseRefreshToken(refreshToken);
+    String tokenHash = tokenHashService.sha256(refreshToken);
+
+    AuthRefreshToken existingToken =
+        authRefreshTokenRepository
+            .findByJtiAndTokenHash(claims.getJti(), tokenHash)
+            .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID));
+    ensureRefreshTokenUsable(existingToken.getRevokedAt(), existingToken.getExpiresAt());
+    ensureRefreshTokenIssuedAfterPasswordUpdate(existingToken, existingToken.getUser());
+
+    existingToken.revoke();
   }
 
   @Override

--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -239,13 +239,23 @@ public class AuthServiceImpl implements AuthService {
     String refreshToken = normalizeText(request.refreshToken());
     JwtTokenProvider.RefreshTokenClaims claims = jwtTokenProvider.parseRefreshToken(refreshToken);
     String tokenHash = tokenHashService.sha256(refreshToken);
+    RefreshTokenStatus tokenStatus =
+        authRefreshTokenRepository
+            .findStatusByJtiAndTokenHash(claims.getJti(), tokenHash)
+            .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID));
+    ensureRefreshTokenUsable(tokenStatus.getRevokedAt(), tokenStatus.getExpiresAt());
+
+    User user =
+        userRepository
+            .findByIdWithLock(tokenStatus.getUserId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID));
 
     AuthRefreshToken existingToken =
         authRefreshTokenRepository
             .findByJtiAndTokenHash(claims.getJti(), tokenHash)
             .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID));
     ensureRefreshTokenUsable(existingToken.getRevokedAt(), existingToken.getExpiresAt());
-    ensureRefreshTokenIssuedAfterPasswordUpdate(existingToken, existingToken.getUser());
+    ensureRefreshTokenIssuedAfterPasswordUpdate(existingToken, user);
 
     existingToken.revoke();
   }

--- a/src/main/java/com/gachi/be/global/code/SuccessCode.java
+++ b/src/main/java/com/gachi/be/global/code/SuccessCode.java
@@ -22,6 +22,7 @@ public enum SuccessCode {
   AUTH_PASSWORD_RESET_EMAIL_CODE_SENT(HttpStatus.OK, "AUTH2010", "비밀번호 재설정 인증 코드가 발송되었습니다."),
   AUTH_PASSWORD_RESET_EMAIL_VERIFIED(HttpStatus.OK, "AUTH2012", "비밀번호 재설정 이메일 인증이 완료되었습니다."),
   AUTH_PASSWORD_RESET_SUCCESS(HttpStatus.OK, "AUTH2013", "비밀번호 재설정이 완료되었습니다."),
+  AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2014", "로그아웃에 성공하였습니다."),
   CHILD_CREATE_SUCCESS(HttpStatus.CREATED, "CHILD2011", "자녀 정보 등록에 성공하였습니다."),
   CHILD_GET_LIST_SUCCESS(HttpStatus.OK, "CHILD2001", "내 자녀 목록 조회에 성공하였습니다."),
   CHILD_UPDATE_SUCCESS(HttpStatus.OK, "CHILD2002", "자녀 정보 수정에 성공하였습니다."),

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
@@ -215,7 +215,7 @@ class AuthControllerIntegrationTest {
             .andExpect(status().isOk())
             .andReturn();
     String refreshToken = readBody(loginResult).path("result").path("refreshToken").asText();
-    logout(refreshToken).andExpect(status().isOk());
+    logout(refreshToken).andExpect(status().isOk()).andExpect(jsonPath("$.code").value("AUTH2014"));
 
     logout(refreshToken)
         .andExpect(status().isUnauthorized())

--- a/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/auth/api/controller/AuthControllerIntegrationTest.java
@@ -191,6 +191,58 @@ class AuthControllerIntegrationTest {
   }
 
   @Test
+  void logoutRevokesRefreshToken() throws Exception {
+    createUser("logout_user", "logout@gachi.com", "01010101020", UserStatus.ACTIVE);
+    MvcResult loginResult =
+        login(loginPayload("logout_user", "Policy12!"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.code").value("AUTH2001"))
+            .andReturn();
+    String refreshToken = readBody(loginResult).path("result").path("refreshToken").asText();
+
+    logout(refreshToken).andExpect(status().isOk()).andExpect(jsonPath("$.code").value("AUTH2014"));
+
+    reissue(refreshToken)
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("AUTH4014"));
+  }
+
+  @Test
+  void logoutRejectsAlreadyRevokedRefreshToken() throws Exception {
+    createUser("logout_revoked_user", "logout-revoked@gachi.com", "01010101021", UserStatus.ACTIVE);
+    MvcResult loginResult =
+        login(loginPayload("logout_revoked_user", "Policy12!"))
+            .andExpect(status().isOk())
+            .andReturn();
+    String refreshToken = readBody(loginResult).path("result").path("refreshToken").asText();
+    logout(refreshToken).andExpect(status().isOk());
+
+    logout(refreshToken)
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("AUTH4014"));
+  }
+
+  @Test
+  void logoutRejectsExpiredRefreshToken() throws Exception {
+    createUser("logout_expired_user", "logout-expired@gachi.com", "01010101022", UserStatus.ACTIVE);
+    MvcResult loginResult =
+        login(loginPayload("logout_expired_user", "Policy12!"))
+            .andExpect(status().isOk())
+            .andReturn();
+    String refreshToken = readBody(loginResult).path("result").path("refreshToken").asText();
+    entityManager.flush();
+    jdbcTemplate.update(
+        "update auth_refresh_tokens set expires_at = ? where token_hash = ?",
+        OffsetDateTime.now().minusSeconds(1),
+        tokenHashService.sha256(refreshToken));
+    entityManager.clear();
+
+    logout(refreshToken)
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("AUTH4013"));
+  }
+
+  @Test
   void signupDuplicateChecksBeforeEmailVerified() throws Exception {
     String registeredEmail = "priority-base@gachi.com";
     String registeredLoginId = "priority_login";
@@ -901,6 +953,14 @@ class AuthControllerIntegrationTest {
       throws Exception {
     return mockMvc.perform(
         post("/api/v1/auth/reissue")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(Map.of("refreshToken", refreshToken))));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions logout(String refreshToken)
+      throws Exception {
+    return mockMvc.perform(
+        post("/api/v1/auth/logout")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(Map.of("refreshToken", refreshToken))));
   }


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 사용자가 현재 로그인 세션에서 로그아웃할 수 있도록 `POST /api/v1/auth/logout` API를 구현
  - 로그아웃 요청 시 refresh token을 검증하고, DB에 저장된 refresh token 세션을 revoke 처리
  - 로그아웃된 refresh token으로는 더 이상 토큰 재발급을 할 수 없도록 처리
  - 유효하지 않은/만료된/이미 폐기된 refresh token은 기존 refresh token 에러 코드로 응답하도록 구현
  - 비밀번호 재설정 이후 발급 기준이 맞지 않는 refresh token도 기존 재발급 흐름과 동일하게 차단하도록 처리
- 관련 이슈: closes #122 

## 🌿 브랜치 정보

- **Source**: `feat/#122-logout-api`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

| 로그아웃 |
| --- |
| ![로그아웃 성공](https://github.com/user-attachments/assets/cc7291ec-0083-4bc6-9499-2d332c36d7e9) |

| 로그아웃 후 재발급 실패 |
| --- |
| ![로그아웃된 refresh token 재발급 실패](https://github.com/user-attachments/assets/fa478d44-b67e-46db-b67b-7688ba610014) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 로그아웃 엔드포인트(POST /api/v1/auth/logout) 추가 - 리프레시 토큰을 무효화하여 사용자 세션을 종료

* **테스트**
  * 로그아웃 기능의 정상 동작, 무효화된 토큰 처리, 만료된 토큰 처리 등에 대한 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->