### PR TITLE
feat: 학사일정 공휴일 및 방학 필터링 보완

### DIFF
--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationService.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationService.java
@@ -108,7 +108,10 @@ class NeisCalendarTranslationService {
           entry("여름방학", new FixedTranslations("Summer Vacation", "暑假", "Kỳ nghỉ hè")),
           entry("겨울방학", new FixedTranslations("Winter Vacation", "寒假", "Kỳ nghỉ đông")),
           entry("봄방학", new FixedTranslations("Spring Vacation", "春假", "Kỳ nghỉ xuân")),
-          entry("개학식", new FixedTranslations("Back-to-School Ceremony", "返校典礼", "Lễ tựu trường")),
+          entry(
+              "개학식", new FixedTranslations("Opening Ceremony of School", "返校典礼", "Lễ tựu trường")),
+          entry(
+              "개학일", new FixedTranslations("Opening Ceremony of School", "返校日", "Ngày tựu trường")),
           entry(
               "개교기념일",
               new FixedTranslations("School Anniversary", "建校纪念日", "Ngày thành lập trường")),

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationService.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationService.java
@@ -108,10 +108,8 @@ class NeisCalendarTranslationService {
           entry("여름방학", new FixedTranslations("Summer Vacation", "暑假", "Kỳ nghỉ hè")),
           entry("겨울방학", new FixedTranslations("Winter Vacation", "寒假", "Kỳ nghỉ đông")),
           entry("봄방학", new FixedTranslations("Spring Vacation", "春假", "Kỳ nghỉ xuân")),
-          entry(
-              "개학식", new FixedTranslations("Opening Ceremony of School", "返校典礼", "Lễ tựu trường")),
-          entry(
-              "개학일", new FixedTranslations("Opening Ceremony of School", "返校日", "Ngày tựu trường")),
+          entry("개학식", new FixedTranslations("School Opening Ceremony", "返校典礼", "Lễ tựu trường")),
+          entry("개학일", new FixedTranslations("First Day of School", "返校日", "Ngày tựu trường")),
           entry(
               "개교기념일",
               new FixedTranslations("School Anniversary", "建校纪念日", "Ngày thành lập trường")),

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
@@ -47,10 +47,8 @@ public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryServic
           "설날",
           "추석",
           "제헌절",
-          "지방선거",
-          "지방선거일",
-          "전국동시지방선거",
-          "전국동시지방선거일");
+          // 단독 "선거일"은 학교 선거 일정과 충돌할 수 있어 지방선거 표현만 공통 휴일로 본다.
+          "지방선거");
 
   private final SchoolScheduleChildReader schoolScheduleChildReader;
   private final NeisSchoolScheduleClient neisSchoolScheduleClient;

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImpl.java
@@ -25,11 +25,32 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class SchoolScheduleQueryServiceImpl implements SchoolScheduleQueryService {
   private static final long MAX_SCHOOL_SCHEDULE_RANGE_DAYS = 366L;
-  private static final Set<String> EXCLUDED_EVENT_NAMES = Set.of("토요휴업일", "토요공휴일", "토요휴무일");
+  private static final Set<String> EXCLUDED_EVENT_NAMES =
+      Set.of("토요휴업일", "토요공휴일", "토요휴무일", "여름방학", "겨울방학", "봄방학");
   private static final Set<String> COMMON_HOLIDAY_KEYWORDS =
       Set.of(
-          "공휴일", "대체공휴일", "대체휴일", "어린이날", "삼일절", "3·1절", "3.1절", "현충일", "광복절", "개천절", "한글날", "성탄절",
-          "석가탄신일", "부처님오신날", "신정", "설날", "추석");
+          "공휴일",
+          "대체공휴일",
+          "대체휴일",
+          "어린이날",
+          "삼일절",
+          "3·1절",
+          "3.1절",
+          "현충일",
+          "광복절",
+          "개천절",
+          "한글날",
+          "성탄절",
+          "석가탄신일",
+          "부처님오신날",
+          "신정",
+          "설날",
+          "추석",
+          "제헌절",
+          "지방선거",
+          "지방선거일",
+          "전국동시지방선거",
+          "전국동시지방선거일");
 
   private final SchoolScheduleChildReader schoolScheduleChildReader;
   private final NeisSchoolScheduleClient neisSchoolScheduleClient;

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationServiceTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationServiceTest.java
@@ -110,6 +110,8 @@ class NeisCalendarTranslationServiceTest {
         .isEqualTo("Independence Movement Day");
     assertThat(service.translateScheduleText(context, "대체공휴일")).isEqualTo("Substitute Holiday");
     assertThat(service.translateScheduleText(context, "제헌절")).isEqualTo("Constitution Day");
+    assertThat(service.translateScheduleText(context, "개학일"))
+        .isEqualTo("Opening Ceremony of School");
     verifyNoInteractions(papagoTranslateClient);
   }
 }

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationServiceTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/NeisCalendarTranslationServiceTest.java
@@ -110,8 +110,8 @@ class NeisCalendarTranslationServiceTest {
         .isEqualTo("Independence Movement Day");
     assertThat(service.translateScheduleText(context, "대체공휴일")).isEqualTo("Substitute Holiday");
     assertThat(service.translateScheduleText(context, "제헌절")).isEqualTo("Constitution Day");
-    assertThat(service.translateScheduleText(context, "개학일"))
-        .isEqualTo("Opening Ceremony of School");
+    assertThat(service.translateScheduleText(context, "개학식")).isEqualTo("School Opening Ceremony");
+    assertThat(service.translateScheduleText(context, "개학일")).isEqualTo("First Day of School");
     verifyNoInteractions(papagoTranslateClient);
   }
 }

