### PR TITLE
feat: NEIS 응답 다국어 번역 적용

### DIFF
--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.gachi.be.domain.calendar.service.impl;
 
 import com.gachi.be.domain.calendar.dto.response.ElementaryTimetableCalendarResponse;
 import com.gachi.be.domain.calendar.service.ElementaryTimetableQueryService;
+import com.gachi.be.domain.calendar.service.impl.NeisCalendarTranslationService.TranslationContext;
 import com.gachi.be.domain.calendar.service.impl.SchoolScheduleChildReader.SchoolScheduleChild;
 import com.gachi.be.domain.school.client.NeisElementaryTimetableClient;
 import com.gachi.be.domain.school.dto.response.NeisElementaryTimetableItem;
@@ -26,6 +27,7 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
 
   private final SchoolScheduleChildReader schoolScheduleChildReader;
   private final NeisElementaryTimetableClient neisElementaryTimetableClient;
+  private final NeisCalendarTranslationService translationService;
 
   @Override
   public ElementaryTimetableCalendarResponse getElementaryTimetables(
@@ -34,6 +36,7 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
 
     Map<SchoolIdentity, List<SchoolScheduleChild>> childrenBySchool =
         groupBySchoolIdentity(schoolScheduleChildReader.findChildren(userId));
+    TranslationContext translationContext = translationService.contextFor(userId);
     List<ElementaryTimetableCalendarResponse.TimetableGroup> groups = new ArrayList<>();
     for (Map.Entry<SchoolIdentity, List<SchoolScheduleChild>> entry : childrenBySchool.entrySet()) {
       SchoolIdentity identity = entry.getKey();
@@ -57,7 +60,7 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
                           .stream())
               .sorted(timetableComparator())
               .toList();
-      groups.add(toGroup(identity, schoolChildren, timetables));
+      groups.add(toGroup(identity, schoolChildren, timetables, translationContext));
     }
 
     return new ElementaryTimetableCalendarResponse(groups);
@@ -89,7 +92,8 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
   private ElementaryTimetableCalendarResponse.TimetableGroup toGroup(
       SchoolIdentity identity,
       List<SchoolScheduleChild> children,
-      List<NeisElementaryTimetableItem> timetables) {
+      List<NeisElementaryTimetableItem> timetables,
+      TranslationContext translationContext) {
     List<Long> childIds = children.stream().map(SchoolScheduleChild::childId).toList();
     List<ElementaryTimetableCalendarResponse.ChildItem> childItems =
         children.stream()
@@ -103,7 +107,7 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
                         child.colorCode()))
             .toList();
     List<ElementaryTimetableCalendarResponse.TimetableItem> timetableItems =
