### PR TITLE
feat: 알림 다국어 템플릿 렌더링 적용

### DIFF
--- a/src/main/java/com/gachi/be/domain/calendar/dto/CalendarPreviewEvent.java
+++ b/src/main/java/com/gachi/be/domain/calendar/dto/CalendarPreviewEvent.java
@@ -2,6 +2,7 @@ package com.gachi.be.domain.calendar.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
+import java.util.Map;
 
 /** Redis에 저장되고 조회되는 캘린더 일정 미리보기 단건 DTO. */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -12,6 +13,9 @@ public record CalendarPreviewEvent(
     /** 일정 제목. AI가 추출하거나 사용자가 수정한 값. */
     String title,
 
+    /** 알림 렌더링용 일정 제목 다국어 map. 사용자가 제목을 직접 수정하면 기존 title을 우선한다. */
+    Map<String, String> titleI18n,
+
     /** AI가 추출한 날짜(+시간). ISO 8601 형식. */
     String extractedDate,
 
@@ -19,4 +23,14 @@ public record CalendarPreviewEvent(
     boolean isDateExtracted,
 
     // 이 일정에 속하는 체크리스트 ID 목록
-    List<Long> checklistIds) {}
+    List<Long> checklistIds) {
+
+  public CalendarPreviewEvent(
+      String tempEventId,
+      String title,
+      String extractedDate,
+      boolean isDateExtracted,
+      List<Long> checklistIds) {
+    this(tempEventId, title, Map.of(), extractedDate, isDateExtracted, checklistIds);
+  }
+}

--- a/src/main/java/com/gachi/be/domain/calendar/entity/CalendarEvent.java
+++ b/src/main/java/com/gachi/be/domain/calendar/entity/CalendarEvent.java
@@ -9,10 +9,14 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 /** 캘린더 일정 엔티티. */
 @Getter
@@ -40,6 +44,10 @@ public class CalendarEvent {
   @Column(nullable = false, length = 200)
   private String title;
 
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "title_i18n", columnDefinition = "jsonb")
+  private Map<String, String> titleI18n = new LinkedHashMap<>();
+
   @Column(columnDefinition = "TEXT")
   private String description;
 
