### PR TITLE
feat: AI 분석 응답의 체크리스트 배열 매핑 구조 반영

### DIFF
--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
@@ -17,6 +17,8 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -148,7 +150,9 @@ public class AiNewsletterClient {
 
     AnalysisResponse normalized() {
       List<ExtractedItem> normalizedItems =
-          items != null ? items.stream().map(ExtractedItem::normalized).toList() : List.of();
+          items != null
+              ? items.stream().filter(Objects::nonNull).map(ExtractedItem::normalized).toList()
+                            : List.of();
       return new AnalysisResponse(
           title,
           summary,
@@ -183,6 +187,10 @@ public class AiNewsletterClient {
       List<ChecklistItemDto> checklistItems) {
 
     ExtractedItem normalized() {
+       List<ChecklistItemDto> normalizedChecklistItems =
+           checklistItems != null
+               ? checklistItems.stream().filter(Objects::nonNull).toList()
+               : List.of();
       return new ExtractedItem(
           type,
           title,
@@ -194,7 +202,7 @@ public class AiNewsletterClient {
           confidence,
           needsUserConfirmation,
           confirmationQuestion,
-          checklistItems != null ? checklistItems : List.of());
+          normalizedChecklistItems);
     }
   }
 }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
@@ -147,6 +147,8 @@ public class AiNewsletterClient {
       Map<String, Object> meta) {
 
     AnalysisResponse normalized() {
+      List<ExtractedItem> normalizedItems =
+          items != null ? items.stream().map(ExtractedItem::normalized).toList() : List.of();
       return new AnalysisResponse(
           title,
           summary,
@@ -164,6 +166,9 @@ public class AiNewsletterClient {
       Integer index, String candidateId, String originalText, LocalDate normalizedDate) {}
 
   @JsonIgnoreProperties(ignoreUnknown = true)
+  public record ChecklistItemDto(String content, String detail) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public record ExtractedItem(
       String type,
       String title,
@@ -174,5 +179,22 @@ public class AiNewsletterClient {
       String dateStatus,
       Double confidence,
       Boolean needsUserConfirmation,
-      String confirmationQuestion) {}
+      String confirmationQuestion,
+      List<ChecklistItemDto> checklistItems) {
+
+      ExtractedItem normalized() {
+          return new ExtractedItem(
+              type,
+              title,
+              selectedDateCandidate,
+              datetime,
+              timezone,
+              evidenceText,
+              dateStatus,
+              confidence,
+              needsUserConfirmation,
+              confirmationQuestion,
+              checklistItems != null ? checklistItems : List.of());
+      }
+  }
 }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
@@ -152,7 +152,7 @@ public class AiNewsletterClient {
       return new AnalysisResponse(
           title,
           summary,
-          items != null ? items : List.of(),
+          normalizedItems,
           conversationTopics != null ? conversationTopics : List.of(),
           meta);
     }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -152,7 +151,7 @@ public class AiNewsletterClient {
       List<ExtractedItem> normalizedItems =
           items != null
               ? items.stream().filter(Objects::nonNull).map(ExtractedItem::normalized).toList()
-                            : List.of();
+              : List.of();
       return new AnalysisResponse(
           title,
           summary,
@@ -187,10 +186,10 @@ public class AiNewsletterClient {
       List<ChecklistItemDto> checklistItems) {
 
     ExtractedItem normalized() {
-       List<ChecklistItemDto> normalizedChecklistItems =
-           checklistItems != null
-               ? checklistItems.stream().filter(Objects::nonNull).toList()
-               : List.of();
+      List<ChecklistItemDto> normalizedChecklistItems =
+          checklistItems != null
+              ? checklistItems.stream().filter(Objects::nonNull).toList()
+              : List.of();
       return new ExtractedItem(
           type,
           title,

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
@@ -182,19 +182,19 @@ public class AiNewsletterClient {
       String confirmationQuestion,
       List<ChecklistItemDto> checklistItems) {
 
-      ExtractedItem normalized() {
-          return new ExtractedItem(
-              type,
-              title,
-              selectedDateCandidate,
-              datetime,
-              timezone,
-              evidenceText,
-              dateStatus,
-              confidence,
-              needsUserConfirmation,
-              confirmationQuestion,
-              checklistItems != null ? checklistItems : List.of());
-      }
+    ExtractedItem normalized() {
+      return new ExtractedItem(
+          type,
+          title,
+          selectedDateCandidate,
+          datetime,
+          timezone,
+          evidenceText,
+          dateStatus,
+          confidence,
+          needsUserConfirmation,
+          confirmationQuestion,
+          checklistItems != null ? checklistItems : List.of());
+    }
   }
 }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -235,10 +235,6 @@ public class NewsletterAiAnalyzer {
     return targetDate != null ? targetDate.toString() : null;
   }
 
-  private List<Long> checklistIdList(Checklist checklist) {
-    return checklist.getId() != null ? List.of(checklist.getId()) : List.of();
-  }
-
   private String normalizeTitle(String aiTitle, String originalText) {
     if (aiTitle != null && !aiTitle.isBlank()) {
       return trimToMax(compact(aiTitle), TITLE_MAX_LENGTH);

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -12,8 +12,8 @@ import com.gachi.be.domain.newsletter.repository.ConversationTopicRepository;
 import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -75,69 +75,83 @@ public class NewsletterAiAnalyzer {
 
   private List<SavedExtractedItem> saveExtractedItems(
       Long newsletterId, Long userId, List<ExtractedItem> items, String language) {
-    if (items == null || items.isEmpty()) {
-      log.warn("[AiAnalyzer] AI 서버 항목 추출 결과 없음. newsletterId={}", newsletterId);
-      return List.of();
-    }
+      if (items == null || items.isEmpty()) {
+          log.warn("[AiAnalyzer] AI 서버 항목 추출 결과 없음. newsletterId={}", newsletterId);
+          return List.of();
+      }
 
-    List<ExtractedItem> validItems =
-        items.stream().filter(item -> item.title() != null && !item.title().isBlank()).toList();
-    List<Checklist> entities =
-        validItems.stream().map(item -> toChecklist(newsletterId, userId, item, language)).toList();
+      List<Checklist> entitiesToSave = new ArrayList<>();
+      List<Integer> ownerItemIndex = new ArrayList<>();
 
-    if (entities.isEmpty()) {
-      log.warn("[AiAnalyzer] 저장 가능한 항목 없음. newsletterId={}", newsletterId);
-      return List.of();
-    }
+      for (int itemIndex = 0; itemIndex < items.size(); itemIndex++) {
+          ExtractedItem item = items.get(itemIndex);
+          if (item.checklistItems() == null || item.checklistItems().isEmpty()) {
+              continue;
+          }
+          for (AiNewsletterClient.ChecklistItemDto checklistItem : item.checklistItems()) {
+              if (checklistItem.content() == null || checklistItem.content().isBlank()) {
+                  continue; // 빈 content는 저장하지 않음
+              }
+              entitiesToSave.add(toChecklist(newsletterId, userId, checklistItem, language));
+              ownerItemIndex.add(itemIndex);
+          }
+      }
 
-    List<Checklist> savedEntities = checklistRepository.saveAll(entities);
-    log.debug("[AiAnalyzer] AI 서버 추출 항목 {}개 저장 완료.", entities.size());
+      List<Checklist> savedEntities =
+          entitiesToSave.isEmpty() ? List.of() : checklistRepository.saveAll(entitiesToSave);
+      if (!savedEntities.isEmpty()) {
+          log.debug("[AiAnalyzer] AI 서버 추출 체크리스트 {}개 저장 완료.", savedEntities.size());
+      }
 
-    List<SavedExtractedItem> savedItems = new ArrayList<>();
-    for (int i = 0; i < validItems.size(); i++) {
-      savedItems.add(new SavedExtractedItem(validItems.get(i), savedEntities.get(i)));
-    }
-    return savedItems;
+      Map<Integer, List<Checklist>> checklistsByItemIndex = new LinkedHashMap<>();
+      for (int i = 0; i < savedEntities.size(); i++) {
+          checklistsByItemIndex
+              .computeIfAbsent(ownerItemIndex.get(i), k -> new ArrayList<>())
+              .add(savedEntities.get(i));
+      }
+
+      List<SavedExtractedItem> result = new ArrayList<>();
+      for (int itemIndex = 0; itemIndex < items.size(); itemIndex++) {
+          ExtractedItem item = items.get(itemIndex);
+          if (item.title() == null || item.title().isBlank()) {
+              // 제목 없는 일정은 캘린더 preview 대상에서 제외 (체크리스트는 이미 저장됨)
+              continue;
+          }
+          List<Checklist> linkedChecklists =
+              checklistsByItemIndex.getOrDefault(itemIndex, List.of());
+          result.add(new SavedExtractedItem(item, linkedChecklists));
+      }
+      return result;
   }
 
   private Checklist toChecklist(
-      Long newsletterId, Long userId, ExtractedItem item, String language) {
-    ChecklistType checklistType =
-        "checklist".equalsIgnoreCase(item.type()) ? ChecklistType.CHECKLIST : ChecklistType.TODO;
+      Long newsletterId, Long userId, AiNewsletterClient.ChecklistItemDto checklistItem, String language) {
 
-    LocalDate targetDate = parseTargetDate(item.datetime());
+      // content: AI 서버가 한국어로 추출한 항목명을 파파고로 번역
+      String content =
+          translateIfNeeded(
+              trimToMax(checklistItem.content().trim(), CHECKLIST_TEXT_MAX_LENGTH),
+              language,
+              "content",
+              newsletterId);
 
-    String targetDateLabel = null;
-    if (targetDate != null) {
-      String koreanLabel = targetDate.getMonthValue() + "월 " + targetDate.getDayOfMonth() + "일";
-      targetDateLabel = translateIfNeeded(koreanLabel, language, "targetDateLabel", newsletterId);
-    }
+      // detail: AI 서버가 한국어로 추출한 상세 설명을 파파고로 번역
+      String detail = null;
+      if (checklistItem.detail() != null && !checklistItem.detail().isBlank()) {
+          String trimmedDetail = trimNullable(checklistItem.detail(), CHECKLIST_TEXT_MAX_LENGTH);
+          detail = translateIfNeeded(trimmedDetail, language, "detail", newsletterId);
+      }
 
-    // content: AI 서버가 한국어로 추출한 항목명을 파파고로 번역
-    String content =
-        translateIfNeeded(
-            trimToMax(item.title().trim(), CHECKLIST_TEXT_MAX_LENGTH),
-            language,
-            "content",
-            newsletterId);
-
-    // detail: AI 서버가 한국어로 추출한 상세 설명을 파파고로 번역
-    String detail = null;
-    if (item.evidenceText() != null && !item.evidenceText().isBlank()) {
-      String trimmedDetail = trimNullable(item.evidenceText(), CHECKLIST_TEXT_MAX_LENGTH);
-      detail = translateIfNeeded(trimmedDetail, language, "detail", newsletterId);
-    }
-
-    return Checklist.builder()
-        .newsletterId(newsletterId)
-        .calendarEventId(null)
-        .userId(userId)
-        .type(checklistType)
-        .content(content)
-        .detail(detail)
-        .targetDate(checklistType == ChecklistType.TODO ? targetDate : null)
-        .targetDateLabel(checklistType == ChecklistType.TODO ? targetDateLabel : null)
-        .build();
+      return Checklist.builder()
+          .newsletterId(newsletterId)
+          .calendarEventId(null) // 캘린더 등록 시점에 연결됨 (linkChecklistsToEvents)
+          .userId(userId)
+          .type(ChecklistType.CHECKLIST) // v7: CHECKLIST만 사용
+          .content(content)
+          .detail(detail)
+          .targetDate(null) // v7: 체크리스트는 날짜를 갖지 않음 (일정의 날짜를 따라감)
+          .targetDateLabel(null)
+          .build();
   }
 
   /** KO가 아닌 경우 파파고로 번역. KO이거나 번역 실패 시 원문 그대로 반환. */
@@ -186,30 +200,30 @@ public class NewsletterAiAnalyzer {
   }
 
   private void saveCalendarPreview(Long newsletterId, List<SavedExtractedItem> savedItems) {
-    List<CalendarPreviewEvent> previewEvents = new ArrayList<>();
+      List<CalendarPreviewEvent> previewEvents = new ArrayList<>();
 
-    for (SavedExtractedItem savedItem : savedItems) {
-      ExtractedItem item = savedItem.item();
-      String extractedDate = normalizePreviewDate(item.datetime());
-      if (!"confirmed".equalsIgnoreCase(item.dateStatus()) || extractedDate == null) {
-        continue;
+      for (SavedExtractedItem savedItem : savedItems) {
+          ExtractedItem item = savedItem.item();
+          String extractedDate = normalizePreviewDate(item.datetime());
+          if (!"confirmed".equalsIgnoreCase(item.dateStatus()) || extractedDate == null) {
+              continue;
+          }
+
+          previewEvents.add(
+              new CalendarPreviewEvent(
+                  "ai_evt_" + (previewEvents.size() + 1),
+                  trimToMax(item.title().trim(), CHECKLIST_TEXT_MAX_LENGTH),
+                  extractedDate,
+                  true,
+                  checklistIdList(savedItem.checklists())));
       }
 
-      previewEvents.add(
-          new CalendarPreviewEvent(
-              "ai_evt_" + (previewEvents.size() + 1),
-              trimToMax(item.title().trim(), CHECKLIST_TEXT_MAX_LENGTH),
-              extractedDate,
-              true,
-              checklistIdList(savedItem.checklist())));
-    }
-
-    if (previewEvents.isEmpty()) {
-      // 재분석 결과에 확정 날짜가 없으면 이전 미리보기 데이터가 남아 잘못 등록될 수 있어 비운다.
-      calendarPreviewRedisService.deletePreview(newsletterId);
-      log.debug("[AiAnalyzer] 캘린더 preview 생성 대상 없음. newsletterId={}", newsletterId);
-      return;
-    }
+      if (previewEvents.isEmpty()) {
+          // 재분석 결과에 확정 날짜가 없으면 이전 미리보기 데이터가 남아 잘못 등록될 수 있어 비운다.
+          calendarPreviewRedisService.deletePreview(newsletterId);
+          log.debug("[AiAnalyzer] 캘린더 preview 생성 대상 없음. newsletterId={}", newsletterId);
+          return;
+      }
 
     calendarPreviewRedisService.savePreview(newsletterId, previewEvents);
     log.debug(
@@ -230,6 +244,16 @@ public class NewsletterAiAnalyzer {
       return trimToMax(compact(aiTitle), TITLE_MAX_LENGTH);
     }
     return inferTitle(originalText);
+  }
+
+  private List<Long> checklistIdList(List<Checklist> checklists) {
+      if (checklists == null || checklists.isEmpty()) {
+          return List.of();
+      }
+      return checklists.stream()
+          .map(Checklist::getId)
+          .filter(Objects::nonNull)
+          .toList();
   }
 
   private String normalizeSummary(String aiSummary, String translatedText, String originalText) {
@@ -282,7 +306,7 @@ public class NewsletterAiAnalyzer {
     return value.substring(0, maxLength - 3).stripTrailing() + "...";
   }
 
-  private record SavedExtractedItem(ExtractedItem item, Checklist checklist) {}
+  private record SavedExtractedItem(ExtractedItem item, List<Checklist> checklists) {}
 
   public record AiAnalysisResult(String title, String summary) {}
 

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -96,17 +96,16 @@ public class NewsletterAiAnalyzer {
       }
     }
 
-    List<Checklist> savedEntities =
-        entitiesToSave.isEmpty() ? List.of() : checklistRepository.saveAll(entitiesToSave);
-    if (!savedEntities.isEmpty()) {
-      log.debug("[AiAnalyzer] AI 서버 추출 체크리스트 {}개 저장 완료.", savedEntities.size());
+    if (!entitiesToSave.isEmpty()) {
+        checklistRepository.saveAll(entitiesToSave);
+        log.debug("[AiAnalyzer] AI 서버 추출 체크리스트 {}개 저장 완료.", entitiesToSave.size());
     }
 
     Map<Integer, List<Checklist>> checklistsByItemIndex = new LinkedHashMap<>();
-    for (int i = 0; i < savedEntities.size(); i++) {
+    for (int i = 0; i < entitiesToSave.size(); i++) {
       checklistsByItemIndex
           .computeIfAbsent(ownerItemIndex.get(i), k -> new ArrayList<>())
-          .add(savedEntities.get(i));
+          .add(entitiesToSave.get(i));
     }
 
     List<SavedExtractedItem> result = new ArrayList<>();

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -13,7 +13,6 @@ import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.*;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -75,83 +74,85 @@ public class NewsletterAiAnalyzer {
 
   private List<SavedExtractedItem> saveExtractedItems(
       Long newsletterId, Long userId, List<ExtractedItem> items, String language) {
-      if (items == null || items.isEmpty()) {
-          log.warn("[AiAnalyzer] AI 서버 항목 추출 결과 없음. newsletterId={}", newsletterId);
-          return List.of();
-      }
+    if (items == null || items.isEmpty()) {
+      log.warn("[AiAnalyzer] AI 서버 항목 추출 결과 없음. newsletterId={}", newsletterId);
+      return List.of();
+    }
 
-      List<Checklist> entitiesToSave = new ArrayList<>();
-      List<Integer> ownerItemIndex = new ArrayList<>();
+    List<Checklist> entitiesToSave = new ArrayList<>();
+    List<Integer> ownerItemIndex = new ArrayList<>();
 
-      for (int itemIndex = 0; itemIndex < items.size(); itemIndex++) {
-          ExtractedItem item = items.get(itemIndex);
-          if (item.checklistItems() == null || item.checklistItems().isEmpty()) {
-              continue;
-          }
-          for (AiNewsletterClient.ChecklistItemDto checklistItem : item.checklistItems()) {
-              if (checklistItem.content() == null || checklistItem.content().isBlank()) {
-                  continue; // 빈 content는 저장하지 않음
-              }
-              entitiesToSave.add(toChecklist(newsletterId, userId, checklistItem, language));
-              ownerItemIndex.add(itemIndex);
-          }
+    for (int itemIndex = 0; itemIndex < items.size(); itemIndex++) {
+      ExtractedItem item = items.get(itemIndex);
+      if (item.checklistItems() == null || item.checklistItems().isEmpty()) {
+        continue;
       }
+      for (AiNewsletterClient.ChecklistItemDto checklistItem : item.checklistItems()) {
+        if (checklistItem.content() == null || checklistItem.content().isBlank()) {
+          continue; // 빈 content는 저장하지 않음
+        }
+        entitiesToSave.add(toChecklist(newsletterId, userId, checklistItem, language));
+        ownerItemIndex.add(itemIndex);
+      }
+    }
 
-      List<Checklist> savedEntities =
-          entitiesToSave.isEmpty() ? List.of() : checklistRepository.saveAll(entitiesToSave);
-      if (!savedEntities.isEmpty()) {
-          log.debug("[AiAnalyzer] AI 서버 추출 체크리스트 {}개 저장 완료.", savedEntities.size());
-      }
+    List<Checklist> savedEntities =
+        entitiesToSave.isEmpty() ? List.of() : checklistRepository.saveAll(entitiesToSave);
+    if (!savedEntities.isEmpty()) {
+      log.debug("[AiAnalyzer] AI 서버 추출 체크리스트 {}개 저장 완료.", savedEntities.size());
+    }
 
-      Map<Integer, List<Checklist>> checklistsByItemIndex = new LinkedHashMap<>();
-      for (int i = 0; i < savedEntities.size(); i++) {
-          checklistsByItemIndex
-              .computeIfAbsent(ownerItemIndex.get(i), k -> new ArrayList<>())
-              .add(savedEntities.get(i));
-      }
+    Map<Integer, List<Checklist>> checklistsByItemIndex = new LinkedHashMap<>();
+    for (int i = 0; i < savedEntities.size(); i++) {
+      checklistsByItemIndex
+          .computeIfAbsent(ownerItemIndex.get(i), k -> new ArrayList<>())
+          .add(savedEntities.get(i));
+    }
 
-      List<SavedExtractedItem> result = new ArrayList<>();
-      for (int itemIndex = 0; itemIndex < items.size(); itemIndex++) {
-          ExtractedItem item = items.get(itemIndex);
-          if (item.title() == null || item.title().isBlank()) {
-              // 제목 없는 일정은 캘린더 preview 대상에서 제외 (체크리스트는 이미 저장됨)
-              continue;
-          }
-          List<Checklist> linkedChecklists =
-              checklistsByItemIndex.getOrDefault(itemIndex, List.of());
-          result.add(new SavedExtractedItem(item, linkedChecklists));
+    List<SavedExtractedItem> result = new ArrayList<>();
+    for (int itemIndex = 0; itemIndex < items.size(); itemIndex++) {
+      ExtractedItem item = items.get(itemIndex);
+      if (item.title() == null || item.title().isBlank()) {
+        // 제목 없는 일정은 캘린더 preview 대상에서 제외 (체크리스트는 이미 저장됨)
+        continue;
       }
-      return result;
+      List<Checklist> linkedChecklists = checklistsByItemIndex.getOrDefault(itemIndex, List.of());
+      result.add(new SavedExtractedItem(item, linkedChecklists));
+    }
+    return result;
   }
 
   private Checklist toChecklist(
-      Long newsletterId, Long userId, AiNewsletterClient.ChecklistItemDto checklistItem, String language) {
+      Long newsletterId,
+      Long userId,
+      AiNewsletterClient.ChecklistItemDto checklistItem,
+      String language) {
 
-      // content: AI 서버가 한국어로 추출한 항목명을 파파고로 번역
-      String content =
-          translateIfNeeded(
-              trimToMax(checklistItem.content().trim(), CHECKLIST_TEXT_MAX_LENGTH),
-              language,
-              "content",
-              newsletterId);
+    // content: AI 서버가 한국어로 추출한 항목명을 파파고로 번역
+    String content =
+        translateIfNeeded(
+            trimToMax(checklistItem.content().trim(), CHECKLIST_TEXT_MAX_LENGTH),
+            language,
+            "content",
+            newsletterId);
 
-      // detail: AI 서버가 한국어로 추출한 상세 설명을 파파고로 번역
-      String detail = null;
-      if (checklistItem.detail() != null && !checklistItem.detail().isBlank()) {
-          String trimmedDetail = trimNullable(checklistItem.detail(), CHECKLIST_TEXT_MAX_LENGTH);
-          detail = translateIfNeeded(trimmedDetail, language, "detail", newsletterId);
-      }
+    // detail: AI 서버가 한국어로 추출한 상세 설명을 파파고로 번역
+    String detail = null;
+    if (checklistItem.detail() != null && !checklistItem.detail().isBlank()) {
+      String trimmedDetail = trimNullable(checklistItem.detail(), CHECKLIST_TEXT_MAX_LENGTH);
+      detail = translateIfNeeded(trimmedDetail, language, "detail", newsletterId);
+    }
 
-      return Checklist.builder()
-          .newsletterId(newsletterId)
-          .calendarEventId(null) // 캘린더 등록 시점에 연결됨 (linkChecklistsToEvents)
-          .userId(userId)
-          .type(ChecklistType.CHECKLIST) // v7: CHECKLIST만 사용
-          .content(content)
-          .detail(detail)
-          .targetDate(null) // v7: 체크리스트는 날짜를 갖지 않음 (일정의 날짜를 따라감)
-          .targetDateLabel(null)
-          .build();
+    return Checklist.builder()
+        .newsletterId(newsletterId)
+        .calendarEventId(null) // 캘린더 등록 시점에 연결됨 (linkChecklistsToEvents)
+        .userId(userId)
+        .type(ChecklistType.CHECKLIST) // v7: CHECKLIST만 사용
+        .content(content)
+        .detail(detail)
+        .targetDate(null) // v7: 체크리스트는 날짜를 갖지 않음 (일정의 날짜를 따라감)
+        .targetDateLabel(null)
+        .build();
   }
 
   /** KO가 아닌 경우 파파고로 번역. KO이거나 번역 실패 시 원문 그대로 반환. */
@@ -200,30 +201,30 @@ public class NewsletterAiAnalyzer {
   }
 
   private void saveCalendarPreview(Long newsletterId, List<SavedExtractedItem> savedItems) {
-      List<CalendarPreviewEvent> previewEvents = new ArrayList<>();
+    List<CalendarPreviewEvent> previewEvents = new ArrayList<>();
 
-      for (SavedExtractedItem savedItem : savedItems) {
-          ExtractedItem item = savedItem.item();
-          String extractedDate = normalizePreviewDate(item.datetime());
-          if (!"confirmed".equalsIgnoreCase(item.dateStatus()) || extractedDate == null) {
-              continue;
-          }
-
-          previewEvents.add(
-              new CalendarPreviewEvent(
-                  "ai_evt_" + (previewEvents.size() + 1),
-                  trimToMax(item.title().trim(), CHECKLIST_TEXT_MAX_LENGTH),
-                  extractedDate,
-                  true,
-                  checklistIdList(savedItem.checklists())));
+    for (SavedExtractedItem savedItem : savedItems) {
+      ExtractedItem item = savedItem.item();
+      String extractedDate = normalizePreviewDate(item.datetime());
+      if (!"confirmed".equalsIgnoreCase(item.dateStatus()) || extractedDate == null) {
+        continue;
       }
 
-      if (previewEvents.isEmpty()) {
-          // 재분석 결과에 확정 날짜가 없으면 이전 미리보기 데이터가 남아 잘못 등록될 수 있어 비운다.
-          calendarPreviewRedisService.deletePreview(newsletterId);
-          log.debug("[AiAnalyzer] 캘린더 preview 생성 대상 없음. newsletterId={}", newsletterId);
-          return;
-      }
+      previewEvents.add(
+          new CalendarPreviewEvent(
+              "ai_evt_" + (previewEvents.size() + 1),
+              trimToMax(item.title().trim(), CHECKLIST_TEXT_MAX_LENGTH),
+              extractedDate,
+              true,
+              checklistIdList(savedItem.checklists())));
+    }
+
+    if (previewEvents.isEmpty()) {
+      // 재분석 결과에 확정 날짜가 없으면 이전 미리보기 데이터가 남아 잘못 등록될 수 있어 비운다.
+      calendarPreviewRedisService.deletePreview(newsletterId);
+      log.debug("[AiAnalyzer] 캘린더 preview 생성 대상 없음. newsletterId={}", newsletterId);
+      return;
+    }
 
     calendarPreviewRedisService.savePreview(newsletterId, previewEvents);
     log.debug(
@@ -243,13 +244,10 @@ public class NewsletterAiAnalyzer {
   }
 
   private List<Long> checklistIdList(List<Checklist> checklists) {
-      if (checklists == null || checklists.isEmpty()) {
-          return List.of();
-      }
-      return checklists.stream()
-          .map(Checklist::getId)
-          .filter(Objects::nonNull)
-          .toList();
+    if (checklists == null || checklists.isEmpty()) {
+      return List.of();
+    }
+    return checklists.stream().map(Checklist::getId).filter(Objects::nonNull).toList();
   }
 
   private String normalizeSummary(String aiSummary, String translatedText, String originalText) {

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -97,8 +97,8 @@ public class NewsletterAiAnalyzer {
     }
 
     if (!entitiesToSave.isEmpty()) {
-        checklistRepository.saveAll(entitiesToSave);
-        log.debug("[AiAnalyzer] AI 서버 추출 체크리스트 {}개 저장 완료.", entitiesToSave.size());
+      checklistRepository.saveAll(entitiesToSave);
+      log.debug("[AiAnalyzer] AI 서버 추출 체크리스트 {}개 저장 완료.", entitiesToSave.size());
     }
 
     Map<Integer, List<Checklist>> checklistsByItemIndex = new LinkedHashMap<>();

--- a/src/test/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClientTest.java
+++ b/src/test/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClientTest.java
@@ -48,26 +48,27 @@ class AiNewsletterClientTest {
 
           byte[] response =
               """
-              {
-                "title": "AI 제목",
-                "summary": "AI 요약",
-                "items": [
-                  {
-                    "type": "checklist",
-                    "title": "동의서 제출",
-                    "selectedDateCandidate": null,
-                    "datetime": "2026-05-25",
-                    "timezone": "Asia/Seoul",
-                    "evidenceText": "5월 25일까지 동의서를 제출해 주세요.",
-                    "dateStatus": "confirmed",
-                    "confidence": 0.9,
-                    "needsUserConfirmation": false,
-                    "confirmationQuestion": null
-                  }
-                ],
-                "meta": {"mode": "test"}
-              }
-              """
+                {
+                  "title": "AI 제목",
+                  "summary": "AI 요약",
+                  "items": [
+                    {
+                      "type": "reminder",
+                      "title": "동의서 제출",
+                      "selectedDateCandidate": null,
+                      "datetime": "2026-05-25",
+                      "timezone": "Asia/Seoul",
+                      "evidenceText": "5월 25일까지 동의서를 제출해 주세요.",
+                      "dateStatus": "confirmed",
+                      "confidence": 0.9,
+                      "needsUserConfirmation": false,
+                      "confirmationQuestion": null,
+                      "checklistItems": []
+                    }
+                  ],
+                  "meta": {"mode": "test"}
+                }
+                """
                   .getBytes(StandardCharsets.UTF_8);
           sendResponse(exchange, 200, response);
         });

--- a/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzerTest.java
+++ b/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzerTest.java
@@ -18,7 +18,6 @@ import com.gachi.be.domain.newsletter.pipeline.AiNewsletterClient.ExtractedItem;
 import com.gachi.be.domain.newsletter.pipeline.NewsletterAiAnalyzer.AiAnalysisResult;
 import com.gachi.be.domain.newsletter.repository.ConversationTopicRepository;
 import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -68,7 +67,8 @@ class NewsletterAiAnalyzerTest {
             "confirmed",
             0.91,
             false,
-            null);
+            null,
+            List.of(new AiNewsletterClient.ChecklistItemDto("준비물 확인", "체육복을 준비해 주세요.")));
 
     when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
     when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
@@ -94,9 +94,8 @@ class NewsletterAiAnalyzerTest {
     assertThat(savedItems.get(0).getUserId()).isEqualTo(20L);
     assertThat(savedItems.get(0).getContent()).isEqualTo("준비물 확인");
     assertThat(savedItems.get(0).getDetail()).isEqualTo("체육복을 준비해 주세요.");
-    assertThat(savedItems.get(0).getTargetDate()).isEqualTo(LocalDate.parse("2026-05-25"));
-    assertThat(savedItems.get(0).getTargetDateLabel()).isEqualTo("5월 25일");
-
+    assertThat(savedItems.get(0).getTargetDate()).isNull();
+    assertThat(savedItems.get(0).getTargetDateLabel()).isNull();
     verify(calendarPreviewRedisService)
         .savePreview(eq(newsletterId), previewEventsCaptor.capture());
     List<CalendarPreviewEvent> previewEvents = previewEventsCaptor.getValue();
@@ -131,14 +130,12 @@ class NewsletterAiAnalyzerTest {
             "ambiguous",
             0.7,
             true,
-            "체험학습 날짜를 확인해 주세요.");
+            "체험학습 날짜를 확인해 주세요.",
+            List.of());
 
     when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
     when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
         .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(item), List.of(), Map.of()));
-    when(checklistRepository.saveAll(anyList()))
-        .thenAnswer(invocation -> invocation.getArgument(0));
-
     newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
 
     verify(calendarPreviewRedisService).deletePreview(newsletterId);
@@ -167,7 +164,8 @@ class NewsletterAiAnalyzerTest {
             "confirmed",
             0.9,
             false,
-            null);
+            null,
+            List.of(new AiNewsletterClient.ChecklistItemDto("도시락 준비하기", "현장학습 당일 도시락을 준비해 주세요.")));
 
     when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
     when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - AI 분석 응답의 `items[].checklistItems[]` 구조를 지원하도록 응답 DTO 변경
  - null item과 null checklistItems를 빈 목록으로 정규화
  - 모든 일정의 checklistItems를 순회해 체크리스트 테이블에 저장
  - content가 비어 있는 체크리스트는 저장 대상에서 제외
  - 일정별로 저장된 체크리스트 ID 목록을 구성
  - 날짜가 확정된 일정의 캘린더 미리보기에 해당 checklistIds 연결
  - 체크리스트는 CHECKLIST 타입으로 저장하고 일정 날짜는 캘린더 이벤트를 따르도록 변경
  - 배열 매핑 및 빈 목록 처리 테스트 보완
- 관련 이슈: closes #146 

## 🌿 브랜치 정보

- **Source**: `feat/#146-checklist-mapping`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

- 하나의 일정에 여러 checklistItems가 포함된 AI 응답의 저장 및 캘린더 미리보기 매핑 결과 확인
<img width="1329" height="722" alt="image" src="https://github.com/user-attachments/assets/289a8f50-b95a-45af-b2f9-25d9add2c2e0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 뉴스레터 AI 분석 시 추출된 항목당 여러 개의 체크리스트 항목 지원 추가
  * 체크리스트 항목에 내용(content)과 상세 정보(detail) 필드 추가로 더욱 상세한 정보 제공 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->