### PR TITLE
fix: 빈 주간 요약 알림 생성 방지

### DIFF
--- a/src/main/java/com/gachi/be/domain/calendar/repository/CalendarEventRepository.java
+++ b/src/main/java/com/gachi/be/domain/calendar/repository/CalendarEventRepository.java
@@ -58,6 +58,9 @@ public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Lo
   List<CalendarEvent> findByStartAtGreaterThanEqualAndStartAtLessThan(
       OffsetDateTime rangeStart, OffsetDateTime rangeEnd);
 
+  long countByUserIdAndStartAtGreaterThanEqualAndStartAtLessThan(
+      Long userId, OffsetDateTime rangeStart, OffsetDateTime rangeEnd);
+
   /** 특정 가정통신문의 모든 일정 삭제. */
   void deleteByNewsletterIdAndUserId(Long newsletterId, Long userId);
 

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationScheduler.java
@@ -17,6 +17,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -170,16 +171,28 @@ public class NotificationScheduler {
     List<User> users = userRepository.findAllByStatus(UserStatus.ACTIVE);
 
     for (User user : users) {
+      long calendarEventCount =
+          calendarEventRepository.countByUserIdAndStartAtGreaterThanEqualAndStartAtLessThan(
+              user.getId(), rangeStart, rangeEnd);
       long newsletterCount =
           newsletterRepository.countByUserIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
               user.getId(), rangeStart, rangeEnd);
       long incompleteCount =
           checklistRepository.countByUserIdAndTypeAndCompletedFalse(
               user.getId(), ChecklistType.CHECKLIST);
+      if (hasNoWeeklySummaryItems(calendarEventCount, newsletterCount, incompleteCount)) {
+        log.info(
+            "[Scheduler] 주간 요약 대상 항목이 없어 알림 생성을 건너뜁니다. userId={}, rangeStart={}, rangeEnd={}",
+            user.getId(),
+            rangeStartDate,
+            rangeEndDate.minusDays(1));
+        continue;
+      }
 
       Map<String, Object> payload = payload();
       payload.put("rangeStart", rangeStartDate.toString());
       payload.put("rangeEnd", rangeEndDate.minusDays(1).toString());
+      payload.put("calendarEventCount", calendarEventCount);
       payload.put("newsletterCount", newsletterCount);
       payload.put("incompleteChecklistCount", incompleteCount);
 
@@ -188,7 +201,7 @@ public class NotificationScheduler {
           new NotificationCreateCommand(
               NotificationType.WEEKLY_SUMMARY,
               "이번 주 요약이 도착했어요",
-              "이번 주 가정통신문 " + newsletterCount + "개와 미완료 할 일 " + incompleteCount + "개를 확인해보세요",
+              buildWeeklySummaryBody(calendarEventCount, newsletterCount, incompleteCount),
               payload,
               "weekly-summary:" + user.getId() + ":" + rangeStartDate,
               NotificationLevel.NORMAL,
@@ -196,6 +209,26 @@ public class NotificationScheduler {
               null),
           "weekly-summary:" + user.getId());
     }
+  }
+
+  private boolean hasNoWeeklySummaryItems(
+      long calendarEventCount, long newsletterCount, long incompleteCount) {
+    return calendarEventCount == 0 && newsletterCount == 0 && incompleteCount == 0;
+  }
+
+  private String buildWeeklySummaryBody(
+      long calendarEventCount, long newsletterCount, long incompleteCount) {
+    List<String> summaryItems = new ArrayList<>();
+    if (calendarEventCount > 0) {
+      summaryItems.add("일정 " + calendarEventCount + "개");
+    }
+    if (newsletterCount > 0) {
+      summaryItems.add("가정통신문 " + newsletterCount + "개");
+    }
+    if (incompleteCount > 0) {
+      summaryItems.add("미완료 할 일 " + incompleteCount + "개");
+    }
+    return "이번 주 " + String.join(", ", summaryItems) + "를 확인해보세요";
   }
 
   private TimeRange dayRange(LocalDate targetDate) {

--- a/src/test/java/com/gachi/be/domain/notification/service/NotificationSchedulerTest.java
+++ b/src/test/java/com/gachi/be/domain/notification/service/NotificationSchedulerTest.java
@@ -1,0 +1,153 @@
+package com.gachi.be.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gachi.be.domain.calendar.repository.CalendarEventRepository;
+import com.gachi.be.domain.checklist.entity.enums.ChecklistType;
+import com.gachi.be.domain.checklist.repository.ChecklistRepository;
+import com.gachi.be.domain.child.repository.ChildRepository;
+import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
+import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
+import com.gachi.be.domain.notification.entity.enums.NotificationType;
+import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.entity.enums.UserStatus;
+import com.gachi.be.domain.user.repository.UserRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class NotificationSchedulerTest {
+  private static final Clock CLOCK =
+      Clock.fixed(Instant.parse("2026-06-09T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+  private static final LocalDate RANGE_START = LocalDate.of(2026, 6, 1);
+  private static final LocalDate RANGE_END = LocalDate.of(2026, 6, 8);
+
+  private CalendarEventRepository calendarEventRepository;
+  private ChecklistRepository checklistRepository;
+  private NewsletterRepository newsletterRepository;
+  private UserRepository userRepository;
+  private ChildRepository childRepository;
+  private NotificationService notificationService;
+  private NotificationScheduler notificationScheduler;
+
+  @BeforeEach
+  void setUp() {
+    calendarEventRepository = mock(CalendarEventRepository.class);
+    checklistRepository = mock(ChecklistRepository.class);
+    newsletterRepository = mock(NewsletterRepository.class);
+    userRepository = mock(UserRepository.class);
+    childRepository = mock(ChildRepository.class);
+    notificationService = mock(NotificationService.class);
+    notificationScheduler =
+        new NotificationScheduler(
+            calendarEventRepository,
+            checklistRepository,
+            newsletterRepository,
+            userRepository,
+            childRepository,
+            notificationService,
+            CLOCK);
+  }
+
+  @Test
+  void createWeeklySummariesSkipsWhenAllCountsAreZero() {
+    User user = activeUser(1L);
+    when(userRepository.findAllByStatus(UserStatus.ACTIVE)).thenReturn(List.of(user));
+    stubWeeklyCounts(user.getId(), 0L, 0L, 0L);
+
+    notificationScheduler.createWeeklySummaries(RANGE_START, RANGE_END);
+
+    verify(notificationService, never()).createNotification(anyLong(), any());
+  }
+
+  @Test
+  void createWeeklySummariesUsesCalendarCountAndOmitsZeroCountTexts() {
+    User user = activeUser(2L);
+    when(userRepository.findAllByStatus(UserStatus.ACTIVE)).thenReturn(List.of(user));
+    stubWeeklyCounts(user.getId(), 1L, 0L, 0L);
+
+    notificationScheduler.createWeeklySummaries(RANGE_START, RANGE_END);
+
+    ArgumentCaptor<NotificationCreateCommand> commandCaptor =
+        ArgumentCaptor.forClass(NotificationCreateCommand.class);
+    verify(notificationService).createNotification(eq(user.getId()), commandCaptor.capture());
+
+    NotificationCreateCommand command = commandCaptor.getValue();
+    assertThat(command.type()).isEqualTo(NotificationType.WEEKLY_SUMMARY);
+    assertThat(command.level()).isEqualTo(NotificationLevel.NORMAL);
+    assertThat(command.title()).isEqualTo("이번 주 요약이 도착했어요");
+    assertThat(command.body()).isEqualTo("이번 주 일정 1개를 확인해보세요");
+    assertThat(command.body()).doesNotContain("가정통신문 0개");
+    assertThat(command.body()).doesNotContain("미완료 할 일 0개");
+    assertThat(command.payload())
+        .containsEntry("calendarEventCount", 1L)
+        .containsEntry("newsletterCount", 0L)
+        .containsEntry("incompleteChecklistCount", 0L)
+        .containsEntry("rangeStart", "2026-06-01")
+        .containsEntry("rangeEnd", "2026-06-07");
+  }
+
+  @Test
+  void createWeeklySummariesCreatesReadableBodyWithOnlyNonZeroItems() {
+    User user = activeUser(3L);
+    when(userRepository.findAllByStatus(UserStatus.ACTIVE)).thenReturn(List.of(user));
+    stubWeeklyCounts(user.getId(), 0L, 2L, 3L);
+
+    notificationScheduler.createWeeklySummaries(RANGE_START, RANGE_END);
+
+    ArgumentCaptor<NotificationCreateCommand> commandCaptor =
+        ArgumentCaptor.forClass(NotificationCreateCommand.class);
+    verify(notificationService).createNotification(eq(user.getId()), commandCaptor.capture());
+
+    NotificationCreateCommand command = commandCaptor.getValue();
+    assertThat(command.body()).isEqualTo("이번 주 가정통신문 2개, 미완료 할 일 3개를 확인해보세요");
+    assertThat(command.payload())
+        .containsEntry("calendarEventCount", 0L)
+        .containsEntry("newsletterCount", 2L)
+        .containsEntry("incompleteChecklistCount", 3L);
+  }
+
+  private void stubWeeklyCounts(
+      Long userId, long calendarEventCount, long newsletterCount, long incompleteCount) {
+    when(calendarEventRepository.countByUserIdAndStartAtGreaterThanEqualAndStartAtLessThan(
+            eq(userId), any(OffsetDateTime.class), any(OffsetDateTime.class)))
+        .thenReturn(calendarEventCount);
+    when(newsletterRepository.countByUserIdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+            eq(userId), any(OffsetDateTime.class), any(OffsetDateTime.class)))
+        .thenReturn(newsletterCount);
+    when(checklistRepository.countByUserIdAndTypeAndCompletedFalse(userId, ChecklistType.CHECKLIST))
+        .thenReturn(incompleteCount);
+  }
+
+  private User activeUser(Long id) {
+    OffsetDateTime now = OffsetDateTime.now(CLOCK);
+    User user =
+        User.builder()
+            .email("weekly" + id + "@example.com")
+            .loginId("weekly" + id)
+            .passwordHash("encoded")
+            .name("주간요약사용자" + id)
+            .phoneNumber("0100000" + id)
+            .status(UserStatus.ACTIVE)
+            .consentAgreedAt(now)
+            .consentVersion("2026-04-v1")
+            .passwordUpdatedAt(now)
+            .build();
+    ReflectionTestUtils.setField(user, "id", id);
+    return user;
+  }
+}


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 주간 요약 대상 항목이 모두 0개인 경우 알림을 생성하지 않도록 수정
  - 주간 요약 기준에 일정 수를 포함하고, payload에 `calendarEventCount` 추가
  - 주간 요약 문구에서 0개 항목은 제외되도록 개선
  - 빈 주간 요약 미생성 및 주간 요약 문구 생성 단위 테스트 추가 
- 관련 이슈: closes #134 

## 🌿 브랜치 정보

- **Source**: `bugfix/#134-weekly-summary-empty-notification`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

- `./gradlew.bat --no-daemon spotlessApply test --tests com.gachi.be.domain.notification.service.NotificationSchedulerTest`
  - 성공
- `./gradlew.bat --no-daemon spotlessCheck`
  - 성공

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 주간 요약 알림을 더욱 스마트하게 구성했습니다. 빈 항목은 알림 본문에 포함하지 않으며, 관련 콘텐츠가 없을 때는 불필요한 알림 생성을 방지합니다.

* **테스트**
  * 주간 요약 알림 생성 로직의 정확성을 검증하는 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->