### PR TITLE
feat: 마이페이지 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/impl/AuthServiceImpl.java
@@ -29,7 +29,7 @@ import com.gachi.be.domain.auth.service.EmailVerificationPurpose;
 import com.gachi.be.domain.auth.service.EmailVerificationStore;
 import com.gachi.be.domain.auth.service.JwtTokenProvider;
 import com.gachi.be.domain.auth.service.TokenHashService;
-import com.gachi.be.domain.auth.service.password.PasswordStrengthEvaluator;
+import com.gachi.be.domain.auth.service.password.PasswordPolicyValidator;
 import com.gachi.be.domain.user.entity.User;
 import com.gachi.be.domain.user.entity.enums.NotificationPreference;
 import com.gachi.be.domain.user.entity.enums.UserStatus;
@@ -41,7 +41,6 @@ import com.gachi.be.global.exception.ExternalApiException;
 import java.time.OffsetDateTime;
 import java.util.Locale;
 import java.util.UUID;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -57,22 +56,10 @@ import org.springframework.util.StringUtils;
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
-  private static final int PASSWORD_MIN_LENGTH = 8;
-  private static final int PASSWORD_MAX_LENGTH = 20;
-  private static final int PASSWORD_MIN_COMPOSITION = 2;
-  private static final int PASSWORD_IDENTIFIER_MIN_LENGTH = 3;
-  private static final int PASSWORD_MIN_PHONE_CHUNK_LENGTH = 4;
-  private static final int PASSWORD_SEQUENCE_LIMIT = 4;
-  private static final Pattern PASSWORD_LETTER_PATTERN = Pattern.compile("[A-Za-z]");
-  private static final Pattern PASSWORD_DIGIT_PATTERN = Pattern.compile("[0-9]");
-  private static final Pattern PASSWORD_SPECIAL_PATTERN = Pattern.compile("[\\p{P}\\p{S}]");
-  private static final Pattern PASSWORD_REPEAT_PATTERN = Pattern.compile("(.)\\1{2,}");
-  private static final Pattern PASSWORD_CANONICAL_PATTERN = Pattern.compile("[^a-z0-9]");
-  private static final Pattern PASSWORD_NON_DIGIT_PATTERN = Pattern.compile("[^0-9]");
-
   private final UserRepository userRepository;
   private final AuthRefreshTokenRepository authRefreshTokenRepository;
   private final PasswordEncoder passwordEncoder;
+  private final PasswordPolicyValidator passwordPolicyValidator;
   private final JwtTokenProvider jwtTokenProvider;
   private final TokenHashService tokenHashService;
   private final EmailVerificationStore emailVerificationStore;
