### PR TITLE
feat: 자녀 학급 정보 및 시간표 반 단위 조회 반영

### DIFF
--- a/src/main/java/com/gachi/be/domain/calendar/dto/response/ElementaryTimetableCalendarResponse.java
+++ b/src/main/java/com/gachi/be/domain/calendar/dto/response/ElementaryTimetableCalendarResponse.java
@@ -22,7 +22,8 @@ public record ElementaryTimetableCalendarResponse(List<TimetableGroup> schoolTim
     }
   }
 
-  public record ChildItem(Long childId, String childName, Integer grade, String colorCode) {}
+  public record ChildItem(
+      Long childId, String childName, Integer grade, String className, String colorCode) {}
 
   public record TimetableItem(
       String date,

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImpl.java
@@ -15,7 +15,6 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -41,14 +40,19 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
       List<SchoolScheduleChild> schoolChildren = entry.getValue();
       List<NeisElementaryTimetableItem> timetables =
           schoolChildren.stream()
-              .map(SchoolScheduleChild::grade)
-              .filter(Objects::nonNull)
+              .map(child -> new ClassIdentity(child.grade(), child.className()))
+              .filter(ClassIdentity::isComplete)
               .distinct()
               .flatMap(
-                  grade ->
+                  classIdentity ->
                       neisElementaryTimetableClient
                           .search(
-                              identity.officeCode(), identity.schoolCode(), fromDate, toDate, grade)
+                              identity.officeCode(),
+                              identity.schoolCode(),
+                              fromDate,
+                              toDate,
+                              classIdentity.grade(),
+                              classIdentity.className())
                           .stream())
               .sorted(timetableComparator())
               .toList();
@@ -75,6 +79,9 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
       if (!StringUtils.hasText(child.officeCode()) || !StringUtils.hasText(child.schoolCode())) {
         throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "자녀 학교의 교육청 코드와 학교 코드가 필요합니다.");
       }
+      if (child.grade() == null || !StringUtils.hasText(child.className())) {
+        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "시간표 조회에는 자녀의 학년과 반 정보가 필요합니다.");
+      }
       SchoolIdentity identity = new SchoolIdentity(child.officeCode(), child.schoolCode());
       grouped.computeIfAbsent(identity, ignored -> new ArrayList<>()).add(child);
     }
@@ -91,7 +98,11 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
             .map(
                 child ->
                     new ElementaryTimetableCalendarResponse.ChildItem(
-                        child.childId(), child.childName(), child.grade(), child.colorCode()))
+                        child.childId(),
+                        child.childName(),
+                        child.grade(),
+                        child.className(),
+                        child.colorCode()))
             .toList();
     List<ElementaryTimetableCalendarResponse.TimetableItem> timetableItems =
         timetables.stream().map(this::toTimetableItem).toList();
@@ -136,6 +147,16 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
   private record SchoolIdentity(String officeCode, String schoolCode) {
     String groupKey() {
       return officeCode + ":" + schoolCode;
+    }
+  }
+
+  private record ClassIdentity(Integer grade, String className) {
+    ClassIdentity {
+      className = StringUtils.hasText(className) ? className.trim() : className;
+    }
+
+    boolean isComplete() {
+      return grade != null && StringUtils.hasText(className);
     }
   }
 }

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImpl.java
@@ -40,6 +40,7 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
       List<SchoolScheduleChild> schoolChildren = entry.getValue();
       List<NeisElementaryTimetableItem> timetables =
           schoolChildren.stream()
+              // 기존 자녀 데이터에는 반이 없을 수 있어, 전체 조회를 막지 않고 보정 필요 상태를 응답에 남긴다.
               .map(child -> new ClassIdentity(child.grade(), child.className()))
               .filter(ClassIdentity::isComplete)
               .distinct()
@@ -78,9 +79,6 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
     for (SchoolScheduleChild child : children) {
       if (!StringUtils.hasText(child.officeCode()) || !StringUtils.hasText(child.schoolCode())) {
         throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "자녀 학교의 교육청 코드와 학교 코드가 필요합니다.");
-      }
-      if (child.grade() == null || !StringUtils.hasText(child.className())) {
-        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "시간표 조회에는 자녀의 학년과 반 정보가 필요합니다.");
       }
       SchoolIdentity identity = new SchoolIdentity(child.officeCode(), child.schoolCode());
       grouped.computeIfAbsent(identity, ignored -> new ArrayList<>()).add(child);

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleChildReader.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleChildReader.java
@@ -31,6 +31,7 @@ class SchoolScheduleChildReader {
                     child.getSchoolCode(),
                     child.getOfficeCode(),
                     child.getGrade(),
+                    child.getClassName(),
                     child.getColorCode()))
         .toList();
   }
