### PR TITLE
feat: 학사일정 공통 휴일 분리 및 필터링 적용

### DIFF
--- a/src/main/java/com/gachi/be/domain/calendar/dto/response/SchoolScheduleCalendarResponse.java
+++ b/src/main/java/com/gachi/be/domain/calendar/dto/response/SchoolScheduleCalendarResponse.java
@@ -2,9 +2,15 @@ package com.gachi.be.domain.calendar.dto.response;
 
 import java.util.List;
 
-public record SchoolScheduleCalendarResponse(List<SchoolScheduleGroup> schoolSchedules) {
+public record SchoolScheduleCalendarResponse(
+    List<ScheduleItem> commonHolidays, List<SchoolScheduleGroup> schoolSchedules) {
   public SchoolScheduleCalendarResponse {
+    commonHolidays = commonHolidays == null ? List.of() : List.copyOf(commonHolidays);
     schoolSchedules = schoolSchedules == null ? List.of() : List.copyOf(schoolSchedules);
+  }
+
+  public SchoolScheduleCalendarResponse(List<SchoolScheduleGroup> schoolSchedules) {
+    this(List.of(), schoolSchedules);
   }
 
   public record SchoolScheduleGroup(

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
@@ -12,8 +12,10 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -22,6 +24,11 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryService {
   private static final long MAX_SCHOOL_SCHEDULE_RANGE_DAYS = 366L;
+  private static final Set<String> EXCLUDED_EVENT_NAMES = Set.of("토요휴업일", "토요공휴일", "토요휴무일");
+  private static final Set<String> COMMON_HOLIDAY_KEYWORDS =
+      Set.of(
+          "공휴일", "대체공휴일", "대체휴일", "어린이날", "삼일절", "3·1절", "3.1절", "현충일", "광복절", "개천절", "한글날", "성탄절",
+          "석가탄신일", "부처님오신날", "신정", "설날", "추석");
 
   private final SchoolScheduleChildReader schoolScheduleChildReader;
   private final NeisSchoolScheduleClient neisSchoolScheduleClient;
@@ -34,16 +41,32 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
     Map<SchoolIdentity, List<SchoolScheduleChild>> childrenBySchool =
         groupBySchoolIdentity(schoolScheduleChildReader.findChildren(userId));
     List<SchoolScheduleCalendarResponse.SchoolScheduleGroup> groups = new ArrayList<>();
+    Map<ScheduleIdentity, SchoolScheduleCalendarResponse.ScheduleItem> commonHolidays =
+        new LinkedHashMap<>();
     for (Map.Entry<SchoolIdentity, List<SchoolScheduleChild>> entry : childrenBySchool.entrySet()) {
       SchoolIdentity identity = entry.getKey();
       List<SchoolScheduleChild> schoolChildren = entry.getValue();
       List<NeisSchoolScheduleItem> schedules =
           neisSchoolScheduleClient.search(
               identity.officeCode(), identity.schoolCode(), fromDate, toDate);
-      groups.add(toGroup(identity, schoolChildren, schedules));
+      List<NeisSchoolScheduleItem> schoolSpecificSchedules = new ArrayList<>();
+      for (NeisSchoolScheduleItem schedule : schedules) {
+        if (isExcludedEvent(schedule)) {
+          continue;
+        }
+        if (isCommonHoliday(schedule)) {
+          SchoolScheduleCalendarResponse.ScheduleItem scheduleItem = toScheduleItem(schedule);
+          commonHolidays.putIfAbsent(ScheduleIdentity.from(scheduleItem), scheduleItem);
+          continue;
+        }
+        if (appliesToAnyChildGrade(schedule, schoolChildren)) {
+          schoolSpecificSchedules.add(schedule);
+        }
+      }
+      groups.add(toGroup(identity, schoolChildren, schoolSpecificSchedules));
     }
 
-    return new SchoolScheduleCalendarResponse(groups);
+    return new SchoolScheduleCalendarResponse(new ArrayList<>(commonHolidays.values()), groups);
   }
 
   private void validateRange(LocalDate fromDate, LocalDate toDate) {
@@ -110,9 +133,63 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
             gradeEventYn.grade6()));
   }
 
+  private boolean isExcludedEvent(NeisSchoolScheduleItem item) {
+    return EXCLUDED_EVENT_NAMES.contains(normalizeText(item.eventName()));
+  }
+
+  private boolean isCommonHoliday(NeisSchoolScheduleItem item) {
+    String eventName = normalizeText(item.eventName());
+    String eventContent = normalizeText(item.eventContent());
+    return COMMON_HOLIDAY_KEYWORDS.stream()
+        .anyMatch(keyword -> eventName.contains(keyword) || eventContent.contains(keyword));
+  }
+
+  private boolean appliesToAnyChildGrade(
+      NeisSchoolScheduleItem item, List<SchoolScheduleChild> children) {
+    Set<Integer> childGrades = new LinkedHashSet<>();
+    for (SchoolScheduleChild child : children) {
+      if (child.grade() != null) {
+        childGrades.add(child.grade());
+      }
+    }
+    if (childGrades.isEmpty()) {
+      return true;
+    }
+    return childGrades.stream().anyMatch(grade -> isGradeTarget(item.gradeEventYn(), grade));
+  }
+
+  private boolean isGradeTarget(NeisSchoolScheduleItem.GradeEventYn gradeEventYn, int grade) {
+    if (gradeEventYn == null) {
+      return true;
+    }
+    return switch (grade) {
+      case 1 -> isYes(gradeEventYn.grade1());
+      case 2 -> isYes(gradeEventYn.grade2());
+      case 3 -> isYes(gradeEventYn.grade3());
+      case 4 -> isYes(gradeEventYn.grade4());
+      case 5 -> isYes(gradeEventYn.grade5());
+      case 6 -> isYes(gradeEventYn.grade6());
+      default -> false;
+    };
+  }
+
+  private boolean isYes(String value) {
+    return "Y".equalsIgnoreCase(normalizeText(value));
+  }
+
+  private String normalizeText(String value) {
+    return value == null ? "" : value.replaceAll("\\s+", "").trim();
+  }
+
   private record SchoolIdentity(String officeCode, String schoolCode) {
     String groupKey() {
       return officeCode + ":" + schoolCode;
+    }
+  }
+
+  private record ScheduleIdentity(String date, String eventName) {
+    static ScheduleIdentity from(SchoolScheduleCalendarResponse.ScheduleItem item) {
+      return new ScheduleIdentity(item.date(), item.eventName());
     }
   }
 }

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
@@ -56,7 +56,9 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
         }
         if (isCommonHoliday(schedule)) {
           SchoolScheduleCalendarResponse.ScheduleItem scheduleItem = toScheduleItem(schedule);
-          commonHolidays.putIfAbsent(ScheduleIdentity.from(scheduleItem), scheduleItem);
+          commonHolidays.putIfAbsent(
+              new ScheduleIdentity(scheduleItem.date(), normalizeText(scheduleItem.eventName())),
+              scheduleItem);
           continue;
         }
         if (appliesToAnyChildGrade(schedule, schoolChildren)) {
@@ -187,9 +189,5 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
     }
   }
 