--- a/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
+++ b/src/test/java/com/gachi/be/domain/calendar/service/impl/SchoolScheduleQueryServiceImplTest.java
@@ -113,6 +113,30 @@ class SchoolScheduleQueryServiceImplTest {
   }
 
   @Test
+  void getSchoolSchedulesSeparatesElectionAndConstitutionDayAndExcludesVacationRanges() {
+    SchoolScheduleChild child = child(1L, "첫째", "서울미아초등학교", "7121303", "B10", 1, "#FFCC2F");
+    LocalDate fromDate = LocalDate.of(2026, 6, 1);
+    LocalDate toDate = LocalDate.of(2026, 8, 31);
+    when(schoolScheduleChildReader.findChildren(10L)).thenReturn(List.of(child));
+    when(neisSchoolScheduleClient.search("B10", "7121303", fromDate, toDate))
+        .thenReturn(
+            List.of(
+                schedule("지방 선거일", LocalDate.of(2026, 6, 3)),
+                schedule("제헌절", LocalDate.of(2026, 7, 17)),
+                schedule("여름방학식", LocalDate.of(2026, 7, 24)),
+                schedule("여름방학", LocalDate.of(2026, 7, 27)),
+                schedule("겨울방학", LocalDate.of(2026, 8, 1)),
+                schedule("개학일", LocalDate.of(2026, 8, 24))));
+
+    var response = service.getSchoolSchedules(10L, fromDate, toDate);
+
+    assertThat(response.commonHolidays()).extracting("eventName").containsExactly("지방 선거일", "제헌절");
+    assertThat(response.schoolSchedules().get(0).schedules())
+        .extracting("eventName")
+        .containsExactly("여름방학식", "개학일");
+  }
+
+  @Test
   void getSchoolSchedulesThrowsWhenChildSchoolIdentityIsMissing() {
     SchoolScheduleChild child = child(1L, "첫째", "화랑초등학교", null, "B10", 4, "#22CC88");
     when(schoolScheduleChildReader.findChildren(10L)).thenReturn(List.of(child));


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - NEIS 학사일정 조회 시 `지방 선거일`, `제헌절`이 공통 휴일로 분리되도록 공휴일 판정 기준을 보완
  - 캘린더에 점이 과도하게 표시되는 `여름방학`, `겨울방학`, `봄방학` 기간 일정은 제외하고, `여름방학식`, `개학일/개학식`처럼 표시가 필요한 일정은 유지하도록 처리 
- 관련 이슈: closes #138 

## 🌿 브랜치 정보

- **Source**: `feat/#138-school-schedule-holiday-vacation-filter`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

| 학사일정 조회 - 방학 기간 일정 제외 |
| --- |
| ![학사일정 필터링 응답](https://github.com/user-attachments/assets/94b54150-0a0e-4ac1-a3ea-86073c03d622) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 학사 일정 번역 항목 확대 - "개학일" 등 추가 일정 번역 지원
  * 공휴일 인식 범위 확장 - 어린이날, 3·1절, 현충일, 광복절, 개천절, 한글날, 성탄절 등 주요 한국 공휴일 및 지방선거일 자동 인식 강화

* **개선 사항**
  * 방학 기간과 개학일 등 학사 일정의 정확한 분류 및 필터링 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->