@@ -42,5 +43,6 @@ class SchoolScheduleChildReader {
       String schoolCode,
       String officeCode,
       Integer grade,
+      String className,
       String colorCode) {}
 }

--- a/src/main/java/com/gachi/be/domain/child/dto/request/ChildCreateRequest.java
+++ b/src/main/java/com/gachi/be/domain/child/dto/request/ChildCreateRequest.java
@@ -13,6 +13,7 @@ public record ChildCreateRequest(
     @NotBlank @Size(max = 64) String schoolCode,
     @NotBlank @Size(max = 20) String officeCode,
     @NotNull @Min(1) @Max(6) Integer grade,
+    @NotBlank @Size(max = 20) String className,
     @NotBlank
         @Pattern(
             regexp = "^#[A-Fa-f0-9]{6}$",

--- a/src/main/java/com/gachi/be/domain/child/dto/request/ChildCreateRequest.java
+++ b/src/main/java/com/gachi/be/domain/child/dto/request/ChildCreateRequest.java
@@ -1,5 +1,6 @@
 package com.gachi.be.domain.child.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -8,14 +9,16 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record ChildCreateRequest(
-    @NotBlank @Size(max = 50) String name,
-    @NotBlank @Size(max = 120) String schoolName,
-    @NotBlank @Size(max = 64) String schoolCode,
-    @NotBlank @Size(max = 20) String officeCode,
-    @NotNull @Min(1) @Max(6) Integer grade,
-    @NotBlank @Size(max = 20) String className,
-    @NotBlank
-        @Pattern(
-            regexp = "^#[A-Fa-f0-9]{6}$",
-            message = "colorCode는 #RRGGBB 형식(예: #FF5A5A)만 허용합니다.")
+    @Schema(description = "자녀 이름", example = "김민수") @NotBlank @Size(max = 50) String name,
+    @Schema(description = "학교명", example = "화랑초등학교") @NotBlank @Size(max = 120) String schoolName,
+    @Schema(description = "NEIS 학교 코드", example = "7051173") @NotBlank @Size(max = 64)
+        String schoolCode,
+    @Schema(description = "NEIS 시도교육청 코드", example = "B10") @NotBlank @Size(max = 20)
+        String officeCode,
+    @Schema(description = "학년", example = "4") @NotNull @Min(1) @Max(6) Integer grade,
+    @Schema(description = "반. NEIS CLASS_NM 값으로 사용한다.", example = "1") @NotBlank @Size(max = 20)
+        String className,
+    @Schema(description = "캘린더 표시 색상", example = "#FF5A5A")
+        @NotBlank
+        @Pattern(regexp = "^#[A-Fa-f0-9]{6}$", message = "colorCode는 #RRGGBB 형식만 허용됩니다.")
         String colorCode) {}

--- a/src/main/java/com/gachi/be/domain/child/dto/request/ChildUpdateRequest.java
+++ b/src/main/java/com/gachi/be/domain/child/dto/request/ChildUpdateRequest.java
@@ -14,5 +14,7 @@ public record ChildUpdateRequest(
     @Size(max = 20) @Pattern(regexp = ".*\\S.*", message = "officeCode는 공백만 입력할 수 없습니다.")
         String officeCode,
     @Min(1) @Max(6) Integer grade,
+    @Size(max = 20) @Pattern(regexp = ".*\\S.*", message = "className은 공백만 입력할 수 없습니다.")
+        String className,
     @Pattern(regexp = "^#[A-Fa-f0-9]{6}$", message = "colorCode는 #RRGGBB 형식(예: #FF5A5A)만 허용합니다.")
         String colorCode) {}

--- a/src/main/java/com/gachi/be/domain/child/dto/request/ChildUpdateRequest.java
+++ b/src/main/java/com/gachi/be/domain/child/dto/request/ChildUpdateRequest.java
@@ -1,20 +1,33 @@
 package com.gachi.be.domain.child.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record ChildUpdateRequest(
-    @Size(max = 50) @Pattern(regexp = ".*\\S.*", message = "name은 공백만 입력할 수 없습니다.") String name,
-    @Size(max = 120) @Pattern(regexp = ".*\\S.*", message = "schoolName은 공백만 입력할 수 없습니다.")
+    @Schema(description = "자녀 이름", example = "김민수")
+        @Size(max = 50)
+        @Pattern(regexp = ".*\\S.*", message = "name은 공백만 입력할 수 없습니다.")
+        String name,
+    @Schema(description = "학교명", example = "화랑초등학교")
+        @Size(max = 120)
+        @Pattern(regexp = ".*\\S.*", message = "schoolName은 공백만 입력할 수 없습니다.")
         String schoolName,
-    @Size(max = 64) @Pattern(regexp = ".*\\S.*", message = "schoolCode는 공백만 입력할 수 없습니다.")
+    @Schema(description = "NEIS 학교 코드", example = "7051173")
+        @Size(max = 64)
+        @Pattern(regexp = ".*\\S.*", message = "schoolCode는 공백만 입력할 수 없습니다.")
         String schoolCode,
-    @Size(max = 20) @Pattern(regexp = ".*\\S.*", message = "officeCode는 공백만 입력할 수 없습니다.")
+    @Schema(description = "NEIS 시도교육청 코드", example = "B10")
+        @Size(max = 20)
+        @Pattern(regexp = ".*\\S.*", message = "officeCode는 공백만 입력할 수 없습니다.")
         String officeCode,
-    @Min(1) @Max(6) Integer grade,
-    @Size(max = 20) @Pattern(regexp = ".*\\S.*", message = "className은 공백만 입력할 수 없습니다.")
+    @Schema(description = "학년", example = "4") @Min(1) @Max(6) Integer grade,
+    @Schema(description = "반. NEIS CLASS_NM 값으로 사용한다.", example = "1")
+        @Size(max = 20)
+        @Pattern(regexp = ".*\\S.*", message = "className은 공백만 입력할 수 없습니다.")
         String className,
-    @Pattern(regexp = "^#[A-Fa-f0-9]{6}$", message = "colorCode는 #RRGGBB 형식(예: #FF5A5A)만 허용합니다.")
+    @Schema(description = "캘린더 표시 색상", example = "#FF5A5A")
+        @Pattern(regexp = "^#[A-Fa-f0-9]{6}$", message = "colorCode는 #RRGGBB 형식만 허용됩니다.")
         String colorCode) {}

--- a/src/main/java/com/gachi/be/domain/child/dto/response/ChildResponse.java
+++ b/src/main/java/com/gachi/be/domain/child/dto/response/ChildResponse.java
@@ -9,5 +9,6 @@ public record ChildResponse(
     String schoolCode,
     String officeCode,
     Integer grade,
+    String className,
     String colorCode,
     LocalDateTime createdAt) {}

--- a/src/main/java/com/gachi/be/domain/child/entity/Child.java
+++ b/src/main/java/com/gachi/be/domain/child/entity/Child.java
@@ -48,6 +48,9 @@ public class Child {
   @Column(nullable = false)
   private Integer grade;
 
+  @Column(name = "class_name", length = 20)
+  private String className;
+
   @Column(name = "color_code", nullable = false, length = 7)
   private String colorCode;
 
@@ -68,6 +71,7 @@ public class Child {
       String schoolCode,
       String officeCode,
       Integer grade,
+      String className,
       String colorCode) {
     this.user = user;
     this.name = name;
@@ -75,6 +79,7 @@ public class Child {
     this.schoolCode = schoolCode;
     this.officeCode = officeCode;
     this.grade = grade;
+    this.className = className;
     this.colorCode = colorCode;
   }
 
@@ -106,12 +111,14 @@ public class Child {
       String schoolCode,
       String officeCode,
       Integer grade,
+      String className,
       String colorCode) {
     if (name != null) this.name = name;
     if (schoolName != null) this.schoolName = schoolName;
     if (schoolCode != null) this.schoolCode = schoolCode;
     if (officeCode != null) this.officeCode = officeCode;
     if (grade != null) this.grade = grade;
+    if (className != null) this.className = className;
     if (colorCode != null) this.colorCode = colorCode;
   }
 }

--- a/src/main/java/com/gachi/be/domain/child/service/ChildService.java
+++ b/src/main/java/com/gachi/be/domain/child/service/ChildService.java
@@ -52,6 +52,7 @@ public class ChildService {
             .schoolCode(normalizeRequiredText(request.schoolCode()))
             .officeCode(normalizeRequiredText(request.officeCode()))
             .grade(request.grade())
+            .className(normalizeRequiredText(request.className()))
             .colorCode(normalizeRequiredText(request.colorCode()).toUpperCase())
             .build();
 
@@ -77,6 +78,7 @@ public class ChildService {
         child.getSchoolCode(),
         child.getOfficeCode(),
         child.getGrade(),
+        child.getClassName(),
         child.getColorCode(),
         child.getCreatedAt());
   }
@@ -104,6 +106,7 @@ public class ChildService {
         request.schoolCode() != null ? request.schoolCode().trim() : null,
         request.officeCode() != null ? request.officeCode().trim() : null,
         request.grade(),
+        normalizeOptionalText(request.className()),
         newColorCode);
 
     // 이름이 변경된 경우 → newsletter, calendar_events child_name 일괄 동기화

--- a/src/main/java/com/gachi/be/domain/school/client/NeisElementaryTimetableClient.java
+++ b/src/main/java/com/gachi/be/domain/school/client/NeisElementaryTimetableClient.java
@@ -39,16 +39,22 @@ public class NeisElementaryTimetableClient {
     this.objectMapper = objectMapper;
   }
 
-  /** 학교 식별값, 기간, 학년으로 NEIS 초등학교 시간표를 조회한다. */
+  /** 학교 식별값, 기간, 학년, 반으로 NEIS 초등학교 시간표를 조회한다. */
   public List<NeisElementaryTimetableItem> search(
-      String officeCode, String schoolCode, LocalDate fromDate, LocalDate toDate, Integer grade) {
+      String officeCode,
+      String schoolCode,
+      LocalDate fromDate,
+      LocalDate toDate,
+      Integer grade,
+      String className) {
     List<NeisElementaryTimetableItem> timetables = new ArrayList<>();
     int pageIndex = 1;
     int totalCount = Integer.MAX_VALUE;
 
     try {
       while (timetables.size() < totalCount) {
-        URI uri = buildSearchUri(officeCode, schoolCode, fromDate, toDate, grade, pageIndex);
+        URI uri =
+            buildSearchUri(officeCode, schoolCode, fromDate, toDate, grade, className, pageIndex);
         NeisHttpResponse response = executeGet(uri);
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
           log.error(
@@ -84,6 +90,7 @@ public class NeisElementaryTimetableClient {
       LocalDate fromDate,
       LocalDate toDate,
       Integer grade,
+      String className,
       int pageIndex) {
     String apiKey = neisProperties.getTimetableApiKey();
     if (!StringUtils.hasText(apiKey)) {
@@ -101,6 +108,9 @@ public class NeisElementaryTimetableClient {
     queryParams.put("TI_TO_YMD", toDate.format(NEIS_DATE_FORMATTER));
     if (grade != null) {
       queryParams.put("GRADE", String.valueOf(grade));
+    }
+    if (StringUtils.hasText(className)) {
+      queryParams.put("CLASS_NM", className.trim());
     }
     queryParams.put("KEY", apiKey);
 

--- a/src/main/resources/db/migration/V20__children_class_name.sql
+++ b/src/main/resources/db/migration/V20__children_class_name.sql
@@ -1,0 +1,6 @@
+ALTER TABLE children
+    ADD COLUMN IF NOT EXISTS class_name VARCHAR(20);
+
+CREATE INDEX IF NOT EXISTS idx_children_user_school_class
+    ON children (user_id, office_code, school_code, grade, class_name)
+    WHERE deleted_at IS NULL;

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.gachi.be.domain.calendar.service.impl.SchoolScheduleChildReader.SchoolScheduleChild;
@@ -81,17 +82,19 @@ class ElementaryTimetableQueryServiceImplTest {
   }
 
   @Test
-  void getElementaryTimetablesThrowsWhenChildClassNameIsMissing() {
+  void getElementaryTimetablesSkipsNeisCallWhenChildClassNameIsMissing() {
     SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, null, "#22CC88");
     when(schoolScheduleChildReader.findChildren(10L)).thenReturn(List.of(child));
 
-    assertThatThrownBy(
-            () ->
-                service.getElementaryTimetables(
-                    10L, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
-        .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+    var response =
+        service.getElementaryTimetables(10L, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+    assertThat(response.schoolTimetables()).hasSize(1);
+    assertThat(response.schoolTimetables().get(0).children())
+        .extracting("childId", "grade", "className")
+        .containsExactly(tuple(1L, 4, null));
+    assertThat(response.schoolTimetables().get(0).timetables()).isEmpty();
+    verifyNoInteractions(neisElementaryTimetableClient);
   }
 
   @Test

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImplTest.java
@@ -28,35 +28,61 @@ class ElementaryTimetableQueryServiceImplTest {
           schoolScheduleChildReader, neisElementaryTimetableClient);
 
   @Test
-  void getElementaryTimetablesQueriesDistinctGradesPerSchool() {
-    SchoolScheduleChild first = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "#22CC88");
-    SchoolScheduleChild sameGrade = child(2L, "둘째", "화랑초등학교", "7051173", "B10", 4, "#FFCC00");
-    SchoolScheduleChild otherGrade = child(3L, "셋째", "화랑초등학교", "7051173", "B10", 2, "#3366FF");
+  void getElementaryTimetablesQueriesDistinctGradesAndClassesPerSchool() {
+    SchoolScheduleChild first = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "1", "#22CC88");
+    SchoolScheduleChild sameClass = child(2L, "둘째", "화랑초등학교", "7051173", "B10", 4, "1", "#FFCC00");
+    SchoolScheduleChild otherClass = child(3L, "셋째", "화랑초등학교", "7051173", "B10", 4, "2", "#3366FF");
+    SchoolScheduleChild otherGrade = child(4L, "넷째", "화랑초등학교", "7051173", "B10", 2, "1", "#6655EE");
     LocalDate fromDate = LocalDate.of(2026, 3, 1);
     LocalDate toDate = LocalDate.of(2026, 3, 31);
     when(schoolScheduleChildReader.findChildren(10L))
-        .thenReturn(List.of(first, sameGrade, otherGrade));
+        .thenReturn(List.of(first, sameClass, otherClass, otherGrade));
     when(neisElementaryTimetableClient.search(
-            eq("B10"), eq("7051173"), eq(fromDate), eq(toDate), eq(4)))
-        .thenReturn(List.of(timetable(LocalDate.of(2026, 3, 2), 4, 2, "수학")));
+            eq("B10"), eq("7051173"), eq(fromDate), eq(toDate), eq(4), eq("1")))
+        .thenReturn(List.of(timetable(LocalDate.of(2026, 3, 2), 4, "1", 2, "수학")));
     when(neisElementaryTimetableClient.search(
-            eq("B10"), eq("7051173"), eq(fromDate), eq(toDate), eq(2)))
-        .thenReturn(List.of(timetable(LocalDate.of(2026, 3, 2), 2, 1, "국어")));
+            eq("B10"), eq("7051173"), eq(fromDate), eq(toDate), eq(4), eq("2")))
+        .thenReturn(List.of(timetable(LocalDate.of(2026, 3, 2), 4, "2", 3, "과학")));
+    when(neisElementaryTimetableClient.search(
+            eq("B10"), eq("7051173"), eq(fromDate), eq(toDate), eq(2), eq("1")))
+        .thenReturn(List.of(timetable(LocalDate.of(2026, 3, 2), 2, "1", 1, "국어")));
 
     var response = service.getElementaryTimetables(10L, fromDate, toDate);
 
     assertThat(response.schoolTimetables()).hasSize(1);
-    assertThat(response.schoolTimetables().get(0).childIds()).containsExactly(1L, 2L, 3L);
+    assertThat(response.schoolTimetables().get(0).childIds()).containsExactly(1L, 2L, 3L, 4L);
+    assertThat(response.schoolTimetables().get(0).children())
+        .extracting("childId", "grade", "className")
+        .containsExactly(
+            tuple(1L, 4, "1"), tuple(2L, 4, "1"), tuple(3L, 4, "2"), tuple(4L, 2, "1"));
     assertThat(response.schoolTimetables().get(0).timetables())
-        .extracting("grade", "period", "content")
-        .containsExactly(tuple(2, 1, "국어"), tuple(4, 2, "수학"));
-    verify(neisElementaryTimetableClient, times(1)).search("B10", "7051173", fromDate, toDate, 4);
-    verify(neisElementaryTimetableClient, times(1)).search("B10", "7051173", fromDate, toDate, 2);
+        .extracting("grade", "className", "period", "content")
+        .containsExactly(tuple(2, "1", 1, "국어"), tuple(4, "1", 2, "수학"), tuple(4, "2", 3, "과학"));
+    verify(neisElementaryTimetableClient, times(1))
+        .search("B10", "7051173", fromDate, toDate, 4, "1");
+    verify(neisElementaryTimetableClient, times(1))
+        .search("B10", "7051173", fromDate, toDate, 4, "2");
+    verify(neisElementaryTimetableClient, times(1))
+        .search("B10", "7051173", fromDate, toDate, 2, "1");
   }
 
   @Test
   void getElementaryTimetablesThrowsWhenChildSchoolIdentityIsMissing() {
-    SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", null, "B10", 4, "#22CC88");
+    SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", null, "B10", 4, "1", "#22CC88");
+    when(schoolScheduleChildReader.findChildren(10L)).thenReturn(List.of(child));
+
+    assertThatThrownBy(
+            () ->
+                service.getElementaryTimetables(
+                    10L, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+  }
+
+  @Test
+  void getElementaryTimetablesThrowsWhenChildClassNameIsMissing() {
+    SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, null, "#22CC88");
     when(schoolScheduleChildReader.findChildren(10L)).thenReturn(List.of(child));
 
     assertThatThrownBy(
@@ -70,32 +96,34 @@ class ElementaryTimetableQueryServiceImplTest {
 
   @Test
   void getElementaryTimetablesAllowsExactlyOneYearRange() {
-    SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "#22CC88");
+    SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "1", "#22CC88");
     LocalDate fromDate = LocalDate.of(2026, 1, 1);
     LocalDate toDate = LocalDate.of(2027, 1, 1);
     when(schoolScheduleChildReader.findChildren(10L)).thenReturn(List.of(child));
-    when(neisElementaryTimetableClient.search("B10", "7051173", fromDate, toDate, 4))
+    when(neisElementaryTimetableClient.search("B10", "7051173", fromDate, toDate, 4, "1"))
         .thenReturn(List.of());
 
     var response = service.getElementaryTimetables(10L, fromDate, toDate);
 
     assertThat(response.schoolTimetables()).hasSize(1);
-    verify(neisElementaryTimetableClient, times(1)).search("B10", "7051173", fromDate, toDate, 4);
+    verify(neisElementaryTimetableClient, times(1))
+        .search("B10", "7051173", fromDate, toDate, 4, "1");
   }
 
   @Test
   void getElementaryTimetablesAllowsLeapYearRangeWithinLimit() {
-    SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "#22CC88");
+    SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "1", "#22CC88");
     LocalDate fromDate = LocalDate.of(2024, 1, 1);
     LocalDate toDate = LocalDate.of(2024, 12, 31);
     when(schoolScheduleChildReader.findChildren(10L)).thenReturn(List.of(child));
-    when(neisElementaryTimetableClient.search("B10", "7051173", fromDate, toDate, 4))
+    when(neisElementaryTimetableClient.search("B10", "7051173", fromDate, toDate, 4, "1"))
         .thenReturn(List.of());
 
     var response = service.getElementaryTimetables(10L, fromDate, toDate);
 
     assertThat(response.schoolTimetables()).hasSize(1);
-    verify(neisElementaryTimetableClient, times(1)).search("B10", "7051173", fromDate, toDate, 4);
+    verify(neisElementaryTimetableClient, times(1))
+        .search("B10", "7051173", fromDate, toDate, 4, "1");
   }
 
   @Test
@@ -127,13 +155,15 @@ class ElementaryTimetableQueryServiceImplTest {
       String schoolCode,
       String officeCode,
       int grade,
+      String className,
       String colorCode) {
-    return new SchoolScheduleChild(id, name, schoolName, schoolCode, officeCode, grade, colorCode);
+    return new SchoolScheduleChild(
+        id, name, schoolName, schoolCode, officeCode, grade, className, colorCode);
   }
 
   private NeisElementaryTimetableItem timetable(
-      LocalDate date, Integer grade, Integer period, String content) {
-    return new NeisElementaryTimetableItem("2026", "1", date, grade, "1", period, content);
+      LocalDate date, Integer grade, String className, Integer period, String content) {
+    return new NeisElementaryTimetableItem("2026", "1", date, grade, className, period, content);
   }
 
   private org.assertj.core.groups.Tuple tuple(Object... values) {

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolMealQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolMealQueryServiceImplTest.java
@@ -116,7 +116,8 @@ class SchoolMealQueryServiceImplTest {
       String officeCode,
       int grade,
       String colorCode) {
-    return new SchoolScheduleChild(id, name, schoolName, schoolCode, officeCode, grade, colorCode);
+    return new SchoolScheduleChild(
+        id, name, schoolName, schoolCode, officeCode, grade, "1", colorCode);
   }
 
   private NeisSchoolMealItem meal(LocalDate date, String mealName, String dishName) {

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
@@ -85,7 +85,8 @@ class SchoolScheduleQueryServiceImplTest {
       String officeCode,
       int grade,
       String colorCode) {
-    return new SchoolScheduleChild(id, name, schoolName, schoolCode, officeCode, grade, colorCode);
+    return new SchoolScheduleChild(
+        id, name, schoolName, schoolCode, officeCode, grade, "1", colorCode);
   }
 
   private NeisSchoolScheduleItem schedule(String eventName, LocalDate date) {

--- a/src/test/java/com/gachi/be/domain/child/api/controller/ChildControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/child/api/controller/ChildControllerIntegrationTest.java
@@ -60,10 +60,12 @@ class ChildControllerIntegrationTest {
                 "schoolCode", "7130118",
                 "officeCode", "B10",
                 "grade", 1,
+                "className", "1",
                 "colorCode", "#FF5A5A"))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.code").value("CHILD2011"))
-        .andExpect(jsonPath("$.result.grade").value(1));
+        .andExpect(jsonPath("$.result.grade").value(1))
+        .andExpect(jsonPath("$.result.className").value("1"));
 
     postChild(
             parentAToken,
@@ -73,6 +75,7 @@ class ChildControllerIntegrationTest {
                 "schoolCode", "7130118",
                 "officeCode", "B10",
                 "grade", 6,
+                "className", "2",
                 "colorCode", "#00AAFF"))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.result.grade").value(6));
@@ -85,6 +88,7 @@ class ChildControllerIntegrationTest {
                 "schoolCode", "7551233",
                 "officeCode", "J10",
                 "grade", 3,
+                "className", "1",
                 "colorCode", "#22CC88"))
         .andExpect(status().isCreated());
 
@@ -120,6 +124,7 @@ class ChildControllerIntegrationTest {
                 "schoolCode", "7130118",
                 "officeCode", "B10",
                 "grade", 2,
+                "className", "1",
                 "colorCode", "#FF5A5A"))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value("AUTH4015"));
@@ -135,6 +140,7 @@ class ChildControllerIntegrationTest {
                 "schoolCode", "7130118",
                 "officeCode", "B10",
                 "grade", 2,
+                "className", "1",
                 "colorCode", "#FF5A5A"))
         .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.code").value("AUTH4016"));
@@ -153,6 +159,7 @@ class ChildControllerIntegrationTest {
                 "schoolCode", "",
                 "officeCode", "",
                 "grade", 0,
+                "className", "",
                 "colorCode", "FF5A5A"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("COMMON4001"))
@@ -160,6 +167,7 @@ class ChildControllerIntegrationTest {
         .andExpect(jsonPath("$.result.schoolCode").exists())
         .andExpect(jsonPath("$.result.officeCode").exists())
         .andExpect(jsonPath("$.result.grade").exists())
+        .andExpect(jsonPath("$.result.className").exists())
         .andExpect(jsonPath("$.result.colorCode").exists());
 
     postChild(
@@ -170,6 +178,7 @@ class ChildControllerIntegrationTest {
                 "schoolCode", "7130118",
                 "officeCode", "B10",
                 "grade", 7,
+                "className", "1",
                 "colorCode", "#00AAFF"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("COMMON4001"))

--- a/src/test/java/com/gachi/be/domain/school/client/NeisElementaryTimetableClientTest.java
+++ b/src/test/java/com/gachi/be/domain/school/client/NeisElementaryTimetableClientTest.java
@@ -74,7 +74,8 @@ class NeisElementaryTimetableClientTest {
     NeisElementaryTimetableClient client = newClient("timetable-key");
 
     var timetables =
-        client.search("B10", "7051173", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31), 4);
+        client.search(
+            "B10", "7051173", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31), 4, "1");
 
     assertThat(rawQuery.get())
         .contains(
@@ -86,10 +87,12 @@ class NeisElementaryTimetableClientTest {
             "SD_SCHUL_CODE=7051173",
             "TI_FROM_YMD=20260301",
             "TI_TO_YMD=20260331",
-            "GRADE=4");
+            "GRADE=4",
+            "CLASS_NM=1");
     assertThat(timetables).hasSize(1);
     assertThat(timetables.get(0).date()).isEqualTo(LocalDate.of(2026, 3, 2));
     assertThat(timetables.get(0).grade()).isEqualTo(4);
+    assertThat(timetables.get(0).className()).isEqualTo("1");
     assertThat(timetables.get(0).period()).isEqualTo(2);
     assertThat(timetables.get(0).content()).isEqualTo("수학");
   }
@@ -111,7 +114,8 @@ class NeisElementaryTimetableClientTest {
     NeisElementaryTimetableClient client = newClient("timetable-key");
 
     var timetables =
-        client.search("B10", "7051173", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31), 4);
+        client.search(
+            "B10", "7051173", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31), 4, "1");
 
     assertThat(timetables).isEmpty();
   }
@@ -123,7 +127,7 @@ class NeisElementaryTimetableClientTest {
     assertThatThrownBy(
             () ->
                 client.search(
-                    "B10", "7051173", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31), 4))
+                    "B10", "7051173", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31), 4, "1"))
         .isInstanceOf(ExternalApiException.class)
         .extracting("errorCode")
         .isEqualTo(ErrorCode.EXTERNAL_API_ERROR);
@@ -148,7 +152,7 @@ class NeisElementaryTimetableClientTest {
     assertThatThrownBy(
             () ->
                 client.search(
-                    "B10", "7051173", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31), 4))
+                    "B10", "7051173", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31), 4, "1"))
         .isInstanceOf(ExternalApiException.class)
         .extracting("errorCode")
         .isEqualTo(ErrorCode.EXTERNAL_API_ERROR);


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 자녀 정보에 반 정보를 추가
  - NEIS 초등학교 시간표 조회 시 학년과 반(CLASS_NM)을 함께 전달하도록 수정