-  private record ScheduleIdentity(String date, String eventName) {
-    static ScheduleIdentity from(SchoolScheduleCalendarResponse.ScheduleItem item) {
-      return new ScheduleIdentity(item.date(), item.eventName());
-    }
-  }
+  private record ScheduleIdentity(String date, String normalizedEventName) {}
 }

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
@@ -47,7 +47,7 @@ class SchoolScheduleQueryServiceImplTest {
     when(neisSchoolScheduleClient.search(eq("J10"), eq("7611076"), eq(fromDate), eq(toDate)))
         .thenReturn(
             List.of(
-                schedule("대체공휴일", LocalDate.of(2026, 3, 2)),
+                schedule("대체 공휴일", LocalDate.of(2026, 3, 2)),
                 schedule("어린이날", LocalDate.of(2026, 5, 5)),
                 schedule("토요공휴일", LocalDate.of(2026, 3, 7)),
                 schedule("재량휴업일", LocalDate.of(2026, 3, 5))));

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
@@ -28,28 +28,46 @@ class SchoolScheduleQueryServiceImplTest {
       new SchoolScheduleQueryServiceImpl(schoolScheduleChildReader, neisSchoolScheduleClient);
 
   @Test
-  void getSchoolSchedulesGroupsChildrenByOfficeCodeAndSchoolCode() {
-    SchoolScheduleChild first = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "#22CC88");
-    SchoolScheduleChild second = child(2L, "둘째", "화랑초등학교", "7051173", "B10", 2, "#FFCC00");
-    SchoolScheduleChild sameNameOtherSchool =
-        child(3L, "셋째", "화랑초등학교", "7611076", "J10", 1, "#3366FF");
+  void getSchoolSchedulesSeparatesCommonHolidaysAndFiltersByChildGrades() {
+    SchoolScheduleChild fourthGrade = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "#22CC88");
+    SchoolScheduleChild secondGrade = child(2L, "둘째", "화랑초등학교", "7051173", "B10", 2, "#FFCC00");
+    SchoolScheduleChild otherSchool = child(3L, "셋째", "가치초등학교", "7611076", "J10", 1, "#3366FF");
     LocalDate fromDate = LocalDate.of(2026, 3, 1);
-    LocalDate toDate = LocalDate.of(2026, 3, 31);
+    LocalDate toDate = LocalDate.of(2026, 5, 31);
     when(schoolScheduleChildReader.findChildren(10L))
-        .thenReturn(List.of(first, second, sameNameOtherSchool));
+        .thenReturn(List.of(fourthGrade, secondGrade, otherSchool));
     when(neisSchoolScheduleClient.search(eq("B10"), eq("7051173"), eq(fromDate), eq(toDate)))
-        .thenReturn(List.of(schedule("시업식", LocalDate.of(2026, 3, 2))));
+        .thenReturn(
+            List.of(
+                schedule("대체공휴일", LocalDate.of(2026, 3, 2)),
+                schedule("토요휴업일", LocalDate.of(2026, 3, 7)),
+                schedule("4학년 현장체험학습", LocalDate.of(2026, 3, 10), "N", "N", "N", "Y", "N", "N"),
+                schedule("6학년 졸업앨범 촬영", LocalDate.of(2026, 3, 11), "N", "N", "N", "N", "N", "Y"),
+                schedule("시업식", LocalDate.of(2026, 3, 3))));
     when(neisSchoolScheduleClient.search(eq("J10"), eq("7611076"), eq(fromDate), eq(toDate)))
-        .thenReturn(List.of(schedule("재량휴업일", LocalDate.of(2026, 3, 5))));
+        .thenReturn(
+            List.of(
+                schedule("대체공휴일", LocalDate.of(2026, 3, 2)),
+                schedule("어린이날", LocalDate.of(2026, 5, 5)),
+                schedule("토요공휴일", LocalDate.of(2026, 3, 7)),
+                schedule("재량휴업일", LocalDate.of(2026, 3, 5))));
 
     var response = service.getSchoolSchedules(10L, fromDate, toDate);
 
+    assertThat(response.commonHolidays())
+        .extracting("date", "eventName")
+        .containsExactly(tuple("2026-03-02", "대체공휴일"), tuple("2026-05-05", "어린이날"));
     assertThat(response.schoolSchedules()).hasSize(2);
     assertThat(response.schoolSchedules().get(0).schoolGroupKey()).isEqualTo("B10:7051173");
     assertThat(response.schoolSchedules().get(0).childIds()).containsExactly(1L, 2L);
-    assertThat(response.schoolSchedules().get(0).schedules().get(0).eventName()).isEqualTo("시업식");
+    assertThat(response.schoolSchedules().get(0).schedules())
+        .extracting("eventName")
+        .containsExactly("4학년 현장체험학습", "시업식");
     assertThat(response.schoolSchedules().get(1).schoolGroupKey()).isEqualTo("J10:7611076");
     assertThat(response.schoolSchedules().get(1).childIds()).containsExactly(3L);
+    assertThat(response.schoolSchedules().get(1).schedules())
+        .extracting("eventName")
+        .containsExactly("재량휴업일");
     verify(neisSchoolScheduleClient, times(2)).search(any(), any(), eq(fromDate), eq(toDate));
   }
 
@@ -90,11 +108,27 @@ class SchoolScheduleQueryServiceImplTest {
   }
 
   private NeisSchoolScheduleItem schedule(String eventName, LocalDate date) {
+    return schedule(eventName, date, "Y", "Y", "Y", "Y", "Y", "Y");
+  }
+
+  private NeisSchoolScheduleItem schedule(
+      String eventName,
+      LocalDate date,
+      String grade1,
+      String grade2,
+      String grade3,
+      String grade4,
+      String grade5,
+      String grade6) {
     return new NeisSchoolScheduleItem(
         "2026",
         date,
         eventName,
         null,
-        new NeisSchoolScheduleItem.GradeEventYn("Y", "Y", "Y", "Y", "Y", "Y"));
+        new NeisSchoolScheduleItem.GradeEventYn(grade1, grade2, grade3, grade4, grade5, grade6));
+  }
+
+  private org.assertj.core.groups.Tuple tuple(Object... values) {
+    return org.assertj.core.api.Assertions.tuple(values);
   }
 }


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - NEIS 학사일정 응답에서 토요휴업일 등 불필요한 일정을 제외 
  - 공통 휴일성 일정은 `commonHolidays`로 분리해 학교가 여러 개여도 중복 표시되지 않도록 개선
- 관련 이슈: closes #130 

## 🌿 브랜치 정보

- **Source**: `feat/#130-school-schedule-filter`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

| 학사일정 조회 - 공통 휴일 분리 |
| --- |
| ![`commonHolidays`](https://github.com/user-attachments/assets/6ee813fe-43cc-4e4b-a854-48ee426e0de9) |

| 학사일정 조회 - 불필요 일정 제거 |
| --- |
| ![`schoolSchedules[].schedules`](https://github.com/user-attachments/assets/e0776be7-7ebd-4b06-bbd4-036d92b15f94)<br>![`schoolSchedules[].schedules`](https://github.com/user-attachments/assets/02c0302a-6cf4-4846-b9fe-59f2906f0365) |