@@ -121,8 +108,7 @@ public class AuthServiceImpl implements AuthService {
       throw new BusinessException(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
     }
     // 프론트 실시간 검증을 우회한 요청도 차단하기 위해 서버에서 정책을 강제한다.
-    validatePasswordPolicy(request.password(), loginId, email, phoneNumber);
-    enforcePasswordStrength(request.password());
+    passwordPolicyValidator.validate(request.password(), loginId, email, phoneNumber);
     if (!Boolean.TRUE.equals(request.consentAgreed())) {
       throw new BusinessException(ErrorCode.AUTH_CONSENT_REQUIRED);
     }
@@ -336,8 +322,7 @@ public class AuthServiceImpl implements AuthService {
       throw new BusinessException(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
     }
 
-    validatePasswordPolicy(request.password(), loginId, email, user.getPhoneNumber());
-    enforcePasswordStrength(request.password());
+    passwordPolicyValidator.validate(request.password(), loginId, email, user.getPhoneNumber());
     user.resetPassword(passwordEncoder.encode(request.password()), OffsetDateTime.now());
     revokeActiveRefreshTokens(user.getId());
     consumeVerifiedEmailAfterCommit(email, EmailVerificationPurpose.RESET_PASSWORD);
@@ -480,38 +465,6 @@ public class AuthServiceImpl implements AuthService {
     return StringUtils.hasText(normalizedLatest) ? normalizedLatest : normalizeNullable(fallback);
   }
 
-  private void validatePasswordPolicy(
-      String password, String loginId, String email, String phoneNumber) {
-    if (password.length() < PASSWORD_MIN_LENGTH || password.length() > PASSWORD_MAX_LENGTH) {
-      throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_LENGTH_INVALID);
-    }
-
-    int compositionCount = 0;
-    if (PASSWORD_LETTER_PATTERN.matcher(password).find()) {
-      compositionCount++;
-    }
-    if (PASSWORD_DIGIT_PATTERN.matcher(password).find()) {
-      compositionCount++;
-    }
-    if (PASSWORD_SPECIAL_PATTERN.matcher(password).find()) {
-      compositionCount++;
-    }
-    if (compositionCount < PASSWORD_MIN_COMPOSITION) {
-      throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_COMPOSITION_INVALID);
-    }
-
-    if (containsForbiddenPattern(password, loginId, email, phoneNumber)) {
-      throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_FORBIDDEN_PATTERN);
-    }
-  }
-
-  /** 강도 판정 결과가 위험이면 회원가입을 차단한다. */
-  private void enforcePasswordStrength(String password) {
-    if (!PasswordStrengthEvaluator.evaluate(password).canSignup()) {
-      throw new BusinessException(ErrorCode.AUTH_PASSWORD_STRENGTH_DANGEROUS);
-    }
-  }
-
   private void ensurePasswordChangeNotRequired(User user) {
     if (user.isPasswordChangeRequired()) {
       throw new BusinessException(ErrorCode.AUTH_PASSWORD_CHANGE_REQUIRED);
@@ -528,105 +481,6 @@ public class AuthServiceImpl implements AuthService {
     return authMailService instanceof NoopAuthMailService
         && AuthProperties.Email.STORE_TYPE_MEMORY.equalsIgnoreCase(
             authProperties.getEmail().getStore());
-  }
-
-  private boolean containsForbiddenPattern(
-      String password, String loginId, String email, String phoneNumber) {
-    // 계정 식별자/예측 가능한 문자열이 비밀번호에 포함되는 케이스를 묶어서 차단한다.
-    String normalizedPassword = password.toLowerCase(Locale.ROOT);
-    if (password.chars().anyMatch(Character::isWhitespace)) {
-      return true;
-    }
-    if (PASSWORD_REPEAT_PATTERN.matcher(normalizedPassword).find()) {
-      return true;
-    }
-    if (containsIgnoreCase(normalizedPassword, loginId)) {
-      return true;
-    }
-
-    String emailLocalPart = email;
-    int emailAtIndex = email.indexOf('@');
-    if (emailAtIndex > 0) {
-      emailLocalPart = email.substring(0, emailAtIndex);
-    }
-    if (emailLocalPart.length() >= 3 && containsIgnoreCase(normalizedPassword, emailLocalPart)) {
-      return true;
-    }
-
-    if (containsPhoneChunk(normalizedPassword, phoneNumber)) {
-      return true;
-    }
-
-    return containsSequentialPattern(normalizedPassword);
-  }
-
-  private boolean containsIgnoreCase(String password, String token) {
-    String normalizedPassword = normalizeText(password).toLowerCase(Locale.ROOT);
-    String normalizedToken = normalizeText(token).toLowerCase(Locale.ROOT);
-    if (normalizedToken.length() >= PASSWORD_IDENTIFIER_MIN_LENGTH
-        && normalizedPassword.contains(normalizedToken)) {
-      return true;
-    }
-
-    // '_' '.' '-' 같은 구분자를 제거한 정규형도 비교해서 식별자 우회를 막는다.
-    String canonicalToken = canonicalizePasswordToken(normalizedToken);
-    String canonicalPassword = canonicalizePasswordToken(normalizedPassword);
-    return canonicalToken.length() >= PASSWORD_IDENTIFIER_MIN_LENGTH
-        && canonicalPassword.contains(canonicalToken);
-  }
-
-  private String canonicalizePasswordToken(String value) {
-    return PASSWORD_CANONICAL_PATTERN.matcher(value).replaceAll("");
-  }
-
-  private boolean containsPhoneChunk(String password, String phoneNumber) {
-    String normalizedPhone = normalizePhone(phoneNumber);
-    // 원문 비밀번호는 구분자 삽입으로 우회 가능하므로 숫자만 추출해서 비교한다.
-    String digitOnlyPassword = extractDigits(password);
-    if (normalizedPhone.length() < PASSWORD_MIN_PHONE_CHUNK_LENGTH) {
-      return false;
-    }
-    for (int start = 0;
-        start <= normalizedPhone.length() - PASSWORD_MIN_PHONE_CHUNK_LENGTH;
-        start++) {
-      String chunk = normalizedPhone.substring(start, start + PASSWORD_MIN_PHONE_CHUNK_LENGTH);
-      if (digitOnlyPassword.contains(chunk)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private String extractDigits(String value) {
-    return PASSWORD_NON_DIGIT_PATTERN.matcher(value).replaceAll("");
-  }
-
-  private boolean containsSequentialPattern(String password) {
-    int ascending = 1;
-    int descending = 1;
-
-    for (int i = 1; i < password.length(); i++) {
-      char previous = password.charAt(i - 1);
-      char current = password.charAt(i);
-      if (!isSameSequentialGroup(previous, current)) {
-        ascending = 1;
-        descending = 1;
-        continue;
-      }
-
-      int diff = current - previous;
-      ascending = diff == 1 ? ascending + 1 : 1;
-      descending = diff == -1 ? descending + 1 : 1;
-      if (ascending >= PASSWORD_SEQUENCE_LIMIT || descending >= PASSWORD_SEQUENCE_LIMIT) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private boolean isSameSequentialGroup(char previous, char current) {
-    return (Character.isDigit(previous) && Character.isDigit(current))
-        || (Character.isLetter(previous) && Character.isLetter(current));
   }
 
   private void consumeVerifiedEmailAfterCommit(String email) {

--- a/src/main/java/com/gachi/be/domain/auth/service/password/PasswordPolicyValidator.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/password/PasswordPolicyValidator.java
@@ -23,6 +23,9 @@ public class PasswordPolicyValidator {
   private static final Pattern PASSWORD_NON_DIGIT_PATTERN = Pattern.compile("[^0-9]");
 
   public void validate(String password, String loginId, String email, String phoneNumber) {
+    if (password == null || password.isEmpty()) {
+      throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_LENGTH_INVALID);
+    }
     validatePasswordPolicy(password, loginId, email, phoneNumber);
     enforcePasswordStrength(password);
   }
@@ -71,10 +74,11 @@ public class PasswordPolicyValidator {
       return true;
     }
 
-    String emailLocalPart = email;
-    int emailAtIndex = email.indexOf('@');
+    String normalizedEmail = normalizeText(email);
+    String emailLocalPart = normalizedEmail;
+    int emailAtIndex = normalizedEmail.indexOf('@');
     if (emailAtIndex > 0) {
-      emailLocalPart = email.substring(0, emailAtIndex);
+      emailLocalPart = normalizedEmail.substring(0, emailAtIndex);
     }
     if (emailLocalPart.length() >= 3 && containsIgnoreCase(normalizedPassword, emailLocalPart)) {
       return true;

--- a/src/main/java/com/gachi/be/domain/auth/service/password/PasswordPolicyValidator.java
+++ b/src/main/java/com/gachi/be/domain/auth/service/password/PasswordPolicyValidator.java
@@ -1,0 +1,164 @@
+package com.gachi.be.domain.auth.service.password;
+
+import com.gachi.be.global.code.ErrorCode;
+import com.gachi.be.global.exception.BusinessException;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+/** 회원가입, 비밀번호 재설정, 마이페이지 비밀번호 변경에서 같은 비밀번호 정책을 검증한다. */
+@Component
+public class PasswordPolicyValidator {
+  private static final int PASSWORD_MIN_LENGTH = 8;
+  private static final int PASSWORD_MAX_LENGTH = 20;
+  private static final int PASSWORD_MIN_COMPOSITION = 2;
+  private static final int PASSWORD_IDENTIFIER_MIN_LENGTH = 3;
+  private static final int PASSWORD_MIN_PHONE_CHUNK_LENGTH = 4;
+  private static final int PASSWORD_SEQUENCE_LIMIT = 4;
+  private static final Pattern PASSWORD_LETTER_PATTERN = Pattern.compile("[A-Za-z]");
+  private static final Pattern PASSWORD_DIGIT_PATTERN = Pattern.compile("[0-9]");
+  private static final Pattern PASSWORD_SPECIAL_PATTERN = Pattern.compile("[\\p{P}\\p{S}]");
+  private static final Pattern PASSWORD_REPEAT_PATTERN = Pattern.compile("(.)\\1{2,}");
+  private static final Pattern PASSWORD_CANONICAL_PATTERN = Pattern.compile("[^a-z0-9]");
+  private static final Pattern PASSWORD_NON_DIGIT_PATTERN = Pattern.compile("[^0-9]");
+
+  public void validate(String password, String loginId, String email, String phoneNumber) {
+    validatePasswordPolicy(password, loginId, email, phoneNumber);
+    enforcePasswordStrength(password);
+  }
+
+  private void validatePasswordPolicy(
+      String password, String loginId, String email, String phoneNumber) {
+    if (password.length() < PASSWORD_MIN_LENGTH || password.length() > PASSWORD_MAX_LENGTH) {
+      throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_LENGTH_INVALID);
+    }
+
+    int compositionCount = 0;
+    if (PASSWORD_LETTER_PATTERN.matcher(password).find()) {
+      compositionCount++;
+    }
+    if (PASSWORD_DIGIT_PATTERN.matcher(password).find()) {
+      compositionCount++;
+    }
+    if (PASSWORD_SPECIAL_PATTERN.matcher(password).find()) {
+      compositionCount++;
+    }
+    if (compositionCount < PASSWORD_MIN_COMPOSITION) {
+      throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_COMPOSITION_INVALID);
+    }
+
+    if (containsForbiddenPattern(password, loginId, email, phoneNumber)) {
+      throw new BusinessException(ErrorCode.AUTH_PASSWORD_POLICY_FORBIDDEN_PATTERN);
+    }
+  }
+
+  private void enforcePasswordStrength(String password) {
+    if (!PasswordStrengthEvaluator.evaluate(password).canSignup()) {
+      throw new BusinessException(ErrorCode.AUTH_PASSWORD_STRENGTH_DANGEROUS);
+    }
+  }
+
+  private boolean containsForbiddenPattern(
+      String password, String loginId, String email, String phoneNumber) {
+    String normalizedPassword = password.toLowerCase(Locale.ROOT);
+    if (password.chars().anyMatch(Character::isWhitespace)) {
+      return true;
+    }
+    if (PASSWORD_REPEAT_PATTERN.matcher(normalizedPassword).find()) {
+      return true;
+    }
+    if (containsIgnoreCase(normalizedPassword, loginId)) {
+      return true;
+    }
+
+    String emailLocalPart = email;
+    int emailAtIndex = email.indexOf('@');
+    if (emailAtIndex > 0) {
+      emailLocalPart = email.substring(0, emailAtIndex);
+    }
+    if (emailLocalPart.length() >= 3 && containsIgnoreCase(normalizedPassword, emailLocalPart)) {
+      return true;
+    }
+
+    if (containsPhoneChunk(normalizedPassword, phoneNumber)) {
+      return true;
+    }
+
+    return containsSequentialPattern(normalizedPassword);
+  }
+
+  private boolean containsIgnoreCase(String password, String token) {
+    String normalizedPassword = normalizeText(password).toLowerCase(Locale.ROOT);
+    String normalizedToken = normalizeText(token).toLowerCase(Locale.ROOT);
+    if (normalizedToken.length() >= PASSWORD_IDENTIFIER_MIN_LENGTH
+        && normalizedPassword.contains(normalizedToken)) {
+      return true;
+    }
+
+    String canonicalToken = canonicalizePasswordToken(normalizedToken);
+    String canonicalPassword = canonicalizePasswordToken(normalizedPassword);
+    return canonicalToken.length() >= PASSWORD_IDENTIFIER_MIN_LENGTH
+        && canonicalPassword.contains(canonicalToken);
+  }
+
+  private String canonicalizePasswordToken(String value) {
+    return PASSWORD_CANONICAL_PATTERN.matcher(value).replaceAll("");
+  }
+
+  private boolean containsPhoneChunk(String password, String phoneNumber) {
+    String normalizedPhone = normalizePhone(phoneNumber);
+    String digitOnlyPassword = extractDigits(password);
+    if (normalizedPhone.length() < PASSWORD_MIN_PHONE_CHUNK_LENGTH) {
+      return false;
+    }
+    for (int start = 0;
+        start <= normalizedPhone.length() - PASSWORD_MIN_PHONE_CHUNK_LENGTH;
+        start++) {
+      String chunk = normalizedPhone.substring(start, start + PASSWORD_MIN_PHONE_CHUNK_LENGTH);
+      if (digitOnlyPassword.contains(chunk)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private String extractDigits(String value) {
+    return PASSWORD_NON_DIGIT_PATTERN.matcher(value).replaceAll("");
+  }
+
+  private boolean containsSequentialPattern(String password) {
+    int ascending = 1;
+    int descending = 1;
+
+    for (int i = 1; i < password.length(); i++) {
+      char previous = password.charAt(i - 1);
+      char current = password.charAt(i);
+      if (!isSameSequentialGroup(previous, current)) {
+        ascending = 1;
+        descending = 1;
+        continue;
+      }
+
+      int diff = current - previous;
+      ascending = diff == 1 ? ascending + 1 : 1;
+      descending = diff == -1 ? descending + 1 : 1;
+      if (ascending >= PASSWORD_SEQUENCE_LIMIT || descending >= PASSWORD_SEQUENCE_LIMIT) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isSameSequentialGroup(char previous, char current) {
+    return (Character.isDigit(previous) && Character.isDigit(current))
+        || (Character.isLetter(previous) && Character.isLetter(current));
+  }
+
+  private String normalizePhone(String phoneNumber) {
+    return normalizeText(phoneNumber).replaceAll("[^0-9]", "");
+  }
+
+  private String normalizeText(String value) {
+    return value == null ? "" : value.trim();
+  }
+}

--- a/src/main/java/com/gachi/be/domain/user/api/controller/UserController.java
+++ b/src/main/java/com/gachi/be/domain/user/api/controller/UserController.java
@@ -11,6 +11,7 @@ import com.gachi.be.domain.user.dto.request.ChangeNotificationRequest;
 import com.gachi.be.domain.user.dto.request.EmailChangeCodeSendRequest;
 import com.gachi.be.domain.user.dto.request.EmailChangeRequest;
 import com.gachi.be.domain.user.dto.request.EmailChangeVerifyRequest;
+import com.gachi.be.domain.user.dto.request.PasswordChangeRequest;
 import com.gachi.be.domain.user.dto.request.ProfileUpdateRequest;
 import com.gachi.be.domain.user.dto.response.EmailChangeResponse;
 import com.gachi.be.domain.user.dto.response.ProfileUpdateResponse;
@@ -166,5 +167,15 @@ public class UserController {
     User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
     return ApiResponse.success(
         SuccessCode.USER_EMAIL_UPDATED, userProfileService.changeEmail(user, request));
+  }
+
+  @Operation(summary = "비밀번호 변경", description = "마이페이지에서 현재 비밀번호 확인 후 새 비밀번호로 변경합니다.")
+  @PatchMapping("/me/password")
+  public ApiResponse<Void> changePassword(
+      @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+      @RequestBody @Valid PasswordChangeRequest request) {
+    User user = authenticatedUserResolver.resolveActiveUser(authorizationHeader);
+    userProfileService.changePassword(user, request);
+    return ApiResponse.success(SuccessCode.USER_PASSWORD_UPDATED, null);
   }
 }

--- a/src/main/java/com/gachi/be/domain/user/dto/request/PasswordChangeRequest.java
+++ b/src/main/java/com/gachi/be/domain/user/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,9 @@
+package com.gachi.be.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PasswordChangeRequest(
+    @NotBlank @Size(max = 100) String currentPassword,
+    @NotBlank @Size(max = 100) String newPassword,
+    @NotBlank @Size(max = 100) String newPasswordConfirm) {}

--- a/src/main/java/com/gachi/be/domain/user/service/UserProfileService.java
+++ b/src/main/java/com/gachi/be/domain/user/service/UserProfileService.java
@@ -8,9 +8,11 @@ import com.gachi.be.domain.auth.service.AuthMailService;
 import com.gachi.be.domain.auth.service.EmailVerificationPurpose;
 import com.gachi.be.domain.auth.service.EmailVerificationStore;
 import com.gachi.be.domain.auth.service.impl.NoopAuthMailService;
+import com.gachi.be.domain.auth.service.password.PasswordPolicyValidator;
 import com.gachi.be.domain.user.dto.request.EmailChangeCodeSendRequest;
 import com.gachi.be.domain.user.dto.request.EmailChangeRequest;
 import com.gachi.be.domain.user.dto.request.EmailChangeVerifyRequest;
+import com.gachi.be.domain.user.dto.request.PasswordChangeRequest;
 import com.gachi.be.domain.user.dto.request.ProfileUpdateRequest;
 import com.gachi.be.domain.user.dto.response.EmailChangeResponse;
 import com.gachi.be.domain.user.dto.response.ProfileUpdateResponse;
@@ -42,6 +44,7 @@ public class UserProfileService {
   private final AuthMailService authMailService;
   private final EmailVerificationStore emailVerificationStore;
   private final AuthProperties authProperties;
+  private final PasswordPolicyValidator passwordPolicyValidator;
 
   @Transactional
   public ProfileUpdateResponse updateProfile(User user, ProfileUpdateRequest request) {
@@ -63,6 +66,25 @@ public class UserProfileService {
       throw e;
     }
     return new ProfileUpdateResponse(currentUser.getName(), currentUser.getPhoneNumber());
+  }
+
+  @Transactional
+  public void changePassword(User user, PasswordChangeRequest request) {
+    User currentUser = findActiveUserWithLock(user.getId());
+    if (!passwordEncoder.matches(request.currentPassword(), currentUser.getPasswordHash())) {
+      throw new BusinessException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+    }
+    if (!request.newPassword().equals(request.newPasswordConfirm())) {
+      throw new BusinessException(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
+    }
+
+    passwordPolicyValidator.validate(
+        request.newPassword(),
+        currentUser.getLoginId(),
+        currentUser.getEmail(),
+        currentUser.getPhoneNumber());
+    currentUser.resetPassword(passwordEncoder.encode(request.newPassword()), OffsetDateTime.now());
+    revokeActiveRefreshTokens(currentUser.getId());
   }
 
   @Transactional

--- a/src/main/java/com/gachi/be/global/code/SuccessCode.java
+++ b/src/main/java/com/gachi/be/global/code/SuccessCode.java
@@ -64,6 +64,7 @@ public enum SuccessCode {
   USER_EMAIL_CHANGE_CODE_SENT(HttpStatus.OK, "USER2004", "이메일 변경 인증 코드가 발송되었습니다."),
   USER_EMAIL_CHANGE_VERIFIED(HttpStatus.OK, "USER2005", "이메일 변경 인증이 완료되었습니다."),
   USER_EMAIL_UPDATED(HttpStatus.OK, "USER2006", "이메일이 변경되었습니다."),
+  USER_PASSWORD_UPDATED(HttpStatus.OK, "USER2007", "비밀번호가 변경되었습니다."),
   NOTIFICATION_LIST_SUCCESS(HttpStatus.OK, "NOTI2001", "알림 목록 조회에 성공하였습니다."),
   NOTIFICATION_UNREAD_COUNT_SUCCESS(HttpStatus.OK, "NOTI2002", "미읽음 알림 수 조회에 성공하였습니다."),
   NOTIFICATION_READ_SUCCESS(HttpStatus.OK, "NOTI2003", "알림 읽음 처리에 성공하였습니다."),

--- a/src/test/java/com/gachi/be/domain/user/api/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/user/api/controller/UserControllerIntegrationTest.java
@@ -169,6 +169,70 @@ class UserControllerIntegrationTest {
         .andExpect(jsonPath("$.code").value("AUTH4093"));
   }
 
+  @Test
+  void passwordChangeUpdatesPasswordAndRevokesRefreshToken() throws Exception {
+    String loginId = "password_change_user";
+    createUser(loginId, "password-change@gachi.com", "01010001008", UserStatus.ACTIVE);
+    JsonNode loginBody = login(loginId, "Policy12!");
+    String accessToken = loginBody.path("result").path("accessToken").asText();
+    String refreshToken = loginBody.path("result").path("refreshToken").asText();
+
+    changePassword(accessToken, "Policy12!", "Changed12ab", "Changed12ab")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value("USER2007"));
+
+    reissue(refreshToken)
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("AUTH4014"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        Map.of("loginId", loginId, "password", "Policy12!", "rememberMe", false))))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("AUTH4011"));
+    login(loginId, "Changed12ab");
+  }
+
+  @Test
+  void passwordChangeRejectsWrongCurrentPassword() throws Exception {
+    createUser(
+        "password_wrong_current",
+        "password-wrong-current@gachi.com",
+        "01010001009",
+        UserStatus.ACTIVE);
+    String accessToken = loginAccessToken("password_wrong_current", "Policy12!");
+
+    changePassword(accessToken, "Wrong12!", "Changed12ab", "Changed12ab")
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("AUTH4011"));
+  }
+
+  @Test
+  void passwordChangeRejectsConfirmMismatch() throws Exception {
+    createUser(
+        "password_mismatch", "password-mismatch@gachi.com", "01010001010", UserStatus.ACTIVE);
+    String accessToken = loginAccessToken("password_mismatch", "Policy12!");
+
+    changePassword(accessToken, "Policy12!", "Changed12ab", "Changed34cd")
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4004"));
+  }
+
+  @Test
+  void passwordChangeRejectsDangerousPasswordStrength() throws Exception {
+    createUser(
+        "password_dangerous", "password-dangerous@gachi.com", "01010001011", UserStatus.ACTIVE);
+    String accessToken = loginAccessToken("password_dangerous", "Policy12!");
+
+    changePassword(accessToken, "Policy12!", "Qa1x2w3e", "Qa1x2w3e")
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("AUTH4009"));
+  }
+
   private org.springframework.test.web.servlet.ResultActions sendEmailChangeCode(
       String accessToken, String email, String currentPassword) throws Exception {
     return mockMvc.perform(
@@ -196,6 +260,24 @@ class UserControllerIntegrationTest {
             .header("Authorization", bearer(accessToken))
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(Map.of("email", email))));
+  }
+
+  private org.springframework.test.web.servlet.ResultActions changePassword(
+      String accessToken, String currentPassword, String newPassword, String newPasswordConfirm)
+      throws Exception {
+    return mockMvc.perform(
+        patch("/api/v1/users/me/password")
+            .header("Authorization", bearer(accessToken))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                objectMapper.writeValueAsString(
+                    Map.of(
+                        "currentPassword",
+                        currentPassword,
+                        "newPassword",
+                        newPassword,
+                        "newPasswordConfirm",
+                        newPasswordConfirm))));
   }
 
   private org.springframework.test.web.servlet.ResultActions reissue(String refreshToken)


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 로그인한 사용자가 마이페이지에서 현재 비밀번호 확인 후 새 비밀번호로 변경할 수 있도록 `PATCH /api/v1/users/me/password` API를 구현
  - 마이페이지 비밀번호 변경은 이메일 인증 없이 동작하며, 현재 비밀번호가 일치하는 경우에만 변경
  - 새 비밀번호/새 비밀번호 확인값 일치 검증과 기존 비밀번호 정책(길이, 조합, 금지 패턴, 보안 강도)을 재사용하도록 공용 `PasswordPolicyValidator`를 분리
  - 비밀번호 변경 완료 후 기존 refresh token을 revoke하여 재로그인이 필요한 상태로 처리
  - 성공 코드 `USER2007`을 추가했으며, ErrorCode는 새로 추가하지 않고 기존 코드를 재사용
- 관련 이슈: closes #128 

## 🌿 브랜치 정보

- **Source**: `feat/#128-mypage-password-change-api`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

| 마이페이지 비밀번호 변경 |
| --- |
| ![PATCH /api/v1/users/me/password 성공](https://github.com/user-attachments/assets/0b981eef-0603-498a-a2de-618cb6c4090e) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자가 비밀번호를 변경할 수 있는 새로운 API 엔드포인트 추가
  * 비밀번호 변경 시 기존 리프레시 토큰 자동 폐기로 보안 강화

* **Refactor**
  * 비밀번호 정책 검증 로직을 독립 컴포넌트로 분리하여 관리 효율성 증대

* **Tests**
  * 비밀번호 변경 기능에 대한 통합 테스트 추가 (성공, 검증 실패 등 다양한 케이스 포함)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->