- 관련 이슈: closes #126

## 🌿 브랜치 정보

- **Source**: `feat/#126-elementary-timetable-class`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

| 자녀 등록 - className 포함 |
| --- |
| ![`className`을 포함해 자녀 등록 성공](https://github.com/user-attachments/assets/6adb633e-ed20-4e0e-9b56-f2d9a4391942) |

| 자녀 목록 조회 - className 응답 확인 |
| --- |
| ![등록된 자녀의 `className` 값이 내려오는지 확인](https://github.com/user-attachments/assets/aa5c1adb-f357-4360-a3a7-b9df7dc721cf) |

| 시간표 조회 - 반 단위 응답 확인 |
| --- |
| ![`className`이 포함되는지 확인](https://github.com/user-attachments/assets/4732c156-9358-4785-8d4b-efe210829c64) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 자녀 프로필에 반(className) 필드 추가 및 응답에 반 정보 포함.
  * 초등 시간표 조회에 반 정보 기반 필터링을 추가해 일정 검색 정확도 향상.

* **Documentation**
  * 자녀 생성/수정 요청의 필드 설명 및 예시 문서화, 유효성 메시지 갱신.

* **Chores**
  * 개인정보 테이블에 반 컬럼 추가 및 관련 인덱스 생성 마이그레이션 수행.

* **Tests**
  * 시간표·연동 클라이언트·컨트롤러 테스트들의 입력/검증을 반 정보 반영으로 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->