-        timetables.stream().map(this::toTimetableItem).toList();
+        timetables.stream().map(item -> toTimetableItem(item, translationContext)).toList();
 
     return new ElementaryTimetableCalendarResponse.TimetableGroup(
         identity.groupKey(),
@@ -116,7 +120,7 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
   }
 
   private ElementaryTimetableCalendarResponse.TimetableItem toTimetableItem(
-      NeisElementaryTimetableItem item) {
+      NeisElementaryTimetableItem item, TranslationContext translationContext) {
     return new ElementaryTimetableCalendarResponse.TimetableItem(
         item.date().format(DateTimeFormatter.ISO_LOCAL_DATE),
         item.academicYear(),
@@ -124,7 +128,7 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
         item.grade(),
         item.className(),
         item.period(),
-        item.content());
+        translationService.translate(translationContext, item.content()));
   }
 
   private Comparator<NeisElementaryTimetableItem> timetableComparator() {

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImpl.java
@@ -128,7 +128,7 @@ public class ElementaryTimetableQueryServiceImpl implements ElementaryTimetableQ
         item.grade(),
         item.className(),
         item.period(),
-        translationService.translate(translationContext, item.content()));
+        translationService.translateTimetableContent(translationContext, item.content()));
   }
 
   private Comparator<NeisElementaryTimetableItem> timetableComparator() {

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationService.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationService.java
@@ -1,0 +1,63 @@
+package com.gachi.be.domain.calendar.service.impl;
+
+import com.gachi.be.domain.newsletter.pipeline.PapagoTranslateClient;
+import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.repository.UserRepository;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+class NeisCalendarTranslationService {
+  private static final String DEFAULT_LANGUAGE = "KO";
+
+  private final UserRepository userRepository;
+  private final PapagoTranslateClient papagoTranslateClient;
+
+  /**
+   * NEIS 캘린더 응답 번역에 사용할 사용자 언어와 요청 단위 번역 캐시를 만든다.
+   *
+   * <p>같은 급식명/행사명/수업명이 반복될 수 있어, 한 요청 안에서는 동일 문구를 한 번만 번역한다.
+   */
+  TranslationContext contextFor(Long userId) {
+    String language =
+        userRepository
+            .findById(userId)
+            .map(User::getLanguageCode)
+            .filter(StringUtils::hasText)
+            .map(value -> value.trim().toUpperCase())
+            .orElse(DEFAULT_LANGUAGE);
+    return new TranslationContext(language, new HashMap<>());
+  }
+
+  String translate(TranslationContext context, String text) {
+    if (context == null || !context.shouldTranslate() || !StringUtils.hasText(text)) {
+      return text;
+    }
+    return context
+        .cache()
+        .computeIfAbsent(text, value -> translateOrOriginal(value, context.language()));
+  }
+
+  private String translateOrOriginal(String text, String language) {
+    try {
+      String translated = papagoTranslateClient.translate(text, language);
+      return StringUtils.hasText(translated) ? translated : text;
+    } catch (RuntimeException e) {
+      // 외부 번역 실패가 급식/시간표/학사일정 조회 실패로 전파되지 않도록 원문을 유지한다.
+      log.warn("[NEIS Calendar] 파파고 번역 실패로 원문을 사용합니다. language={}", language, e);
+      return text;
+    }
+  }
+
+  record TranslationContext(String language, Map<String, String> cache) {
+    boolean shouldTranslate() {
+      return StringUtils.hasText(language) && !DEFAULT_LANGUAGE.equalsIgnoreCase(language);
+    }
+  }
+}

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationService.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationService.java
@@ -1,5 +1,7 @@
 package com.gachi.be.domain.calendar.service.impl;
 
+import static java.util.Map.entry;
+
 import com.gachi.be.domain.newsletter.pipeline.PapagoTranslateClient;
 import com.gachi.be.domain.user.entity.User;
 import com.gachi.be.domain.user.repository.UserRepository;
@@ -15,6 +17,115 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 class NeisCalendarTranslationService {
   private static final String DEFAULT_LANGUAGE = "KO";
+  private static final Map<String, MealNameTranslations> MEAL_NAME_TRANSLATIONS =
+      Map.of(
+          "1", new MealNameTranslations("Breakfast", "早餐", "Bữa sáng"),
+          "2", new MealNameTranslations("Lunch", "午餐", "Bữa trưa"),
+          "3", new MealNameTranslations("Dinner", "晚餐", "Bữa tối"));
+  private static final Map<String, LabelTranslations> NUTRITION_LABEL_TRANSLATIONS =
+      Map.of(
+          "탄수화물", new LabelTranslations("Carbohydrates", "碳水化合物", "Carbohydrate"),
+          "단백질", new LabelTranslations("Protein", "蛋白质", "Chất đạm"),
+          "지방", new LabelTranslations("Fat", "脂肪", "Chất béo"),
+          "비타민A", new LabelTranslations("Vitamin A", "维生素A", "Vitamin A"),
+          "티아민", new LabelTranslations("Thiamine", "硫胺素", "Thiamine"),
+          "리보플라빈", new LabelTranslations("Riboflavin", "核黄素", "Riboflavin"),
+          "비타민C", new LabelTranslations("Vitamin C", "维生素C", "Vitamin C"),
+          "칼슘", new LabelTranslations("Calcium", "钙", "Canxi"),
+          "철", new LabelTranslations("Iron", "铁", "Sắt"));
+  private static final Map<String, FixedTranslations> TIMETABLE_CONTENT_TRANSLATIONS =
+      Map.ofEntries(
+          entry("국어", new FixedTranslations("Korean", "国语", "Tiếng Hàn")),
+          entry("수학", new FixedTranslations("Mathematics", "数学", "Toán học")),
+          entry("사회", new FixedTranslations("Social Studies", "社会", "Xã hội")),
+          entry("과학", new FixedTranslations("Science", "科学", "Khoa học")),
+          entry("영어", new FixedTranslations("English", "英语", "Tiếng Anh")),
+          entry("체육", new FixedTranslations("Physical Education", "体育", "Thể dục")),
+          entry("음악", new FixedTranslations("Music", "音乐", "Âm nhạc")),
+          entry("미술", new FixedTranslations("Art", "美术", "Mỹ thuật")),
+          entry("도덕", new FixedTranslations("Moral Education", "道德", "Đạo đức")),
+          entry("실과", new FixedTranslations("Practical Arts", "实科", "Kỹ thuật thực hành")),
+          entry(
+              "창체",
+              new FixedTranslations(
+                  "Creative Experiential Activities", "创意体验活动", "Hoạt động trải nghiệm sáng tạo")),
+          entry("동아리", new FixedTranslations("Club Activities", "社团活动", "Hoạt động câu lạc bộ")),
+          entry("진로", new FixedTranslations("Career Activities", "职业活动", "Hoạt động hướng nghiệp")),
+          entry("자율", new FixedTranslations("Autonomous Activities", "自主活动", "Hoạt động tự quản")),
+          entry(
+              "자치",
+              new FixedTranslations("Self-Governance Activities", "自治活动", "Hoạt động tự trị")),
+          entry(
+              "자율/자치활동",
+              new FixedTranslations(
+                  "Autonomous Activities", "自主/自治活动", "Hoạt động tự quản/tự trị")),
+          entry(
+              "봉사",
+              new FixedTranslations("Volunteer Activities", "志愿服务活动", "Hoạt động tình nguyện")),
+          entry("안전", new FixedTranslations("Safety Education", "安全教育", "Giáo dục an toàn")),
+          entry("정보", new FixedTranslations("Information", "信息", "Tin học")),
+          entry("보건", new FixedTranslations("Health", "保健", "Sức khỏe")));
+  private static final Map<String, FixedTranslations> SCHEDULE_TEXT_TRANSLATIONS =
+      Map.ofEntries(
+          entry(
+              "3·1절",
+              new FixedTranslations(
+                  "Independence Movement Day", "三一节", "Ngày Phong trào Độc lập 1/3")),
+          entry(
+              "3.1절",
+              new FixedTranslations(
+                  "Independence Movement Day", "三一节", "Ngày Phong trào Độc lập 1/3")),
+          entry(
+              "삼일절",
+              new FixedTranslations(
+                  "Independence Movement Day", "三一节", "Ngày Phong trào Độc lập 1/3")),
+          entry("대체공휴일", new FixedTranslations("Substitute Holiday", "补休假日", "Ngày nghỉ bù")),
+          entry("대체휴일", new FixedTranslations("Substitute Holiday", "补休假日", "Ngày nghỉ bù")),
+          entry("공휴일", new FixedTranslations("Public Holiday", "公休日", "Ngày nghỉ lễ")),
+          entry("어린이날", new FixedTranslations("Children's Day", "儿童节", "Ngày Thiếu nhi")),
+          entry("석가탄신일", new FixedTranslations("Buddha's Birthday", "佛诞节", "Lễ Phật Đản")),
+          entry("부처님오신날", new FixedTranslations("Buddha's Birthday", "佛诞节", "Lễ Phật Đản")),
+          entry("현충일", new FixedTranslations("Memorial Day", "显忠日", "Ngày Tưởng niệm")),
+          entry(
+              "광복절",
+              new FixedTranslations("National Liberation Day", "光复节", "Ngày Giải phóng Quốc gia")),
+          entry("개천절", new FixedTranslations("National Foundation Day", "开天节", "Ngày Lập quốc")),
+          entry("한글날", new FixedTranslations("Hangeul Day", "韩文节", "Ngày Hangeul")),
+          entry("성탄절", new FixedTranslations("Christmas Day", "圣诞节", "Lễ Giáng sinh")),
+          entry("크리스마스", new FixedTranslations("Christmas Day", "圣诞节", "Lễ Giáng sinh")),
+          entry("신정", new FixedTranslations("New Year's Day", "元旦", "Tết Dương lịch")),
+          entry("설날", new FixedTranslations("Lunar New Year", "春节", "Tết Nguyên đán")),
+          entry("추석", new FixedTranslations("Chuseok", "中秋节", "Tết Trung thu")),
+          entry("제헌절", new FixedTranslations("Constitution Day", "制宪节", "Ngày Hiến pháp")),
+          entry("시업식", new FixedTranslations("Opening Ceremony", "开学典礼", "Lễ khai giảng")),
+          entry("입학식", new FixedTranslations("Entrance Ceremony", "入学典礼", "Lễ nhập học")),
+          entry("졸업식", new FixedTranslations("Graduation Ceremony", "毕业典礼", "Lễ tốt nghiệp")),
+          entry("종업식", new FixedTranslations("Closing Ceremony", "结业典礼", "Lễ bế giảng")),
+          entry("방학식", new FixedTranslations("Vacation Ceremony", "放假典礼", "Lễ nghỉ học")),
+          entry("여름방학식", new FixedTranslations("Summer Vacation Ceremony", "暑假典礼", "Lễ nghỉ hè")),
+          entry("겨울방학식", new FixedTranslations("Winter Vacation Ceremony", "寒假典礼", "Lễ nghỉ đông")),
+          entry("봄방학식", new FixedTranslations("Spring Vacation Ceremony", "春假典礼", "Lễ nghỉ xuân")),
+          entry("여름방학", new FixedTranslations("Summer Vacation", "暑假", "Kỳ nghỉ hè")),
+          entry("겨울방학", new FixedTranslations("Winter Vacation", "寒假", "Kỳ nghỉ đông")),
+          entry("봄방학", new FixedTranslations("Spring Vacation", "春假", "Kỳ nghỉ xuân")),
+          entry("개학식", new FixedTranslations("Back-to-School Ceremony", "返校典礼", "Lễ tựu trường")),
+          entry(
+              "개교기념일",
+              new FixedTranslations("School Anniversary", "建校纪念日", "Ngày thành lập trường")),
+          entry(
+              "학교자율휴업일",
+              new FixedTranslations(
+                  "School Discretionary Holiday", "学校自主休业日", "Ngày nghỉ tự chọn của trường")),
+          entry(
+              "재량휴업일",
+              new FixedTranslations(
+                  "School Discretionary Holiday", "学校自主休业日", "Ngày nghỉ tự chọn của trường")),
+          entry("지방선거", new FixedTranslations("Local Elections", "地方选举", "Bầu cử địa phương")),
+          entry(
+              "전국동시지방선거",
+              new FixedTranslations(
+                  "National Local Elections", "全国同时地方选举", "Bầu cử địa phương toàn quốc")),
+          entry("선거일", new FixedTranslations("Election Day", "选举日", "Ngày bầu cử")));
 
   private final UserRepository userRepository;
   private final PapagoTranslateClient papagoTranslateClient;
@@ -44,6 +155,42 @@ class NeisCalendarTranslationService {
         .computeIfAbsent(text, value -> translateOrOriginal(value, context.language()));
   }
 
+  String translateMealName(TranslationContext context, String mealCode, String mealName) {
+    if (context == null || !context.shouldTranslate() || !StringUtils.hasText(mealName)) {
+      return mealName;
+    }
+    MealNameTranslations translations = MEAL_NAME_TRANSLATIONS.get(mealCode);
+    if (translations == null) {
+      translations = MEAL_NAME_TRANSLATIONS.get(mealCodeByName(mealName));
+    }
+    return translations == null
+        ? translate(context, mealName)
+        : translations.get(context.language());
+  }
+
+  String translateNutritionInfo(TranslationContext context, String nutritionInfo) {
+    if (context == null || !context.shouldTranslate() || !StringUtils.hasText(nutritionInfo)) {
+      return nutritionInfo;
+    }
+    String[] lines = nutritionInfo.split("\\R", -1);
+    StringBuilder translated = new StringBuilder();
+    for (int i = 0; i < lines.length; i++) {
+      if (i > 0) {
+        translated.append('\n');
+      }
+      translated.append(translateNutritionLine(context, lines[i]));
+    }
+    return translated.toString();
+  }
+
+  String translateTimetableContent(TranslationContext context, String content) {
+    return translateFixedOrPapago(context, content, TIMETABLE_CONTENT_TRANSLATIONS);
+  }
+
+  String translateScheduleText(TranslationContext context, String text) {
+    return translateFixedOrPapago(context, text, SCHEDULE_TEXT_TRANSLATIONS);
+  }
+
   private String translateOrOriginal(String text, String language) {
     try {
       String translated = papagoTranslateClient.translate(text, language);
@@ -55,9 +202,87 @@ class NeisCalendarTranslationService {
     }
   }
 
+  private String translateNutritionLine(TranslationContext context, String line) {
+    int separatorIndex = line.indexOf(':');
+    if (separatorIndex < 0) {
+      return translate(context, line);
+    }
+    String label = line.substring(0, separatorIndex).trim();
+    String value = line.substring(separatorIndex);
+    String normalizedLabel = label.replaceAll("\\s+", "").replaceAll("\\([^)]*\\)", "");
+    LabelTranslations translations = NUTRITION_LABEL_TRANSLATIONS.get(normalizedLabel);
+    if (translations == null) {
+      return translate(context, line);
+    }
+    String unit = extractUnit(label);
+    return translations.get(context.language()) + unit + value;
+  }
+
+  private String translateFixedOrPapago(
+      TranslationContext context, String text, Map<String, FixedTranslations> translationsByText) {
+    if (context == null || !context.shouldTranslate() || !StringUtils.hasText(text)) {
+      return text;
+    }
+    FixedTranslations translations = translationsByText.get(normalizeKey(text));
+    return translations == null ? translate(context, text) : translations.get(context.language());
+  }
+
+  private String extractUnit(String label) {
+    int start = label.indexOf('(');
+    int end = label.lastIndexOf(')');
+    if (start < 0 || end <= start) {
+      return "";
+    }
+    return " " + label.substring(start, end + 1);
+  }
+
+  private String mealCodeByName(String mealName) {
+    String normalized = normalizeKey(mealName);
+    return switch (normalized) {
+      case "조식" -> "1";
+      case "중식" -> "2";
+      case "석식" -> "3";
+      default -> null;
+    };
+  }
+
+  private String normalizeKey(String value) {
+    return value == null ? "" : value.replaceAll("\\s+", "").trim();
+  }
+
   record TranslationContext(String language, Map<String, String> cache) {
     boolean shouldTranslate() {
       return StringUtils.hasText(language) && !DEFAULT_LANGUAGE.equalsIgnoreCase(language);
+    }
+  }
+
+  private record MealNameTranslations(String us, String zh, String vi) {
+    String get(String language) {
+      return switch (language) {
+        case "ZH" -> zh;
+        case "VI" -> vi;
+        default -> us;
+      };
+    }
+  }
+
+  private record LabelTranslations(String us, String zh, String vi) {
+    String get(String language) {
+      return switch (language) {
+        case "ZH" -> zh;
+        case "VI" -> vi;
+        default -> us;
+      };
+    }
+  }
+
+  private record FixedTranslations(String us, String zh, String vi) {
+    String get(String language) {
+      return switch (language) {
+        case "ZH" -> zh;
+        case "VI" -> vi;
+        default -> us;
+      };
     }
   }
 }

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolMealQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolMealQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.gachi.be.domain.calendar.service.impl;
 
 import com.gachi.be.domain.calendar.dto.response.SchoolMealCalendarResponse;
 import com.gachi.be.domain.calendar.service.SchoolMealQueryService;
+import com.gachi.be.domain.calendar.service.impl.NeisCalendarTranslationService.TranslationContext;
 import com.gachi.be.domain.calendar.service.impl.SchoolScheduleChildReader.SchoolScheduleChild;
 import com.gachi.be.domain.school.client.NeisSchoolMealClient;
 import com.gachi.be.domain.school.dto.response.NeisSchoolMealItem;
@@ -25,6 +26,7 @@ public class SchoolMealQueryServiceImpl implements SchoolMealQueryService {
 
   private final SchoolScheduleChildReader schoolScheduleChildReader;
   private final NeisSchoolMealClient neisSchoolMealClient;
+  private final NeisCalendarTranslationService translationService;
 
   @Override
   public SchoolMealCalendarResponse getSchoolMeals(
@@ -33,6 +35,7 @@ public class SchoolMealQueryServiceImpl implements SchoolMealQueryService {
 
     Map<SchoolIdentity, List<SchoolScheduleChild>> childrenBySchool =
         groupBySchoolIdentity(schoolScheduleChildReader.findChildren(userId));
+    TranslationContext translationContext = translationService.contextFor(userId);
     List<SchoolMealCalendarResponse.SchoolMealGroup> groups = new ArrayList<>();
     for (Map.Entry<SchoolIdentity, List<SchoolScheduleChild>> entry : childrenBySchool.entrySet()) {
       SchoolIdentity identity = entry.getKey();
@@ -40,7 +43,7 @@ public class SchoolMealQueryServiceImpl implements SchoolMealQueryService {
       List<NeisSchoolMealItem> meals =
           neisSchoolMealClient.search(
               identity.officeCode(), identity.schoolCode(), fromDate, toDate);
-      groups.add(toGroup(identity, schoolChildren, meals));
+      groups.add(toGroup(identity, schoolChildren, meals, translationContext));
     }
 
     return new SchoolMealCalendarResponse(groups);
@@ -70,7 +73,10 @@ public class SchoolMealQueryServiceImpl implements SchoolMealQueryService {
   }
 
   private SchoolMealCalendarResponse.SchoolMealGroup toGroup(
-      SchoolIdentity identity, List<SchoolScheduleChild> children, List<NeisSchoolMealItem> meals) {
+      SchoolIdentity identity,
+      List<SchoolScheduleChild> children,
+      List<NeisSchoolMealItem> meals,
+      TranslationContext translationContext) {
     List<Long> childIds = children.stream().map(SchoolScheduleChild::childId).toList();
     List<SchoolMealCalendarResponse.ChildItem> childItems =
         children.stream()
@@ -80,7 +86,7 @@ public class SchoolMealQueryServiceImpl implements SchoolMealQueryService {
                         child.childId(), child.childName(), child.grade(), child.colorCode()))
             .toList();
     List<SchoolMealCalendarResponse.MealItem> mealItems =
-        meals.stream().map(this::toMealItem).toList();
+        meals.stream().map(item -> toMealItem(item, translationContext)).toList();
 
     return new SchoolMealCalendarResponse.SchoolMealGroup(
         identity.groupKey(),
@@ -92,16 +98,17 @@ public class SchoolMealQueryServiceImpl implements SchoolMealQueryService {
         mealItems);
   }
 
-  private SchoolMealCalendarResponse.MealItem toMealItem(NeisSchoolMealItem item) {
+  private SchoolMealCalendarResponse.MealItem toMealItem(
+      NeisSchoolMealItem item, TranslationContext translationContext) {
     return new SchoolMealCalendarResponse.MealItem(
         item.date().format(DateTimeFormatter.ISO_LOCAL_DATE),
         item.mealCode(),
-        item.mealName(),
+        translationService.translate(translationContext, item.mealName()),
         item.mealPeopleCount(),
-        item.dishName(),
-        item.originInfo(),
+        translationService.translate(translationContext, item.dishName()),
+        translationService.translate(translationContext, item.originInfo()),
         item.calorieInfo(),
-        item.nutritionInfo());
+        translationService.translate(translationContext, item.nutritionInfo()));
   }
 
   private record SchoolIdentity(String officeCode, String schoolCode) {

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolMealQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolMealQueryServiceImpl.java
@@ -103,12 +103,12 @@ public class SchoolMealQueryServiceImpl implements SchoolMealQueryService {
     return new SchoolMealCalendarResponse.MealItem(
         item.date().format(DateTimeFormatter.ISO_LOCAL_DATE),
         item.mealCode(),
-        translationService.translate(translationContext, item.mealName()),
+        translationService.translateMealName(translationContext, item.mealCode(), item.mealName()),
         item.mealPeopleCount(),
         translationService.translate(translationContext, item.dishName()),
         translationService.translate(translationContext, item.originInfo()),
         item.calorieInfo(),
-        translationService.translate(translationContext, item.nutritionInfo()));
+        translationService.translateNutritionInfo(translationContext, item.nutritionInfo()));
   }
 
   private record SchoolIdentity(String officeCode, String schoolCode) {

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
@@ -132,8 +132,8 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
     return new SchoolScheduleCalendarResponse.ScheduleItem(
         item.date().format(DateTimeFormatter.ISO_LOCAL_DATE),
         item.academicYear(),
-        translationService.translate(translationContext, item.eventName()),
-        translationService.translate(translationContext, item.eventContent()),
+        translationService.translateScheduleText(translationContext, item.eventName()),
+        translationService.translateScheduleText(translationContext, item.eventContent()),
         new SchoolScheduleCalendarResponse.GradeEventYn(
             gradeEventYn.grade1(),
             gradeEventYn.grade2(),

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.gachi.be.domain.calendar.service.impl;
 
 import com.gachi.be.domain.calendar.dto.response.SchoolScheduleCalendarResponse;
 import com.gachi.be.domain.calendar.service.SchoolScheduleQueryService;
+import com.gachi.be.domain.calendar.service.impl.NeisCalendarTranslationService.TranslationContext;
 import com.gachi.be.domain.calendar.service.impl.SchoolScheduleChildReader.SchoolScheduleChild;
 import com.gachi.be.domain.school.client.NeisSchoolScheduleClient;
 import com.gachi.be.domain.school.dto.response.NeisSchoolScheduleItem;
@@ -32,6 +33,7 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
 
   private final SchoolScheduleChildReader schoolScheduleChildReader;
   private final NeisSchoolScheduleClient neisSchoolScheduleClient;
+  private final NeisCalendarTranslationService translationService;
 
   @Override
   public SchoolScheduleCalendarResponse getSchoolSchedules(
@@ -40,6 +42,7 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
 
     Map<SchoolIdentity, List<SchoolScheduleChild>> childrenBySchool =
         groupBySchoolIdentity(schoolScheduleChildReader.findChildren(userId));
+    TranslationContext translationContext = translationService.contextFor(userId);
     List<SchoolScheduleCalendarResponse.SchoolScheduleGroup> groups = new ArrayList<>();
     Map<ScheduleIdentity, SchoolScheduleCalendarResponse.ScheduleItem> commonHolidays =
         new LinkedHashMap<>();
@@ -55,9 +58,12 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
           continue;
         }
         if (isCommonHoliday(schedule)) {
-          SchoolScheduleCalendarResponse.ScheduleItem scheduleItem = toScheduleItem(schedule);
+          SchoolScheduleCalendarResponse.ScheduleItem scheduleItem =
+              toScheduleItem(schedule, translationContext);
           commonHolidays.putIfAbsent(
-              new ScheduleIdentity(scheduleItem.date(), normalizeText(scheduleItem.eventName())),
+              new ScheduleIdentity(
+                  schedule.date().format(DateTimeFormatter.ISO_LOCAL_DATE),
+                  normalizeText(schedule.eventName())),
               scheduleItem);
           continue;
         }
@@ -65,7 +71,7 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
           schoolSpecificSchedules.add(schedule);
         }
       }
-      groups.add(toGroup(identity, schoolChildren, schoolSpecificSchedules));
+      groups.add(toGroup(identity, schoolChildren, schoolSpecificSchedules, translationContext));
     }
 
     return new SchoolScheduleCalendarResponse(new ArrayList<>(commonHolidays.values()), groups);
@@ -97,7 +103,8 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
   private SchoolScheduleCalendarResponse.SchoolScheduleGroup toGroup(
       SchoolIdentity identity,
       List<SchoolScheduleChild> children,
-      List<NeisSchoolScheduleItem> schedules) {
+      List<NeisSchoolScheduleItem> schedules,
+      TranslationContext translationContext) {
     List<Long> childIds = children.stream().map(SchoolScheduleChild::childId).toList();
     List<SchoolScheduleCalendarResponse.ChildItem> childItems =
         children.stream()
@@ -107,7 +114,7 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
                         child.childId(), child.childName(), child.grade(), child.colorCode()))
             .toList();
     List<SchoolScheduleCalendarResponse.ScheduleItem> scheduleItems =
-        schedules.stream().map(this::toScheduleItem).toList();
+        schedules.stream().map(item -> toScheduleItem(item, translationContext)).toList();
 
     return new SchoolScheduleCalendarResponse.SchoolScheduleGroup(
         identity.groupKey(),
@@ -119,13 +126,14 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
         scheduleItems);
   }
 
-  private SchoolScheduleCalendarResponse.ScheduleItem toScheduleItem(NeisSchoolScheduleItem item) {
+  private SchoolScheduleCalendarResponse.ScheduleItem toScheduleItem(
+      NeisSchoolScheduleItem item, TranslationContext translationContext) {
     NeisSchoolScheduleItem.GradeEventYn gradeEventYn = item.gradeEventYn();
     return new SchoolScheduleCalendarResponse.ScheduleItem(
         item.date().format(DateTimeFormatter.ISO_LOCAL_DATE),
         item.academicYear(),
-        item.eventName(),
-        item.eventContent(),
+        translationService.translate(translationContext, item.eventName()),
+        translationService.translate(translationContext, item.eventContent()),
         new SchoolScheduleCalendarResponse.GradeEventYn(
             gradeEventYn.grade1(),
             gradeEventYn.grade2(),

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImplTest.java
@@ -3,19 +3,23 @@ package com.gachi.be.domain.calendar.service.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.gachi.be.domain.calendar.service.impl.NeisCalendarTranslationService.TranslationContext;
 import com.gachi.be.domain.calendar.service.impl.SchoolScheduleChildReader.SchoolScheduleChild;
 import com.gachi.be.domain.school.client.NeisElementaryTimetableClient;
 import com.gachi.be.domain.school.dto.response.NeisElementaryTimetableItem;
 import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.exception.BusinessException;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ElementaryTimetableQueryServiceImplTest {
@@ -24,9 +28,20 @@ class ElementaryTimetableQueryServiceImplTest {
       mock(SchoolScheduleChildReader.class);
   private final NeisElementaryTimetableClient neisElementaryTimetableClient =
       mock(NeisElementaryTimetableClient.class);
+  private final NeisCalendarTranslationService translationService =
+      mock(NeisCalendarTranslationService.class);
+  private final TranslationContext translationContext =
+      new TranslationContext("KO", new HashMap<>());
   private final ElementaryTimetableQueryServiceImpl service =
       new ElementaryTimetableQueryServiceImpl(
-          schoolScheduleChildReader, neisElementaryTimetableClient);
+          schoolScheduleChildReader, neisElementaryTimetableClient, translationService);
+
+  @BeforeEach
+  void setUpTranslation() {
+    when(translationService.contextFor(10L)).thenReturn(translationContext);
+    when(translationService.translate(eq(translationContext), nullable(String.class)))
+        .thenAnswer(invocation -> invocation.getArgument(1));
+  }
 
   @Test
   void getElementaryTimetablesQueriesDistinctGradesAndClassesPerSchool() {
@@ -65,6 +80,23 @@ class ElementaryTimetableQueryServiceImplTest {
         .search("B10", "7051173", fromDate, toDate, 4, "2");
     verify(neisElementaryTimetableClient, times(1))
         .search("B10", "7051173", fromDate, toDate, 2, "1");
+  }
+
+  @Test
+  void getElementaryTimetablesTranslatesContentByUserLanguage() {
+    TranslationContext englishContext = new TranslationContext("US", new HashMap<>());
+    SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "1", "#22CC88");
+    LocalDate fromDate = LocalDate.of(2026, 3, 1);
+    LocalDate toDate = LocalDate.of(2026, 3, 31);
+    when(translationService.contextFor(20L)).thenReturn(englishContext);
+    when(translationService.translate(englishContext, "수학")).thenReturn("Math");
+    when(schoolScheduleChildReader.findChildren(20L)).thenReturn(List.of(child));
+    when(neisElementaryTimetableClient.search("B10", "7051173", fromDate, toDate, 4, "1"))
+        .thenReturn(List.of(timetable(LocalDate.of(2026, 3, 2), 4, "1", 2, "수학")));
+
+    var response = service.getElementaryTimetables(20L, fromDate, toDate);
+
+    assertThat(response.schoolTimetables().get(0).timetables().get(0).content()).isEqualTo("Math");
   }
 
   @Test

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/ElementaryTimetableQueryServiceImplTest.java
@@ -39,7 +39,8 @@ class ElementaryTimetableQueryServiceImplTest {
   @BeforeEach
   void setUpTranslation() {
     when(translationService.contextFor(10L)).thenReturn(translationContext);
-    when(translationService.translate(eq(translationContext), nullable(String.class)))
+    when(translationService.translateTimetableContent(
+            eq(translationContext), nullable(String.class)))
         .thenAnswer(invocation -> invocation.getArgument(1));
   }
 
@@ -89,7 +90,7 @@ class ElementaryTimetableQueryServiceImplTest {
     LocalDate fromDate = LocalDate.of(2026, 3, 1);
     LocalDate toDate = LocalDate.of(2026, 3, 31);
     when(translationService.contextFor(20L)).thenReturn(englishContext);
-    when(translationService.translate(englishContext, "수학")).thenReturn("Math");
+    when(translationService.translateTimetableContent(englishContext, "수학")).thenReturn("Math");
     when(schoolScheduleChildReader.findChildren(20L)).thenReturn(List.of(child));
     when(neisElementaryTimetableClient.search("B10", "7051173", fromDate, toDate, 4, "1"))
         .thenReturn(List.of(timetable(LocalDate.of(2026, 3, 2), 4, "1", 2, "수학")));

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationServiceTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationServiceTest.java
@@ -57,4 +57,59 @@ class NeisCalendarTranslationServiceTest {
 
     assertThat(service.translate(context, "수학")).isEqualTo("수학");
   }
+
+  @Test
+  void translateMealNameUsesNeisMealCodeToAvoidAmbiguousPapagoTranslation() {
+    User user = mock(User.class);
+    when(user.getLanguageCode()).thenReturn("US");
+    when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+
+    var context = service.contextFor(10L);
+
+    assertThat(service.translateMealName(context, "2", "중식")).isEqualTo("Lunch");
+    verifyNoInteractions(papagoTranslateClient);
+  }
+
+  @Test
+  void translateNutritionInfoUsesFixedLabelsToAvoidWrongContextTranslation() {
+    User user = mock(User.class);
+    when(user.getLanguageCode()).thenReturn("US");
+    when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+
+    var context = service.contextFor(10L);
+
+    assertThat(service.translateNutritionInfo(context, "탄수화물(g): 90.3\n지방(g): 22.6"))
+        .isEqualTo("Carbohydrates (g): 90.3\nFat (g): 22.6");
+    verifyNoInteractions(papagoTranslateClient);
+  }
+
+  @Test
+  void translateTimetableContentUsesFixedSubjectLabelsToAvoidWrongContextTranslation() {
+    User user = mock(User.class);
+    when(user.getLanguageCode()).thenReturn("US");
+    when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+
+    var context = service.contextFor(10L);
+
+    assertThat(service.translateTimetableContent(context, "사회")).isEqualTo("Social Studies");
+    assertThat(service.translateTimetableContent(context, "실과")).isEqualTo("Practical Arts");
+    assertThat(service.translateTimetableContent(context, "자율/자치활동"))
+        .isEqualTo("Autonomous Activities");
+    verifyNoInteractions(papagoTranslateClient);
+  }
+
+  @Test
+  void translateScheduleTextUsesFixedEventLabelsToAvoidWrongContextTranslation() {
+    User user = mock(User.class);
+    when(user.getLanguageCode()).thenReturn("US");
+    when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+
+    var context = service.contextFor(10L);
+
+    assertThat(service.translateScheduleText(context, "3·1절"))
+        .isEqualTo("Independence Movement Day");
+    assertThat(service.translateScheduleText(context, "대체공휴일")).isEqualTo("Substitute Holiday");
+    assertThat(service.translateScheduleText(context, "제헌절")).isEqualTo("Constitution Day");
+    verifyNoInteractions(papagoTranslateClient);
+  }
 }

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationServiceTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationServiceTest.java
@@ -1,0 +1,60 @@
+package com.gachi.be.domain.calendar.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.gachi.be.domain.newsletter.pipeline.PapagoTranslateClient;
+import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class NeisCalendarTranslationServiceTest {
+
+  private final UserRepository userRepository = mock(UserRepository.class);
+  private final PapagoTranslateClient papagoTranslateClient = mock(PapagoTranslateClient.class);
+  private final NeisCalendarTranslationService service =
+      new NeisCalendarTranslationService(userRepository, papagoTranslateClient);
+
+  @Test
+  void translateUsesUserLanguageAndCachesSameText() {
+    User user = mock(User.class);
+    when(user.getLanguageCode()).thenReturn("US");
+    when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+    when(papagoTranslateClient.translate("중식", "US")).thenReturn("Lunch");
+
+    var context = service.contextFor(10L);
+
+    assertThat(service.translate(context, "중식")).isEqualTo("Lunch");
+    assertThat(service.translate(context, "중식")).isEqualTo("Lunch");
+    verify(papagoTranslateClient, times(1)).translate("중식", "US");
+  }
+
+  @Test
+  void translateSkipsPapagoForKoreanUser() {
+    User user = mock(User.class);
+    when(user.getLanguageCode()).thenReturn("KO");
+    when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+
+    var context = service.contextFor(10L);
+
+    assertThat(service.translate(context, "현미밥")).isEqualTo("현미밥");
+    verifyNoInteractions(papagoTranslateClient);
+  }
+
+  @Test
+  void translateFallsBackToOriginalWhenPapagoFails() {
+    User user = mock(User.class);
+    when(user.getLanguageCode()).thenReturn("VI");
+    when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+    when(papagoTranslateClient.translate("수학", "VI")).thenThrow(new RuntimeException("failed"));
+
+    var context = service.contextFor(10L);
+
+    assertThat(service.translate(context, "수학")).isEqualTo("수학");
+  }
+}

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolMealQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolMealQueryServiceImplTest.java
@@ -39,6 +39,11 @@ class SchoolMealQueryServiceImplTest {
     when(translationService.contextFor(10L)).thenReturn(translationContext);
     when(translationService.translate(eq(translationContext), nullable(String.class)))
         .thenAnswer(invocation -> invocation.getArgument(1));
+    when(translationService.translateMealName(
+            eq(translationContext), nullable(String.class), nullable(String.class)))
+        .thenAnswer(invocation -> invocation.getArgument(2));
+    when(translationService.translateNutritionInfo(eq(translationContext), nullable(String.class)))
+        .thenAnswer(invocation -> invocation.getArgument(1));
   }
 
   @Test
@@ -73,8 +78,10 @@ class SchoolMealQueryServiceImplTest {
     LocalDate fromDate = LocalDate.of(2026, 3, 1);
     LocalDate toDate = LocalDate.of(2026, 3, 31);
     when(translationService.contextFor(20L)).thenReturn(englishContext);
-    when(translationService.translate(englishContext, "중식")).thenReturn("Lunch");
+    when(translationService.translateMealName(englishContext, "2", "중식")).thenReturn("Lunch");
     when(translationService.translate(englishContext, "현미밥")).thenReturn("Brown rice");
+    when(translationService.translateNutritionInfo(eq(englishContext), nullable(String.class)))
+        .thenAnswer(invocation -> invocation.getArgument(1));
     when(schoolScheduleChildReader.findChildren(20L)).thenReturn(List.of(child));
     when(neisSchoolMealClient.search("B10", "7051173", fromDate, toDate))
         .thenReturn(List.of(meal(LocalDate.of(2026, 3, 2), "중식", "현미밥")));

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolMealQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolMealQueryServiceImplTest.java
@@ -3,18 +3,22 @@ package com.gachi.be.domain.calendar.service.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.gachi.be.domain.calendar.service.impl.NeisCalendarTranslationService.TranslationContext;
 import com.gachi.be.domain.calendar.service.impl.SchoolScheduleChildReader.SchoolScheduleChild;
 import com.gachi.be.domain.school.client.NeisSchoolMealClient;
 import com.gachi.be.domain.school.dto.response.NeisSchoolMealItem;
 import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.exception.BusinessException;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SchoolMealQueryServiceImplTest {
@@ -22,8 +26,20 @@ class SchoolMealQueryServiceImplTest {
   private final SchoolScheduleChildReader schoolScheduleChildReader =
       mock(SchoolScheduleChildReader.class);
   private final NeisSchoolMealClient neisSchoolMealClient = mock(NeisSchoolMealClient.class);
+  private final NeisCalendarTranslationService translationService =
+      mock(NeisCalendarTranslationService.class);
+  private final TranslationContext translationContext =
+      new TranslationContext("KO", new HashMap<>());
   private final SchoolMealQueryServiceImpl service =
-      new SchoolMealQueryServiceImpl(schoolScheduleChildReader, neisSchoolMealClient);
+      new SchoolMealQueryServiceImpl(
+          schoolScheduleChildReader, neisSchoolMealClient, translationService);
+
+  @BeforeEach
+  void setUpTranslation() {
+    when(translationService.contextFor(10L)).thenReturn(translationContext);
+    when(translationService.translate(eq(translationContext), nullable(String.class)))
+        .thenAnswer(invocation -> invocation.getArgument(1));
+  }
 
   @Test
   void getSchoolMealsGroupsChildrenByOfficeCodeAndSchoolCode() {
@@ -48,6 +64,25 @@ class SchoolMealQueryServiceImplTest {
     assertThat(response.schoolMeals().get(1).schoolGroupKey()).isEqualTo("J10:7611076");
     verify(neisSchoolMealClient, times(1)).search("B10", "7051173", fromDate, toDate);
     verify(neisSchoolMealClient, times(1)).search("J10", "7611076", fromDate, toDate);
+  }
+
+  @Test
+  void getSchoolMealsTranslatesMealTextByUserLanguage() {
+    TranslationContext englishContext = new TranslationContext("US", new HashMap<>());
+    SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "#22CC88");
+    LocalDate fromDate = LocalDate.of(2026, 3, 1);
+    LocalDate toDate = LocalDate.of(2026, 3, 31);
+    when(translationService.contextFor(20L)).thenReturn(englishContext);
+    when(translationService.translate(englishContext, "중식")).thenReturn("Lunch");
+    when(translationService.translate(englishContext, "현미밥")).thenReturn("Brown rice");
+    when(schoolScheduleChildReader.findChildren(20L)).thenReturn(List.of(child));
+    when(neisSchoolMealClient.search("B10", "7051173", fromDate, toDate))
+        .thenReturn(List.of(meal(LocalDate.of(2026, 3, 2), "중식", "현미밥")));
+
+    var response = service.getSchoolMeals(20L, fromDate, toDate);
+
+    assertThat(response.schoolMeals().get(0).meals().get(0).mealName()).isEqualTo("Lunch");
+    assertThat(response.schoolMeals().get(0).meals().get(0).dishName()).isEqualTo("Brown rice");
   }
 
   @Test

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
@@ -39,7 +39,7 @@ class SchoolScheduleQueryServiceImplTest {
   @BeforeEach
   void setUpTranslation() {
     when(translationService.contextFor(10L)).thenReturn(translationContext);
-    when(translationService.translate(eq(translationContext), nullable(String.class)))
+    when(translationService.translateScheduleText(eq(translationContext), nullable(String.class)))
         .thenAnswer(invocation -> invocation.getArgument(1));
   }
 
@@ -94,8 +94,10 @@ class SchoolScheduleQueryServiceImplTest {
     LocalDate fromDate = LocalDate.of(2026, 3, 1);
     LocalDate toDate = LocalDate.of(2026, 5, 31);
     when(translationService.contextFor(20L)).thenReturn(englishContext);
-    when(translationService.translate(englishContext, "대체공휴일")).thenReturn("Substitute holiday");
-    when(translationService.translate(englishContext, "시업식")).thenReturn("Opening ceremony");
+    when(translationService.translateScheduleText(englishContext, "대체공휴일"))
+        .thenReturn("Substitute holiday");
+    when(translationService.translateScheduleText(englishContext, "시업식"))
+        .thenReturn("Opening ceremony");
     when(schoolScheduleChildReader.findChildren(20L)).thenReturn(List.of(child));
     when(neisSchoolScheduleClient.search("B10", "7051173", fromDate, toDate))
         .thenReturn(

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
@@ -4,18 +4,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.gachi.be.domain.calendar.service.impl.NeisCalendarTranslationService.TranslationContext;
 import com.gachi.be.domain.calendar.service.impl.SchoolScheduleChildReader.SchoolScheduleChild;
 import com.gachi.be.domain.school.client.NeisSchoolScheduleClient;
 import com.gachi.be.domain.school.dto.response.NeisSchoolScheduleItem;
 import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.exception.BusinessException;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SchoolScheduleQueryServiceImplTest {
@@ -24,8 +28,20 @@ class SchoolScheduleQueryServiceImplTest {
       mock(SchoolScheduleChildReader.class);
   private final NeisSchoolScheduleClient neisSchoolScheduleClient =
       mock(NeisSchoolScheduleClient.class);
+  private final NeisCalendarTranslationService translationService =
+      mock(NeisCalendarTranslationService.class);
+  private final TranslationContext translationContext =
+      new TranslationContext("KO", new HashMap<>());
   private final SchoolScheduleQueryServiceImpl service =
-      new SchoolScheduleQueryServiceImpl(schoolScheduleChildReader, neisSchoolScheduleClient);
+      new SchoolScheduleQueryServiceImpl(
+          schoolScheduleChildReader, neisSchoolScheduleClient, translationService);
+
+  @BeforeEach
+  void setUpTranslation() {
+    when(translationService.contextFor(10L)).thenReturn(translationContext);
+    when(translationService.translate(eq(translationContext), nullable(String.class)))
+        .thenAnswer(invocation -> invocation.getArgument(1));
+  }
 
   @Test
   void getSchoolSchedulesSeparatesCommonHolidaysAndFiltersByChildGrades() {
@@ -69,6 +85,29 @@ class SchoolScheduleQueryServiceImplTest {
         .extracting("eventName")
         .containsExactly("재량휴업일");
     verify(neisSchoolScheduleClient, times(2)).search(any(), any(), eq(fromDate), eq(toDate));
+  }
+
+  @Test
+  void getSchoolSchedulesTranslatesCommonHolidaysAndSchoolSchedulesByUserLanguage() {
+    TranslationContext englishContext = new TranslationContext("US", new HashMap<>());
+    SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", "7051173", "B10", 4, "#22CC88");
+    LocalDate fromDate = LocalDate.of(2026, 3, 1);
+    LocalDate toDate = LocalDate.of(2026, 5, 31);
+    when(translationService.contextFor(20L)).thenReturn(englishContext);
+    when(translationService.translate(englishContext, "대체공휴일")).thenReturn("Substitute holiday");
+    when(translationService.translate(englishContext, "시업식")).thenReturn("Opening ceremony");
+    when(schoolScheduleChildReader.findChildren(20L)).thenReturn(List.of(child));
+    when(neisSchoolScheduleClient.search("B10", "7051173", fromDate, toDate))
+        .thenReturn(
+            List.of(
+                schedule("대체공휴일", LocalDate.of(2026, 3, 2)),
+                schedule("시업식", LocalDate.of(2026, 3, 3))));
+
+    var response = service.getSchoolSchedules(20L, fromDate, toDate);
+
+    assertThat(response.commonHolidays().get(0).eventName()).isEqualTo("Substitute holiday");
+    assertThat(response.schoolSchedules().get(0).schedules().get(0).eventName())
+        .isEqualTo("Opening ceremony");
   }
 
   @Test


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 사용자 언어 설정에 따라 NEIS 급식표, 초등학교 시간표, 학사일정 응답 데이터를 번역하도록 적용 
  - 급식명/영양정보, 시간표 과목명, 학사일정 공휴일·행사명처럼 파파고에서 문맥상 오역될 수 있는 항목은 고정 번역값으로 보정
- 관련 이슈: closes #132 

## 🌿 브랜치 정보

- **Source**: `feat/#132-neis-response-translation`
- **Target**: `develop`
 
## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

| 급식표 조회 - 사용자 언어 기준 번역 |
| --- |
| ![급식표 번역 응답](https://github.com/user-attachments/assets/7d5c4188-d769-45b0-9953-ac0d7a2b48f0) |

| 초등학교 시간표 조회 - 사용자 언어 기준 번역 |
| --- |
| ![시간표 번역 응답](https://github.com/user-attachments/assets/ec4828cc-f7ec-4b4c-9fd7-3a8b8243a2fc) |

| 학사일정 조회 - 사용자 언어 기준 번역 |
| --- |
| ![학사일정 번역 응답](https://github.com/user-attachments/assets/149d201c-29db-4c3d-94c8-06e6d5a82e6b) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 시간표, 급식, 학사 일정에서 사용자의 언어 설정에 따른 다국어 지원 추가
  * 번역된 콘텐츠 캐싱으로 조회 성능 개선
  * 번역 실패 시 원문 자동 표시로 서비스 안정성 향상

* **Tests**
  * 다국어 번역 및 캐싱 동작 검증 테스트 추가
  * 캘린더 기능 번역 기능 테스트 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->