@@ -65,6 +73,7 @@ public class CalendarEvent {
       String childName,
       String childColor,
       String title,
+      Map<String, String> titleI18n,
       String description,
       String externalKey,
       OffsetDateTime startAt,
@@ -74,6 +83,7 @@ public class CalendarEvent {
     this.childName = childName;
     this.childColor = childColor;
     this.title = title;
+    this.titleI18n = titleI18n == null ? new LinkedHashMap<>() : new LinkedHashMap<>(titleI18n);
     this.description = description;
     this.externalKey = externalKey;
     this.startAt = startAt;
@@ -84,6 +94,7 @@ public class CalendarEvent {
   protected void onCreate() {
     OffsetDateTime now = OffsetDateTime.now();
     if (createdAt == null) createdAt = now;
+    if (titleI18n == null) titleI18n = new LinkedHashMap<>();
     updatedAt = now;
   }
 

--- a/src/main/java/com/gachi/be/domain/calendar/service/impl/CalendarRegisterServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/calendar/service/impl/CalendarRegisterServiceImpl.java
@@ -112,6 +112,7 @@ public class CalendarRegisterServiceImpl implements CalendarRegisterService {
                     return new CalendarPreviewEvent(
                         event.tempEventId(),
                         event.title(),
+                        event.titleI18n(),
                         correctedDate,
                         true,
                         event.checklistIds());
@@ -135,6 +136,13 @@ public class CalendarRegisterServiceImpl implements CalendarRegisterService {
     Newsletter newsletter = findNewsletterAndValidateOwner(userId, newsletterId);
 
     List<CalendarEvent> savedEvents = new ArrayList<>();
+
+    List<CalendarPreviewEvent> previewEvents = previewRedisService.getPreview(newsletterId);
+    Map<String, CalendarPreviewEvent> previewByTempId =
+        previewEvents == null
+            ? Map.of()
+            : previewEvents.stream()
+                .collect(Collectors.toMap(CalendarPreviewEvent::tempEventId, e -> e, (a, b) -> a));
 
     // 일정 등록
     for (CalendarRegisterRequest.EventRegister eventReq : request.events()) {
@@ -168,6 +176,8 @@ public class CalendarRegisterServiceImpl implements CalendarRegisterService {
                       ? newsletter.getChildColor()
                       : DEFAULT_CHILD_COLOR)
               .title(eventReq.title())
+              .titleI18n(
+                  resolveCalendarTitleI18n(eventReq, previewByTempId.get(eventReq.tempEventId())))
               .externalKey(externalKey)
               .startAt(startAt)
               .endAt(endAt)
@@ -184,7 +194,6 @@ public class CalendarRegisterServiceImpl implements CalendarRegisterService {
 
     // preview 목록 기반으로 체크리스트를 각 일정에 정확하게 연결
     if (!savedEvents.isEmpty()) {
-      List<CalendarPreviewEvent> previewEvents = previewRedisService.getPreview(newsletterId);
       if (previewEvents != null) {
         linkChecklistsToEvents(newsletterId, savedEvents, previewEvents);
       }
@@ -201,6 +210,18 @@ public class CalendarRegisterServiceImpl implements CalendarRegisterService {
         count);
 
     return new CalendarRegisterResponse(count);
+  }
+
+  private Map<String, String> resolveCalendarTitleI18n(
+      CalendarRegisterRequest.EventRegister eventReq, CalendarPreviewEvent preview) {
+    if (preview == null || preview.titleI18n() == null || preview.titleI18n().isEmpty()) {
+      return Map.of();
+    }
+    // 사용자가 preview 제목을 수정했다면 AI가 만든 다국어 제목은 더 이상 같은 의미라고 보장할 수 없습니다.
+    if (!eventReq.title().equals(preview.title())) {
+      return Map.of();
+    }
+    return preview.titleI18n();
   }
 
   /** CHECKLIST 타입 항목들을 등록된 캘린더 일정에 연결. */

--- a/src/main/java/com/gachi/be/domain/checklist/entity/Checklist.java
+++ b/src/main/java/com/gachi/be/domain/checklist/entity/Checklist.java
@@ -13,10 +13,14 @@ import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 /** 체크리스트/해야할일 통합 엔티티 */
 @Getter
@@ -45,6 +49,10 @@ public class Checklist {
   @Column(nullable = false, length = 500)
   private String content;
 
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "content_i18n", columnDefinition = "jsonb")
+  private Map<String, String> contentI18n = new LinkedHashMap<>();
+
   @Column(length = 500)
   private String detail;
 
@@ -70,6 +78,7 @@ public class Checklist {
       Long userId,
       ChecklistType type,
       String content,
+      Map<String, String> contentI18n,
       String detail,
       LocalDate targetDate,
       String targetDateLabel) {
@@ -77,6 +86,8 @@ public class Checklist {
     this.userId = userId;
     this.type = type;
     this.content = content;
+    this.contentI18n =
+        contentI18n == null ? new LinkedHashMap<>() : new LinkedHashMap<>(contentI18n);
     this.detail = detail;
     this.targetDate = targetDate;
     this.targetDateLabel = targetDateLabel;
@@ -87,6 +98,7 @@ public class Checklist {
   protected void onCreate() {
     OffsetDateTime now = OffsetDateTime.now();
     if (createdAt == null) createdAt = now;
+    if (contentI18n == null) contentI18n = new LinkedHashMap<>();
     updatedAt = now;
   }
 

--- a/src/main/java/com/gachi/be/domain/newsletter/entity/Newsletter.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/entity/Newsletter.java
@@ -13,7 +13,9 @@ import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -69,6 +71,10 @@ public class Newsletter {
   @Column(name = "title", length = 255)
   private String title;
 
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "title_i18n", columnDefinition = "jsonb")
+  private Map<String, String> titleI18n = new LinkedHashMap<>();
+
   @Column(name = "summary", columnDefinition = "TEXT")
   private String summary;
 
@@ -120,12 +126,14 @@ public class Newsletter {
     if (status == null) status = NewsletterStatus.PENDING;
     if (language == null) language = "KO";
     if (dateCandidates == null) dateCandidates = new ArrayList<>();
+    if (titleI18n == null) titleI18n = new LinkedHashMap<>();
   }
 
   @PreUpdate
   protected void onUpdate() {
     updatedAt = OffsetDateTime.now();
     if (dateCandidates == null) dateCandidates = new ArrayList<>();
+    if (titleI18n == null) titleI18n = new LinkedHashMap<>();
   }
 
   /** AI 분석 시작 시 PROCESSING 상태로 전환합니다. */
@@ -138,10 +146,22 @@ public class Newsletter {
   /** AI 분석 결과를 저장하고 COMPLETED 상태로 전환합니다. */
   public void complete(
       String ocrText, String originalText, String translatedText, String title, String summary) {
+    complete(ocrText, originalText, translatedText, title, null, summary);
+  }
+
+  /** AI 분석 결과와 알림 렌더링용 다국어 제목을 저장하고 COMPLETED 상태로 전환합니다. */
+  public void complete(
+      String ocrText,
+      String originalText,
+      String translatedText,
+      String title,
+      Map<String, String> titleI18n,
+      String summary) {
     this.ocrText = ocrText;
     this.originalText = originalText;
     this.translatedText = translatedText;
     this.title = title;
+    this.titleI18n = titleI18n == null ? new LinkedHashMap<>() : new LinkedHashMap<>(titleI18n);
     this.summary = summary;
     this.status = NewsletterStatus.COMPLETED;
     this.failureStage = null;
@@ -174,6 +194,7 @@ public class Newsletter {
     this.failureStage = null;
     this.failureReason = null;
     this.title = null;
+    this.titleI18n = new LinkedHashMap<>();
     this.summary = null;
   }
 

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
@@ -142,10 +142,20 @@ public class AiNewsletterClient {
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record AnalysisResponse(
       String title,
+      Map<String, String> titleI18n,
       String summary,
       List<ExtractedItem> items,
       List<ConversationTopicItem> conversationTopics,
       Map<String, Object> meta) {
+
+    public AnalysisResponse(
+        String title,
+        String summary,
+        List<ExtractedItem> items,
+        List<ConversationTopicItem> conversationTopics,
+        Map<String, Object> meta) {
+      this(title, Map.of(), summary, items, conversationTopics, meta);
+    }
 
     AnalysisResponse normalized() {
       List<ExtractedItem> normalizedItems =
@@ -154,6 +164,7 @@ public class AiNewsletterClient {
               : List.of();
       return new AnalysisResponse(
           title,
+          titleI18n != null ? titleI18n : Map.of(),
           summary,
           normalizedItems,
           conversationTopics != null ? conversationTopics : List.of(),
@@ -169,12 +180,21 @@ public class AiNewsletterClient {
       Integer index, String candidateId, String originalText, LocalDate normalizedDate) {}
 
   @JsonIgnoreProperties(ignoreUnknown = true)
-  public record ChecklistItemDto(String content, String detail) {}
+  public record ChecklistItemDto(String content, Map<String, String> contentI18n, String detail) {
+    public ChecklistItemDto(String content, String detail) {
+      this(content, Map.of(), detail);
+    }
+
+    ChecklistItemDto normalized() {
+      return new ChecklistItemDto(content, contentI18n != null ? contentI18n : Map.of(), detail);
+    }
+  }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record ExtractedItem(
       String type,
       String title,
+      Map<String, String> titleI18n,
       SelectedDateCandidate selectedDateCandidate,
       String datetime,
       String timezone,
@@ -185,14 +205,45 @@ public class AiNewsletterClient {
       String confirmationQuestion,
       List<ChecklistItemDto> checklistItems) {
 
+    public ExtractedItem(
+        String type,
+        String title,
+        SelectedDateCandidate selectedDateCandidate,
+        String datetime,
+        String timezone,
+        String evidenceText,
+        String dateStatus,
+        Double confidence,
+        Boolean needsUserConfirmation,
+        String confirmationQuestion,
+        List<ChecklistItemDto> checklistItems) {
+      this(
+          type,
+          title,
+          Map.of(),
+          selectedDateCandidate,
+          datetime,
+          timezone,
+          evidenceText,
+          dateStatus,
+          confidence,
+          needsUserConfirmation,
+          confirmationQuestion,
+          checklistItems);
+    }
+
     ExtractedItem normalized() {
       List<ChecklistItemDto> normalizedChecklistItems =
           checklistItems != null
-              ? checklistItems.stream().filter(Objects::nonNull).toList()
+              ? checklistItems.stream()
+                  .filter(Objects::nonNull)
+                  .map(ChecklistItemDto::normalized)
+                  .toList()
               : List.of();
       return new ExtractedItem(
           type,
           title,
+          titleI18n != null ? titleI18n : Map.of(),
           selectedDateCandidate,
           datetime,
           timezone,

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -31,7 +31,6 @@ public class NewsletterAiAnalyzer {
   private final ChecklistRepository checklistRepository;
   private final CalendarPreviewRedisService calendarPreviewRedisService;
   private final NewsletterRepository newsletterRepository;
-  private final PapagoTranslateClient papagoTranslateClient;
   private final ConversationTopicRepository conversationTopicRepository;
 
   public AiAnalysisResult analyze(
@@ -62,14 +61,13 @@ public class NewsletterAiAnalyzer {
     }
 
     saveConversationTopics(
-        newsletterId, newsletter.getUserId(), analysisResponse.conversationTopics(), language);
+        newsletterId, newsletter.getUserId(), analysisResponse.conversationTopics());
     String rawTitle = normalizeTitle(analysisResponse.title(), originalText);
-    String title = translateIfNeeded(rawTitle, language, "title", newsletterId);
     String summary = normalizeSummary(analysisResponse.summary(), translatedText, originalText);
 
     log.info(
         "[AiAnalyzer] AI 서버 분석 완료. newsletterId={}, extractedItems={}", newsletterId, items.size());
-    return new AiAnalysisResult(title, summary);
+    return new AiAnalysisResult(rawTitle, analysisResponse.titleI18n(), summary);
   }
 
   private List<SavedExtractedItem> saveExtractedItems(
@@ -91,7 +89,7 @@ public class NewsletterAiAnalyzer {
         if (checklistItem.content() == null || checklistItem.content().isBlank()) {
           continue; // 빈 content는 저장하지 않음
         }
-        entitiesToSave.add(toChecklist(newsletterId, userId, checklistItem, language));
+        entitiesToSave.add(toChecklist(newsletterId, userId, checklistItem));
         ownerItemIndex.add(itemIndex);
       }
     }
@@ -122,24 +120,12 @@ public class NewsletterAiAnalyzer {
   }
 
   private Checklist toChecklist(
-      Long newsletterId,
-      Long userId,
-      AiNewsletterClient.ChecklistItemDto checklistItem,
-      String language) {
+      Long newsletterId, Long userId, AiNewsletterClient.ChecklistItemDto checklistItem) {
+    String content = trimToMax(checklistItem.content().trim(), CHECKLIST_TEXT_MAX_LENGTH);
 
-    // content: AI 서버가 한국어로 추출한 항목명을 파파고로 번역
-    String content =
-        translateIfNeeded(
-            trimToMax(checklistItem.content().trim(), CHECKLIST_TEXT_MAX_LENGTH),
-            language,
-            "content",
-            newsletterId);
-
-    // detail: AI 서버가 한국어로 추출한 상세 설명을 파파고로 번역
     String detail = null;
     if (checklistItem.detail() != null && !checklistItem.detail().isBlank()) {
-      String trimmedDetail = trimNullable(checklistItem.detail(), CHECKLIST_TEXT_MAX_LENGTH);
-      detail = translateIfNeeded(trimmedDetail, language, "detail", newsletterId);
+      detail = trimNullable(checklistItem.detail(), CHECKLIST_TEXT_MAX_LENGTH);
     }
 
     return Checklist.builder()
@@ -148,42 +134,11 @@ public class NewsletterAiAnalyzer {
         .userId(userId)
         .type(ChecklistType.CHECKLIST) // v7: CHECKLIST만 사용
         .content(content)
+        .contentI18n(trimI18nValues(checklistItem.contentI18n(), CHECKLIST_TEXT_MAX_LENGTH))
         .detail(detail)
         .targetDate(null) // v7: 체크리스트는 날짜를 갖지 않음 (일정의 날짜를 따라감)
         .targetDateLabel(null)
         .build();
-  }
-
-  /** KO가 아닌 경우 파파고로 번역. KO이거나 번역 실패 시 원문 그대로 반환. */
-  private String translateIfNeeded(
-      String text, String language, String fieldName, Long newsletterId) {
-    if (text == null || text.isBlank()) {
-      return text;
-    }
-    if ("KO".equals(language)) {
-      // KO는 번역 스킵, 원문 그대로 반환
-      return text;
-    }
-    try {
-      String translated = papagoTranslateClient.translate(text, language);
-      if (translated != null && !translated.isBlank()) {
-        log.debug(
-            "[AiAnalyzer] {} 번역 완료. newsletterId={}, language={}",
-            fieldName,
-            newsletterId,
-            language);
-        return translated;
-      }
-    } catch (Exception e) {
-      // 번역 실패 시 원문 유지 (파이프라인 전체를 중단하지 않음)
-      log.warn(
-          "[AiAnalyzer] {} 번역 실패. 원문 유지. newsletterId={}, language={}, error={}",
-          fieldName,
-          newsletterId,
-          language,
-          e.getMessage());
-    }
-    return text;
   }
 
   private LocalDate parseTargetDate(String value) {
@@ -213,6 +168,7 @@ public class NewsletterAiAnalyzer {
           new CalendarPreviewEvent(
               "ai_evt_" + (previewEvents.size() + 1),
               trimToMax(item.title().trim(), CHECKLIST_TEXT_MAX_LENGTH),
+              trimI18nValues(item.titleI18n(), CHECKLIST_TEXT_MAX_LENGTH),
               extractedDate,
               true,
               checklistIdList(savedItem.checklists())));
@@ -301,13 +257,10 @@ public class NewsletterAiAnalyzer {
 
   private record SavedExtractedItem(ExtractedItem item, List<Checklist> checklists) {}
 
-  public record AiAnalysisResult(String title, String summary) {}
+  public record AiAnalysisResult(String title, Map<String, String> titleI18n, String summary) {}
 
   private void saveConversationTopics(
-      Long newsletterId,
-      Long userId,
-      List<AiNewsletterClient.ConversationTopicItem> topicItems,
-      String language) {
+      Long newsletterId, Long userId, List<AiNewsletterClient.ConversationTopicItem> topicItems) {
 
     if (topicItems == null || topicItems.isEmpty()) {
       log.debug("[AiAnalyzer] 대화 주제 없음. newsletterId={}", newsletterId);
@@ -319,14 +272,10 @@ public class NewsletterAiAnalyzer {
             .filter(item -> item.topic() != null && !item.topic().isBlank())
             .map(
                 item -> {
-                  // AI 서버가 한국어로 반환 → 파파고로 번역 (KO이면 원문 유지)
-                  String translated =
-                      translateIfNeeded(
-                          item.topic().trim(), language, "conversationTopic", newsletterId);
                   return com.gachi.be.domain.newsletter.entity.ConversationTopic.builder()
                       .newsletterId(newsletterId)
                       .userId(userId)
-                      .topic(translated)
+                      .topic(item.topic().trim())
                       .build();
                 })
             .toList();
@@ -335,5 +284,19 @@ public class NewsletterAiAnalyzer {
       conversationTopicRepository.saveAll(entities);
       log.debug("[AiAnalyzer] 대화 주제 {}개 저장 완료. newsletterId={}", entities.size(), newsletterId);
     }
+  }
+
+  private Map<String, String> trimI18nValues(Map<String, String> values, int maxLength) {
+    if (values == null || values.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, String> result = new LinkedHashMap<>();
+    values.forEach(
+        (language, value) -> {
+          if (language != null && value != null && !value.isBlank()) {
+            result.put(language.trim().toUpperCase(), trimToMax(compact(value), maxLength));
+          }
+        });
+    return result;
   }
 }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -64,10 +64,12 @@ public class NewsletterAiAnalyzer {
         newsletterId, newsletter.getUserId(), analysisResponse.conversationTopics());
     String rawTitle = normalizeTitle(analysisResponse.title(), originalText);
     String summary = normalizeSummary(analysisResponse.summary(), translatedText, originalText);
+    Map<String, String> normalizedTitleI18n =
+        trimI18nValues(analysisResponse.titleI18n(), TITLE_MAX_LENGTH);
 
     log.info(
         "[AiAnalyzer] AI 서버 분석 완료. newsletterId={}, extractedItems={}", newsletterId, items.size());
-    return new AiAnalysisResult(rawTitle, analysisResponse.titleI18n(), summary);
+    return new AiAnalysisResult(rawTitle, normalizedTitleI18n, summary);
   }
 
   private List<SavedExtractedItem> saveExtractedItems(

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
@@ -126,6 +126,7 @@ public class NewsletterPipelineService {
           originalText,
           translatedText,
           aiResult.title(),
+          aiResult.titleI18n(),
           aiResult.summary());
 
       log.info("[Pipeline] 파이프라인 완료. newsletterId={}", newsletterId);

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusService.java
@@ -7,6 +7,7 @@ import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
 import com.gachi.be.domain.notification.entity.enums.NotificationType;
 import com.gachi.be.domain.notification.service.NotificationCreateCommand;
 import com.gachi.be.domain.notification.service.NotificationService;
+import com.gachi.be.domain.notification.service.NotificationTemplateKey;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,11 +49,23 @@ public class NewsletterPipelineStatusService {
       String translatedText,
       String title,
       String summary) {
+    markCompleted(newsletterId, ocrText, originalText, translatedText, title, Map.of(), summary);
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void markCompleted(
+      Long newsletterId,
+      String ocrText,
+      String originalText,
+      String translatedText,
+      String title,
+      Map<String, String> titleI18n,
+      String summary) {
     newsletterRepository
         .findById(newsletterId)
         .ifPresent(
             newsletter -> {
-              newsletter.complete(ocrText, originalText, translatedText, title, summary);
+              newsletter.complete(ocrText, originalText, translatedText, title, titleI18n, summary);
               Newsletter saved = newsletterRepository.save(newsletter);
               scheduleAnalysisCompletedNotification(saved);
             });
@@ -125,6 +138,12 @@ public class NewsletterPipelineStatusService {
                 newsletter.getId(),
                 "childName",
                 newsletter.getChildName() != null ? newsletter.getChildName() : ""),
+            NotificationTemplateKey.NEWSLETTER_ANALYSIS,
+            Map.of(
+                "newsletterTitle",
+                newsletter.getTitle() != null ? newsletter.getTitle() : "",
+                "newsletterTitleI18n",
+                newsletter.getTitleI18n() != null ? newsletter.getTitleI18n() : Map.of()),
             "newsletter-analysis:" + newsletter.getId(),
             NotificationLevel.IMPORTANT,
             childId,

--- a/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
@@ -67,6 +67,7 @@ public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
           n.failureStage = null,
           n.failureReason = null,
           n.title = null,
+          n.titleI18n = null,
           n.summary = null
       WHERE n.id = :newsletterId
         AND n.userId = :userId

--- a/src/main/java/com/gachi/be/domain/notification/entity/Notification.java
+++ b/src/main/java/com/gachi/be/domain/notification/entity/Notification.java
@@ -55,6 +55,12 @@ public class Notification {
   @Column(name = "payload_json", columnDefinition = "TEXT")
   private String payloadJson;
 
+  @Column(name = "template_key", length = 80)
+  private String templateKey;
+
+  @Column(name = "template_params_json", columnDefinition = "TEXT")
+  private String templateParamsJson;
+
   @Column(name = "dedupe_key", length = 255)
   private String dedupeKey;
 
@@ -77,6 +83,8 @@ public class Notification {
       String title,
       String body,
       String payloadJson,
+      String templateKey,
+      String templateParamsJson,
       String dedupeKey) {
     this.userId = userId;
     this.type = type;
@@ -86,6 +94,8 @@ public class Notification {
     this.title = title;
     this.body = body;
     this.payloadJson = payloadJson;
+    this.templateKey = templateKey;
+    this.templateParamsJson = templateParamsJson;
     this.dedupeKey = dedupeKey;
   }
 

--- a/src/main/java/com/gachi/be/domain/notification/service/ExpoPushNotificationClient.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/ExpoPushNotificationClient.java
@@ -45,14 +45,18 @@ public class ExpoPushNotificationClient implements PushNotificationClient {
 
   @Override
   public PushSendResult send(
-      Notification notification, PushDeviceToken pushDeviceToken, Map<String, Object> payload) {
+      Notification notification,
+      PushDeviceToken pushDeviceToken,
+      Map<String, Object> payload,
+      String title,
+      String body) {
     try {
-      String body =
+      String requestBody =
           objectMapper.writeValueAsString(
               new ExpoPushRequest(
                   pushDeviceToken.getToken(),
-                  notification.getTitle(),
-                  notification.getBody(),
+                  title,
+                  body,
                   "default",
                   payload != null ? payload : Map.of()));
 
@@ -63,7 +67,7 @@ public class ExpoPushNotificationClient implements PushNotificationClient {
               .header("Accept-Encoding", "gzip, deflate")
               .header("Content-Type", "application/json")
               .timeout(Duration.ofSeconds(properties.getReadTimeoutSeconds()))
-              .POST(HttpRequest.BodyPublishers.ofString(body));
+              .POST(HttpRequest.BodyPublishers.ofString(requestBody));
       if (StringUtils.hasText(properties.getExpo().getAccessToken())) {
         requestBuilder.header("Authorization", "Bearer " + properties.getExpo().getAccessToken());
       }

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationCreateCommand.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationCreateCommand.java
@@ -10,6 +10,8 @@ public record NotificationCreateCommand(
     String title,
     String body,
     Map<String, Object> payload,
+    NotificationTemplateKey templateKey,
+    Map<String, Object> templateParams,
     String dedupeKey,
     NotificationLevel level,
     Long childId,
@@ -21,6 +23,19 @@ public record NotificationCreateCommand(
       String body,
       Map<String, Object> payload,
       String dedupeKey) {
-    this(type, title, body, payload, dedupeKey, NotificationLevel.IMPORTANT, null, null);
+    this(
+        type, title, body, payload, null, null, dedupeKey, NotificationLevel.IMPORTANT, null, null);
+  }
+
+  public NotificationCreateCommand(
+      NotificationType type,
+      String title,
+      String body,
+      Map<String, Object> payload,
+      String dedupeKey,
+      NotificationLevel level,
+      Long childId,
+      String childName) {
+    this(type, title, body, payload, null, null, dedupeKey, level, childId, childName);
   }
 }

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationPushDispatcher.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationPushDispatcher.java
@@ -40,6 +40,7 @@ public class NotificationPushDispatcher {
   private final NotificationDeliveryLogRepository deliveryLogRepository;
   private final UserRepository userRepository;
   private final PushNotificationClient pushNotificationClient;
+  private final NotificationTemplateRenderer notificationTemplateRenderer;
   private final ObjectMapper objectMapper;
 
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
@@ -88,19 +89,26 @@ public class NotificationPushDispatcher {
     }
 
     Map<String, Object> payload = deserializePayload(notification.getPayloadJson());
+    RenderedNotification rendered =
+        notificationTemplateRenderer.render(notification, user.getLanguageCode());
     for (PushDeviceToken token : tokens) {
-      dispatchToToken(notification, token, payload);
+      dispatchToToken(notification, token, payload, rendered);
     }
   }
 
   private void dispatchToToken(
-      Notification notification, PushDeviceToken token, Map<String, Object> payload) {
+      Notification notification,
+      PushDeviceToken token,
+      Map<String, Object> payload,
+      RenderedNotification rendered) {
     if (token.getPlatform() != PushPlatform.EXPO) {
       saveSkipped(notification, token, "현재 provider에서 지원하지 않는 토큰 플랫폼입니다: " + token.getPlatform());
       return;
     }
 
-    PushSendResult result = pushNotificationClient.send(notification, token, payload);
+    PushSendResult result =
+        pushNotificationClient.send(
+            notification, token, payload, rendered.title(), rendered.body());
     if (result.success()) {
       saveDeliveryLog(
           notification,

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationScheduler.java
@@ -78,6 +78,12 @@ public class NotificationScheduler {
               event.getTitle() + " 마감 D-1",
               "내일 마감이에요",
               payload,
+              NotificationTemplateKey.DEADLINE_REMINDER,
+              Map.of(
+                  "eventTitle",
+                  event.getTitle(),
+                  "eventTitleI18n",
+                  i18nOrEmpty(event.getTitleI18n())),
               "deadline:" + event.getId() + ":" + targetDate,
               NotificationLevel.URGENT,
               childId,
@@ -113,6 +119,12 @@ public class NotificationScheduler {
               "미완료 할 일이 있어요",
               checklist.getContent(),
               payload,
+              NotificationTemplateKey.CHECKLIST_DUE,
+              Map.of(
+                  "checklistContent",
+                  checklist.getContent(),
+                  "checklistContentI18n",
+                  i18nOrEmpty(checklist.getContentI18n())),
               "todo:" + checklist.getId() + ":d-" + daysBefore + ":" + targetDate,
               NotificationLevel.IMPORTANT,
               childId,
@@ -157,6 +169,12 @@ public class NotificationScheduler {
               "미완료 할 일이 있어요",
               checklist.getContent(),
               payload,
+              NotificationTemplateKey.CHECKLIST_DUE,
+              Map.of(
+                  "checklistContent",
+                  checklist.getContent(),
+                  "checklistContentI18n",
+                  i18nOrEmpty(checklist.getContentI18n())),
               "checklist:" + checklist.getId() + ":d-" + daysBefore + ":" + targetDate,
               NotificationLevel.IMPORTANT,
               childId,
@@ -203,6 +221,8 @@ public class NotificationScheduler {
               "이번 주 요약이 도착했어요",
               buildWeeklySummaryBody(calendarEventCount, newsletterCount, incompleteCount),
               payload,
+              NotificationTemplateKey.WEEKLY_SUMMARY,
+              Map.of(),
               "weekly-summary:" + user.getId() + ":" + rangeStartDate,
               NotificationLevel.NORMAL,
               null,
@@ -256,6 +276,10 @@ public class NotificationScheduler {
 
   private Map<String, Object> payload() {
     return new LinkedHashMap<>();
+  }
+
+  private Map<String, String> i18nOrEmpty(Map<String, String> values) {
+    return values != null ? values : Map.of();
   }
 
   private void putIfPresent(Map<String, Object> payload, String key, Object value) {

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationService.java
@@ -18,6 +18,7 @@ import com.gachi.be.domain.notification.entity.enums.NotificationDeliveryStatus;
 import com.gachi.be.domain.notification.repository.NotificationDeliveryLogRepository;
 import com.gachi.be.domain.notification.repository.NotificationRepository;
 import com.gachi.be.domain.notification.repository.PushDeviceTokenRepository;
+import com.gachi.be.domain.user.repository.UserRepository;
 import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.exception.BusinessException;
 import java.nio.charset.StandardCharsets;
@@ -48,6 +49,8 @@ public class NotificationService {
   private final PushDeviceTokenRepository pushDeviceTokenRepository;
   private final NotificationDeliveryLogRepository notificationDeliveryLogRepository;
   private final ChildRepository childRepository;
+  private final UserRepository userRepository;
+  private final NotificationTemplateRenderer notificationTemplateRenderer;
   private final ObjectMapper objectMapper;
   private final ApplicationEventPublisher eventPublisher;
 
@@ -64,8 +67,11 @@ public class NotificationService {
     List<Notification> page = hasNext ? rows.subList(0, pageSize) : rows;
     Long nextCursor = hasNext && !page.isEmpty() ? page.get(page.size() - 1).getId() : null;
 
+    String language = resolveUserLanguage(userId);
     return new NotificationListResponse(
-        page.stream().map(this::toResponse).toList(), nextCursor, hasNext);
+        page.stream().map(notification -> toResponse(notification, language)).toList(),
+        nextCursor,
+        hasNext);
   }
 
   @Transactional(readOnly = true)
@@ -181,6 +187,8 @@ public class NotificationService {
             .title(normalizeRequired(command.title()))
             .body(normalizeRequired(command.body()))
             .payloadJson(serializePayload(command.payload()))
+            .templateKey(command.templateKey() != null ? command.templateKey().name() : null)
+            .templateParamsJson(serializePayload(command.templateParams()))
             .dedupeKey(dedupeKey)
             .build();
 
@@ -223,19 +231,27 @@ public class NotificationService {
             .build());
   }
 
-  private NotificationResponse toResponse(Notification notification) {
+  private NotificationResponse toResponse(Notification notification, String language) {
+    RenderedNotification rendered = notificationTemplateRenderer.render(notification, language);
     return new NotificationResponse(
         notification.getId(),
         notification.getType(),
         notification.getLevel(),
         notification.getChildId(),
         notification.getChildName(),
-        notification.getTitle(),
-        notification.getBody(),
+        rendered.title(),
+        rendered.body(),
         deserializePayload(notification.getPayloadJson()),
         notification.isRead(),
         notification.getReadAt(),
         notification.getCreatedAt());
+  }
+
+  private String resolveUserLanguage(Long userId) {
+    return userRepository
+        .findById(userId)
+        .map(user -> normalizeOptional(user.getLanguageCode()))
+        .orElse("KO");
   }
 
   private PushTokenResponse toResponse(PushDeviceToken token) {

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationTemplateKey.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationTemplateKey.java
@@ -1,0 +1,9 @@
+package com.gachi.be.domain.notification.service;
+
+/** 알림 title/body를 현재 사용자 언어로 렌더링할 때 사용하는 템플릿 식별자. */
+public enum NotificationTemplateKey {
+  NEWSLETTER_ANALYSIS,
+  DEADLINE_REMINDER,
+  CHECKLIST_DUE,
+  WEEKLY_SUMMARY
+}

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationTemplateRenderer.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationTemplateRenderer.java
@@ -184,7 +184,7 @@ public class NotificationTemplateRenderer {
       try {
         return NotificationTemplateKey.valueOf(notification.getTemplateKey());
       } catch (IllegalArgumentException ignored) {
-        return null;
+        // 저장값이 손상되어도 type 기반 추론으로 기존 알림을 최대한 렌더링합니다.
       }
     }
     if (notification.getType() == NotificationType.NEWSLETTER_ANALYSIS) {

--- a/src/main/java/com/gachi/be/domain/notification/service/NotificationTemplateRenderer.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/NotificationTemplateRenderer.java
@@ -1,0 +1,318 @@
+package com.gachi.be.domain.notification.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gachi.be.domain.calendar.repository.CalendarEventRepository;
+import com.gachi.be.domain.checklist.repository.ChecklistRepository;
+import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
+import com.gachi.be.domain.notification.entity.Notification;
+import com.gachi.be.domain.notification.entity.enums.NotificationType;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** 저장된 알림 템플릿과 payload를 현재 사용자 언어의 title/body로 변환합니다. */
+@Component
+@RequiredArgsConstructor
+public class NotificationTemplateRenderer {
+  private static final String DEFAULT_LANGUAGE = "KO";
+  private static final List<String> SUPPORTED_LANGUAGES = List.of("KO", "US", "ZH", "VI");
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+  private final NewsletterRepository newsletterRepository;
+  private final CalendarEventRepository calendarEventRepository;
+  private final ChecklistRepository checklistRepository;
+  private final ObjectMapper objectMapper;
+
+  public RenderedNotification render(Notification notification, String languageCode) {
+    String language = normalizeLanguage(languageCode);
+    Map<String, Object> payload = readMap(notification.getPayloadJson());
+    Map<String, Object> params = readMap(notification.getTemplateParamsJson());
+    NotificationTemplateKey key = resolveTemplateKey(notification);
+
+    if (key == null) {
+      return fallback(notification);
+    }
+
+    return switch (key) {
+      case NEWSLETTER_ANALYSIS -> renderNewsletterAnalysis(notification, language, payload, params);
+      case DEADLINE_REMINDER -> renderDeadlineReminder(notification, language, payload, params);
+      case CHECKLIST_DUE -> renderChecklistDue(notification, language, payload, params);
+      case WEEKLY_SUMMARY -> renderWeeklySummary(language, payload);
+    };
+  }
+
+  private RenderedNotification renderNewsletterAnalysis(
+      Notification notification,
+      String language,
+      Map<String, Object> payload,
+      Map<String, Object> params) {
+    String newsletterTitle =
+        firstText(
+            i18nParam(params, "newsletterTitleI18n", language),
+            textParam(params, "newsletterTitle"),
+            newsletterTitleFromPayload(payload, language));
+    if (!StringUtils.hasText(newsletterTitle)) {
+      return fallback(notification);
+    }
+    return new RenderedNotification(
+        switchLanguage(
+            language,
+            "새 가정통신문 분석 완료",
+            "New newsletter analysis complete",
+            "新家庭通知分析完成",
+            "Đã hoàn tất phân tích thông báo mới"),
+        switchLanguage(
+            language,
+            newsletterTitle + " 분석이 완료되었어요",
+            newsletterTitle + " analysis is complete",
+            newsletterTitle + "分析已完成",
+            "Đã hoàn tất phân tích " + newsletterTitle));
+  }
+
+  private RenderedNotification renderDeadlineReminder(
+      Notification notification,
+      String language,
+      Map<String, Object> payload,
+      Map<String, Object> params) {
+    String eventTitle =
+        firstText(
+            i18nParam(params, "eventTitleI18n", language),
+            textParam(params, "eventTitle"),
+            calendarEventTitleFromPayload(payload, language));
+    if (!StringUtils.hasText(eventTitle)) {
+      return fallback(notification);
+    }
+    return new RenderedNotification(
+        switchLanguage(
+            language,
+            eventTitle + " 마감 D-1",
+            eventTitle + " deadline D-1",
+            eventTitle + " 截止 D-1",
+            eventTitle + " hạn chót D-1"),
+        switchLanguage(language, "내일 마감이에요", "Due tomorrow", "明天截止", "Hạn chót là ngày mai"));
+  }
+
+  private RenderedNotification renderChecklistDue(
+      Notification notification,
+      String language,
+      Map<String, Object> payload,
+      Map<String, Object> params) {
+    String checklistContent =
+        firstText(
+            i18nParam(params, "checklistContentI18n", language),
+            textParam(params, "checklistContent"),
+            checklistContentFromPayload(payload, language));
+    if (!StringUtils.hasText(checklistContent)) {
+      return fallback(notification);
+    }
+    return new RenderedNotification(
+        switchLanguage(
+            language,
+            "미완료 할 일이 있어요",
+            "You have an incomplete task",
+            "你有未完成的事项",
+            "Bạn có việc chưa hoàn thành"),
+        checklistContent);
+  }
+
+  private RenderedNotification renderWeeklySummary(String language, Map<String, Object> payload) {
+    long calendarEventCount = longValue(payload.get("calendarEventCount"));
+    long newsletterCount = longValue(payload.get("newsletterCount"));
+    long incompleteChecklistCount = longValue(payload.get("incompleteChecklistCount"));
+    return new RenderedNotification(
+        switchLanguage(
+            language,
+            "이번 주 요약이 도착했어요",
+            "Your weekly summary is here",
+            "本周摘要已送达",
+            "Tóm tắt tuần này đã sẵn sàng"),
+        weeklyBody(language, calendarEventCount, newsletterCount, incompleteChecklistCount));
+  }
+
+  private String weeklyBody(
+      String language, long calendarEventCount, long newsletterCount, long incompleteCount) {
+    return switch (language) {
+      case "US" -> {
+        String items =
+            joinNonEmpty(
+                countText(calendarEventCount, "schedule " + calendarEventCount),
+                countText(newsletterCount, "newsletter " + newsletterCount),
+                countText(incompleteCount, "incomplete task " + incompleteCount));
+        yield "Please check this week's " + items;
+      }
+      case "ZH" -> {
+        String items =
+            joinNonEmpty(
+                countText(calendarEventCount, "日程 " + calendarEventCount + " 个"),
+                countText(newsletterCount, "家庭通知 " + newsletterCount + " 个"),
+                countText(incompleteCount, "未完成事项 " + incompleteCount + " 个"));
+        yield "请查看本周的" + items;
+      }
+      case "VI" -> {
+        String items =
+            joinNonEmpty(
+                countText(calendarEventCount, calendarEventCount + " lịch trình"),
+                countText(newsletterCount, newsletterCount + " thông báo gia đình"),
+                countText(incompleteCount, incompleteCount + " việc chưa hoàn thành"));
+        yield "Vui lòng kiểm tra " + items + " trong tuần này";
+      }
+      default -> {
+        String items =
+            joinNonEmpty(
+                countText(calendarEventCount, "일정 " + calendarEventCount + "개"),
+                countText(newsletterCount, "가정통신문 " + newsletterCount + "개"),
+                countText(incompleteCount, "미완료 할 일 " + incompleteCount + "개"));
+        yield "이번 주 " + items + "를 확인해보세요";
+      }
+    };
+  }
+
+  private String joinNonEmpty(String... values) {
+    return String.join(", ", java.util.Arrays.stream(values).filter(StringUtils::hasText).toList());
+  }
+
+  private String countText(long count, String text) {
+    return count > 0 ? text : null;
+  }
+
+  private NotificationTemplateKey resolveTemplateKey(Notification notification) {
+    if (StringUtils.hasText(notification.getTemplateKey())) {
+      try {
+        return NotificationTemplateKey.valueOf(notification.getTemplateKey());
+      } catch (IllegalArgumentException ignored) {
+        return null;
+      }
+    }
+    if (notification.getType() == NotificationType.NEWSLETTER_ANALYSIS) {
+      return NotificationTemplateKey.NEWSLETTER_ANALYSIS;
+    }
+    if (notification.getType() == NotificationType.DEADLINE_REMINDER) {
+      return NotificationTemplateKey.DEADLINE_REMINDER;
+    }
+    if (notification.getType() == NotificationType.CHECKLIST_DUE) {
+      return NotificationTemplateKey.CHECKLIST_DUE;
+    }
+    if (notification.getType() == NotificationType.WEEKLY_SUMMARY) {
+      return NotificationTemplateKey.WEEKLY_SUMMARY;
+    }
+    return null;
+  }
+
+  private String newsletterTitleFromPayload(Map<String, Object> payload, String language) {
+    Long newsletterId = longObject(payload.get("newsletterId"));
+    if (newsletterId == null) {
+      return null;
+    }
+    return newsletterRepository
+        .findById(newsletterId)
+        .map(newsletter -> i18nText(newsletter.getTitleI18n(), language, newsletter.getTitle()))
+        .orElse(null);
+  }
+
+  private String calendarEventTitleFromPayload(Map<String, Object> payload, String language) {
+    Long calendarEventId = longObject(payload.get("calendarEventId"));
+    if (calendarEventId == null) {
+      return null;
+    }
+    return calendarEventRepository
+        .findById(calendarEventId)
+        .map(event -> i18nText(event.getTitleI18n(), language, event.getTitle()))
+        .orElse(null);
+  }
+
+  private String checklistContentFromPayload(Map<String, Object> payload, String language) {
+    Long checklistId = longObject(payload.get("checklistId"));
+    if (checklistId == null) {
+      return null;
+    }
+    return checklistRepository
+        .findById(checklistId)
+        .map(checklist -> i18nText(checklist.getContentI18n(), language, checklist.getContent()))
+        .orElse(null);
+  }
+
+  private String i18nParam(Map<String, Object> params, String key, String language) {
+    Object value = params.get(key);
+    if (value instanceof Map<?, ?> map) {
+      return firstText(stringValue(map.get(language)), stringValue(map.get(DEFAULT_LANGUAGE)));
+    }
+    return null;
+  }
+
+  private String i18nText(Map<String, String> values, String language, String fallback) {
+    if (values == null || values.isEmpty()) {
+      return fallback;
+    }
+    return firstText(values.get(language), values.get(DEFAULT_LANGUAGE), fallback);
+  }
+
+  private String textParam(Map<String, Object> params, String key) {
+    Object value = params.get(key);
+    return value instanceof String text && StringUtils.hasText(text) ? text : null;
+  }
+
+  private String stringValue(Object value) {
+    return value instanceof String text && StringUtils.hasText(text) ? text : null;
+  }
+
+  private String firstText(String... values) {
+    for (String value : values) {
+      if (StringUtils.hasText(value)) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  private RenderedNotification fallback(Notification notification) {
+    return new RenderedNotification(notification.getTitle(), notification.getBody());
+  }
+
+  private Map<String, Object> readMap(String json) {
+    if (!StringUtils.hasText(json)) {
+      return Collections.emptyMap();
+    }
+    try {
+      return objectMapper.readValue(json, MAP_TYPE);
+    } catch (Exception e) {
+      return Collections.emptyMap();
+    }
+  }
+
+  private String normalizeLanguage(String languageCode) {
+    String normalized = languageCode == null ? DEFAULT_LANGUAGE : languageCode.trim().toUpperCase();
+    return SUPPORTED_LANGUAGES.contains(normalized) ? normalized : DEFAULT_LANGUAGE;
+  }
+
+  private String switchLanguage(String language, String ko, String us, String zh, String vi) {
+    return switch (language) {
+      case "US" -> us;
+      case "ZH" -> zh;
+      case "VI" -> vi;
+      default -> ko;
+    };
+  }
+
+  private long longValue(Object value) {
+    Long parsed = longObject(value);
+    return parsed != null ? parsed : 0L;
+  }
+
+  private Long longObject(Object value) {
+    if (value instanceof Number number) {
+      return number.longValue();
+    }
+    if (value instanceof String text && StringUtils.hasText(text)) {
+      try {
+        return Long.parseLong(text);
+      } catch (NumberFormatException ignored) {
+        return null;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/gachi/be/domain/notification/service/PushNotificationClient.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/PushNotificationClient.java
@@ -23,8 +23,14 @@ public interface PushNotificationClient {
    * @param notification 발송할 알림 엔티티
    * @param pushDeviceToken 대상 디바이스 토큰
    * @param payload 앱에서 알림 클릭 후 라우팅 등에 사용할 추가 데이터
+   * @param title 사용자 현재 언어로 렌더링된 푸시 제목
+   * @param body 사용자 현재 언어로 렌더링된 푸시 본문
    * @return 성공/실패, provider 메시지 ID, 토큰 무효화 여부를 포함한 발송 결과
    */
   PushSendResult send(
-      Notification notification, PushDeviceToken pushDeviceToken, Map<String, Object> payload);
+      Notification notification,
+      PushDeviceToken pushDeviceToken,
+      Map<String, Object> payload,
+      String title,
+      String body);
 }

--- a/src/main/java/com/gachi/be/domain/notification/service/RenderedNotification.java
+++ b/src/main/java/com/gachi/be/domain/notification/service/RenderedNotification.java
@@ -1,0 +1,3 @@
+package com.gachi.be.domain.notification.service;
+
+public record RenderedNotification(String title, String body) {}

--- a/src/main/resources/db/migration/V21__notification_i18n_templates.sql
+++ b/src/main/resources/db/migration/V21__notification_i18n_templates.sql
@@ -1,0 +1,16 @@
+ALTER TABLE notifications
+    ADD COLUMN IF NOT EXISTS template_key VARCHAR(80),
+    ADD COLUMN IF NOT EXISTS template_params_json TEXT;
+
+ALTER TABLE newsletter
+    ADD COLUMN IF NOT EXISTS title_i18n JSONB;
+
+ALTER TABLE calendar_events
+    ADD COLUMN IF NOT EXISTS title_i18n JSONB;
+
+ALTER TABLE checklist
+    ADD COLUMN IF NOT EXISTS content_i18n JSONB;
+
+CREATE INDEX IF NOT EXISTS idx_notifications_template_key
+    ON notifications (template_key)
+    WHERE template_key IS NOT NULL;

--- a/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzerTest.java
+++ b/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzerTest.java
@@ -72,7 +72,14 @@ class NewsletterAiAnalyzerTest {
 
     when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
     when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
-        .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(item), List.of(), Map.of()));
+        .thenReturn(
+            new AnalysisResponse(
+                "AI 제목",
+                Map.of(" us ", " AI English title "),
+                "AI 요약",
+                List.of(item),
+                List.of(),
+                Map.of()));
     when(checklistRepository.saveAll(anyList()))
         .thenAnswer(
             invocation -> {
@@ -84,6 +91,7 @@ class NewsletterAiAnalyzerTest {
     AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
 
     assertThat(result.title()).isEqualTo("AI 제목");
+    assertThat(result.titleI18n()).containsEntry("US", "AI English title");
     assertThat(result.summary()).isEqualTo("AI 요약");
 
     verify(checklistRepository).saveAll(checklistsCaptor.capture());

--- a/src/test/java/com/gachi/be/domain/notification/service/NotificationPushDispatcherIntegrationTest.java
+++ b/src/test/java/com/gachi/be/domain/notification/service/NotificationPushDispatcherIntegrationTest.java
@@ -56,6 +56,8 @@ class NotificationPushDispatcherIntegrationTest {
     assertThat(logs.get(0).getProvider()).isEqualTo("TEST");
     assertThat(logs.get(0).getProviderMessageId()).isEqualTo("ticket-1");
     assertThat(pushNotificationClient.sendCount).isEqualTo(1);
+    assertThat(pushNotificationClient.lastTitle).isEqualTo("title");
+    assertThat(pushNotificationClient.lastBody).isEqualTo("body");
   }
 
   @Test
@@ -139,6 +141,8 @@ class NotificationPushDispatcherIntegrationTest {
   static class CapturingPushNotificationClient implements PushNotificationClient {
     private PushSendResult nextResult = PushSendResult.sent("ticket-1");
     private int sendCount;
+    private String lastTitle;
+    private String lastBody;
 
     @Override
     public String providerName() {
@@ -147,14 +151,22 @@ class NotificationPushDispatcherIntegrationTest {
 
     @Override
     public PushSendResult send(
-        Notification notification, PushDeviceToken pushDeviceToken, Map<String, Object> payload) {
+        Notification notification,
+        PushDeviceToken pushDeviceToken,
+        Map<String, Object> payload,
+        String title,
+        String body) {
       sendCount++;
+      lastTitle = title;
+      lastBody = body;
       return nextResult;
     }
 
     void reset() {
       nextResult = PushSendResult.sent("ticket-1");
       sendCount = 0;
+      lastTitle = null;
+      lastBody = null;
     }
   }
 }

--- a/src/test/java/com/gachi/be/domain/notification/service/NotificationTemplateRendererTest.java
+++ b/src/test/java/com/gachi/be/domain/notification/service/NotificationTemplateRendererTest.java
@@ -1,0 +1,74 @@
+package com.gachi.be.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gachi.be.domain.calendar.repository.CalendarEventRepository;
+import com.gachi.be.domain.checklist.repository.ChecklistRepository;
+import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
+import com.gachi.be.domain.notification.entity.Notification;
+import com.gachi.be.domain.notification.entity.enums.NotificationType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class NotificationTemplateRendererTest {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final NotificationTemplateRenderer renderer =
+      new NotificationTemplateRenderer(
+          mock(NewsletterRepository.class),
+          mock(CalendarEventRepository.class),
+          mock(ChecklistRepository.class),
+          objectMapper);
+
+  @Test
+  void renderUsesCurrentLanguageTemplateAndI18nParams() throws Exception {
+    Notification notification =
+        Notification.builder()
+            .userId(1L)
+            .type(NotificationType.NEWSLETTER_ANALYSIS)
+            .title("새 가정통신문 분석 완료")
+            .body("토요 베이커리 안내 분석이 완료되었어요")
+            .payloadJson(objectMapper.writeValueAsString(Map.of("newsletterId", 10L)))
+            .templateKey(NotificationTemplateKey.NEWSLETTER_ANALYSIS.name())
+            .templateParamsJson(
+                objectMapper.writeValueAsString(
+                    Map.of(
+                        "newsletterTitle",
+                        "토요 베이커리 안내",
+                        "newsletterTitleI18n",
+                        Map.of(
+                            "KO",
+                            "토요 베이커리 안내",
+                            "US",
+                            "Saturday Bakery Guide",
+                            "ZH",
+                            "周六烘焙通知",
+                            "VI",
+                            "Thông báo làm bánh thứ Bảy"))))
+            .dedupeKey("newsletter-analysis:10")
+            .build();
+
+    RenderedNotification rendered = renderer.render(notification, "US");
+
+    assertThat(rendered.title()).isEqualTo("New newsletter analysis complete");
+    assertThat(rendered.body()).isEqualTo("Saturday Bakery Guide analysis is complete");
+  }
+
+  @Test
+  void renderFallsBackToStoredTextWhenTemplateCannotBeResolved() {
+    Notification notification =
+        Notification.builder()
+            .userId(1L)
+            .type(NotificationType.SYSTEM)
+            .title("system title")
+            .body("system body")
+            .dedupeKey("system:1")
+            .build();
+
+    RenderedNotification rendered = renderer.render(notification, "US");
+
+    assertThat(rendered.title()).isEqualTo("system title");
+    assertThat(rendered.body()).isEqualTo("system body");
+  }
+}

--- a/src/test/java/com/gachi/be/domain/notification/service/NotificationTemplateRendererTest.java
+++ b/src/test/java/com/gachi/be/domain/notification/service/NotificationTemplateRendererTest.java
@@ -71,4 +71,29 @@ class NotificationTemplateRendererTest {
     assertThat(rendered.title()).isEqualTo("system title");
     assertThat(rendered.body()).isEqualTo("system body");
   }
+
+  @Test
+  void renderFallsBackToTypeWhenTemplateKeyIsInvalid() throws Exception {
+    Notification notification =
+        Notification.builder()
+            .userId(1L)
+            .type(NotificationType.CHECKLIST_DUE)
+            .title("미완료 할 일이 있어요")
+            .body("준비물 챙기기")
+            .templateKey("BROKEN_KEY")
+            .templateParamsJson(
+                objectMapper.writeValueAsString(
+                    Map.of(
+                        "checklistContent",
+                        "준비물 챙기기",
+                        "checklistContentI18n",
+                        Map.of("US", "Pack supplies"))))
+            .dedupeKey("checklist:1")
+            .build();
+
+    RenderedNotification rendered = renderer.render(notification, "US");
+
+    assertThat(rendered.title()).isEqualTo("You have an incomplete task");
+    assertThat(rendered.body()).isEqualTo("Pack supplies");
+  }
 }


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 알림을 저장된 `title/body` 그대로 반환하지 않고, 조회 시점의 사용자 `languageCode` 기준으로 렌더링하도록 개선
  - `notifications`에 `template_key`, `template_params_json` 컬럼 추가
  - `newsletter.title_i18n`, `calendar_events.title_i18n`, `checklist.content_i18n` 컬럼 추가
  - AI 응답의 `titleI18n`, `items[].titleI18n`, `checklistItems[].contentI18n` 수신 및 저장 반영
  - 알림 템플릿 키와 KO/US/ZH/VI 문구 렌더러 추가
  - 알림 목록 조회와 푸시 발송이 동일한 렌더링 결과를 사용하도록 변경
  - 기존 알림은 `type`, `payload_json`, `dedupe_key` 기반으로 가능한 범위에서 렌더링하고, 정보가 없으면 기존 `title/body`로 fallback
  - BE에서 AI가 생성한 사용자 노출 문구를 Papago로 다시 번역하지 않도록 처리
  - 알림 다국어 렌더링 단위 테스트 추가
- 관련 이슈: closes #148 

## 🌿 브랜치 정보

- **Source**: `feat/#148-notification-i18n-template`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

```powershell
$env:GRADLE_USER_HOME='C:\Users\mjmdm\IdeaProjects\GACHI-BE\.gradle-user-home'
.\gradlew.bat --no-daemon spotlessCheck
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 일정, 체크리스트, 뉴스레터에 다국어 콘텐츠 저장 및 표시 기능 추가
  * 사용자 언어 설정에 따른 알림 메시지 자동 렌더링 기능 추가
  * 알림 템플릿 시스템 도입으로 마감 알림, 체크리스트 알림, 주간 요약 등에 맞춤형 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->