### PR TITLE
fix: 가정통신문 체크리스트·요약 2차 번역 보정 실패 수정

### DIFF
--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
@@ -27,7 +27,7 @@ public class AiNewsletterClient {
 
   private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
   private static final String ANALYZE_PATH = "/ai/newsletters/analyze";
-
+  private static final String REFINE_TRANSLATION_PATH = "/ai/newsletters/refine-translation";
   private final AiServerProperties aiServerProperties;
   private final ObjectMapper objectMapper;
   private final HttpClient httpClient;
@@ -92,6 +92,52 @@ public class AiNewsletterClient {
       throw new ExternalApiException(
           ErrorCode.EXTERNAL_API_ERROR, "AI 서버 통신 오류: " + e.getMessage(), e);
     }
+  }
+
+  public RefineTranslationResponse refineTranslation(
+      String originalText, String language, List<RefineFieldRequest> fields) {
+      if (fields == null || fields.isEmpty()) {
+          return new RefineTranslationResponse(List.of());
+      }
+
+      try {
+          String requestBody =
+              objectMapper.writeValueAsString(
+                  new RefineTranslationRequest(originalText, language != null ? language : "KO", fields));
+          log.info("[AiNewsletterClient] 2차 검증 요청 body: {}", requestBody);
+
+          HttpRequest request =
+              HttpRequest.newBuilder()
+                  .uri(URI.create(normalizedBaseUrl() + REFINE_TRANSLATION_PATH))
+                  .header("Content-Type", "application/json")
+                  .header("Accept", "application/json")
+                  .timeout(Duration.ofSeconds(aiServerProperties.getReadTimeoutSeconds()))
+                  .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                  .build();
+
+          HttpResponse<String> response =
+              httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+          if (response.statusCode() < 200 || response.statusCode() >= 300) {
+              log.error(
+                  "[AiNewsletterClient] 2차 검증 실패. status={}, body={}",
+                  response.statusCode(),
+                  response.body());
+              throw new ExternalApiException(
+                  ErrorCode.EXTERNAL_API_ERROR, "AI 서버 2차 검증 실패. status=" + response.statusCode());
+          }
+
+          return objectMapper.readValue(response.body(), RefineTranslationResponse.class);
+      } catch (ExternalApiException e) {
+          throw e;
+      } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new ExternalApiException(
+              ErrorCode.EXTERNAL_API_ERROR, "AI 서버 통신 인터럽트: " + e.getMessage(), e);
+      } catch (IOException e) {
+          throw new ExternalApiException(
+              ErrorCode.EXTERNAL_API_ERROR, "AI 서버 통신 오류: " + e.getMessage(), e);
+      }
   }
 
   private String normalizedBaseUrl() {
@@ -254,5 +300,31 @@ public class AiNewsletterClient {
           confirmationQuestion,
           normalizedChecklistItems);
     }
+  }
+  /** 2차 검증 요청에 포함되는 단일 필드. id로 응답과 매핑한다. */
+  public record RefineFieldRequest(String id, String koText, String translatedText) {}
+
+  record RefineTranslationRequest(String originalText, String language, List<RefineFieldRequest> fields) {}
+
+  /** 2차 검증 응답에 포함되는 단일 필드. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record RefineFieldResponse(String id, String text) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record RefineTranslationResponse(List<RefineFieldResponse> fields) {
+
+      /** id → 교정된 텍스트 맵으로 변환. */
+      public Map<String, String> toMap() {
+          if (fields == null || fields.isEmpty()) {
+              return Map.of();
+          }
+          Map<String, String> result = new java.util.LinkedHashMap<>();
+          for (RefineFieldResponse field : fields) {
+              if (field != null && field.id() != null && field.text() != null) {
+                  result.put(field.id(), field.text());
+              }
+          }
+          return result;
+      }
   }
 }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
@@ -96,48 +96,49 @@ public class AiNewsletterClient {
 
   public RefineTranslationResponse refineTranslation(
       String originalText, String language, List<RefineFieldRequest> fields) {
-      if (fields == null || fields.isEmpty()) {
-          return new RefineTranslationResponse(List.of());
+    if (fields == null || fields.isEmpty()) {
+      return new RefineTranslationResponse(List.of());
+    }
+
+    try {
+      String requestBody =
+          objectMapper.writeValueAsString(
+              new RefineTranslationRequest(
+                  originalText, language != null ? language : "KO", fields));
+      log.info("[AiNewsletterClient] 2차 검증 요청 body: {}", requestBody);
+
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(normalizedBaseUrl() + REFINE_TRANSLATION_PATH))
+              .header("Content-Type", "application/json")
+              .header("Accept", "application/json")
+              .timeout(Duration.ofSeconds(aiServerProperties.getReadTimeoutSeconds()))
+              .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+              .build();
+
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+        log.error(
+            "[AiNewsletterClient] 2차 검증 실패. status={}, body={}",
+            response.statusCode(),
+            response.body());
+        throw new ExternalApiException(
+            ErrorCode.EXTERNAL_API_ERROR, "AI 서버 2차 검증 실패. status=" + response.statusCode());
       }
 
-      try {
-          String requestBody =
-              objectMapper.writeValueAsString(
-                  new RefineTranslationRequest(originalText, language != null ? language : "KO", fields));
-          log.info("[AiNewsletterClient] 2차 검증 요청 body: {}", requestBody);
-
-          HttpRequest request =
-              HttpRequest.newBuilder()
-                  .uri(URI.create(normalizedBaseUrl() + REFINE_TRANSLATION_PATH))
-                  .header("Content-Type", "application/json")
-                  .header("Accept", "application/json")
-                  .timeout(Duration.ofSeconds(aiServerProperties.getReadTimeoutSeconds()))
-                  .POST(HttpRequest.BodyPublishers.ofString(requestBody))
-                  .build();
-
-          HttpResponse<String> response =
-              httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-          if (response.statusCode() < 200 || response.statusCode() >= 300) {
-              log.error(
-                  "[AiNewsletterClient] 2차 검증 실패. status={}, body={}",
-                  response.statusCode(),
-                  response.body());
-              throw new ExternalApiException(
-                  ErrorCode.EXTERNAL_API_ERROR, "AI 서버 2차 검증 실패. status=" + response.statusCode());
-          }
-
-          return objectMapper.readValue(response.body(), RefineTranslationResponse.class);
-      } catch (ExternalApiException e) {
-          throw e;
-      } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new ExternalApiException(
-              ErrorCode.EXTERNAL_API_ERROR, "AI 서버 통신 인터럽트: " + e.getMessage(), e);
-      } catch (IOException e) {
-          throw new ExternalApiException(
-              ErrorCode.EXTERNAL_API_ERROR, "AI 서버 통신 오류: " + e.getMessage(), e);
-      }
+      return objectMapper.readValue(response.body(), RefineTranslationResponse.class);
+    } catch (ExternalApiException e) {
+      throw e;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ExternalApiException(
+          ErrorCode.EXTERNAL_API_ERROR, "AI 서버 통신 인터럽트: " + e.getMessage(), e);
+    } catch (IOException e) {
+      throw new ExternalApiException(
+          ErrorCode.EXTERNAL_API_ERROR, "AI 서버 통신 오류: " + e.getMessage(), e);
+    }
   }
 
   private String normalizedBaseUrl() {
@@ -301,10 +302,12 @@ public class AiNewsletterClient {
           normalizedChecklistItems);
     }
   }
+
   /** 2차 검증 요청에 포함되는 단일 필드. id로 응답과 매핑한다. */
   public record RefineFieldRequest(String id, String koText, String translatedText) {}
 
-  record RefineTranslationRequest(String originalText, String language, List<RefineFieldRequest> fields) {}
+  record RefineTranslationRequest(
+      String originalText, String language, List<RefineFieldRequest> fields) {}
 
   /** 2차 검증 응답에 포함되는 단일 필드. */
   @JsonIgnoreProperties(ignoreUnknown = true)
@@ -313,18 +316,18 @@ public class AiNewsletterClient {
   @JsonIgnoreProperties(ignoreUnknown = true)
   public record RefineTranslationResponse(List<RefineFieldResponse> fields) {
 
-      /** id → 교정된 텍스트 맵으로 변환. */
-      public Map<String, String> toMap() {
-          if (fields == null || fields.isEmpty()) {
-              return Map.of();
-          }
-          Map<String, String> result = new java.util.LinkedHashMap<>();
-          for (RefineFieldResponse field : fields) {
-              if (field != null && field.id() != null && field.text() != null) {
-                  result.put(field.id(), field.text());
-              }
-          }
-          return result;
+    /** id → 교정된 텍스트 맵으로 변환. */
+    public Map<String, String> toMap() {
+      if (fields == null || fields.isEmpty()) {
+        return Map.of();
       }
+      Map<String, String> result = new java.util.LinkedHashMap<>();
+      for (RefineFieldResponse field : fields) {
+        if (field != null && field.id() != null && field.text() != null) {
+          result.put(field.id(), field.text());
+        }
+      }
+      return result;
+    }
   }
 }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/AiNewsletterClient.java
@@ -105,7 +105,11 @@ public class AiNewsletterClient {
           objectMapper.writeValueAsString(
               new RefineTranslationRequest(
                   originalText, language != null ? language : "KO", fields));
-      log.info("[AiNewsletterClient] 2차 검증 요청 body: {}", requestBody);
+      log.debug(
+          "[AiNewsletterClient] 2차 검증 요청. language={}, fieldCount={}, fieldIds={}",
+          language != null ? language : "KO",
+          fields.size(),
+          fields.stream().map(RefineFieldRequest::id).toList());
 
       HttpRequest request =
           HttpRequest.newBuilder()
@@ -323,9 +327,13 @@ public class AiNewsletterClient {
       }
       Map<String, String> result = new java.util.LinkedHashMap<>();
       for (RefineFieldResponse field : fields) {
-        if (field != null && field.id() != null && field.text() != null) {
-          result.put(field.id(), field.text());
+        if (field == null || field.id() == null || field.id().isBlank()) {
+          continue;
         }
+        if (field.text() == null || field.text().isBlank()) {
+          continue;
+        }
+        result.put(field.id(), field.text().trim());
       }
       return result;
     }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -87,89 +87,90 @@ public class NewsletterAiAnalyzer {
   private static final String FIELD_ID_SUMMARY = "summary";
 
   /**
-     * 1차 분석 응답(한국어)에서 화면에 노출되는 텍스트(title/summary/items[].title/
-     * checklistItems[].content,detail/conversationTopics[].topic)를 모아 id를 부여하고,
-     * KO가 아니면 Papago로 1차 번역 → AI 서버로 2차 검증을 거쳐 최종 텍스트 맵을 반환한다.
-     *
-     * language=KO이거나 번역 대상 텍스트가 없으면 한국어 원본을 그대로 반환한다 (id → 원본 텍스트).
-     */
+   * 1차 분석 응답(한국어)에서 화면에 노출되는 텍스트(title/summary/items[].title/
+   * checklistItems[].content,detail/conversationTopics[].topic)를 모아 id를 부여하고, KO가 아니면 Papago로 1차 번역
+   * → AI 서버로 2차 검증을 거쳐 최종 텍스트 맵을 반환한다.
+   *
+   * <p>language=KO이거나 번역 대상 텍스트가 없으면 한국어 원본을 그대로 반환한다 (id → 원본 텍스트).
+   */
   private Map<String, String> translateAndRefineDisplayTexts(
-      String originalText, String language, AnalysisResponse analysisResponse, List<ExtractedItem> items) {
+      String originalText,
+      String language,
+      AnalysisResponse analysisResponse,
+      List<ExtractedItem> items) {
 
-      Map<String, String> koTextsById = collectKoreanDisplayTexts(analysisResponse, items);
+    Map<String, String> koTextsById = collectKoreanDisplayTexts(analysisResponse, items);
 
-      if ("KO".equals(language)) {
-            // KO 사용자는 한국어 원본을 그대로 사용 (번역/검증 불필요)
-          return koTextsById;
-      }
+    if ("KO".equals(language)) {
+      // KO 사용자는 한국어 원본을 그대로 사용 (번역/검증 불필요)
+      return koTextsById;
+    }
 
-      // 1차: Papago 한국어 → language 번역
-      Map<String, String> papagoTextsById = new LinkedHashMap<>();
-      for (Map.Entry<String, String> entry : koTextsById.entrySet()) {
-          String koText = entry.getValue();
-          String translated = papagoTranslateClient.translate(koText, language);
-          papagoTextsById.put(entry.getKey(), translated != null ? translated : koText);
-      }
+    // 1차: Papago 한국어 → language 번역
+    Map<String, String> papagoTextsById = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry : koTextsById.entrySet()) {
+      String koText = entry.getValue();
+      String translated = papagoTranslateClient.translate(koText, language);
+      papagoTextsById.put(entry.getKey(), translated != null ? translated : koText);
+    }
 
-        // 2차: AI 서버 검증/교정
-      List<RefineFieldRequest> refineFields = new ArrayList<>();
-      for (Map.Entry<String, String> entry : koTextsById.entrySet()) {
-          refineFields.add(
-              new RefineFieldRequest(
-                  entry.getKey(), entry.getValue(), papagoTextsById.get(entry.getKey())));
-      }
+    // 2차: AI 서버 검증/교정
+    List<RefineFieldRequest> refineFields = new ArrayList<>();
+    for (Map.Entry<String, String> entry : koTextsById.entrySet()) {
+      refineFields.add(
+          new RefineFieldRequest(
+              entry.getKey(), entry.getValue(), papagoTextsById.get(entry.getKey())));
+    }
 
-      try {
-          Map<String, String> refinedById =
-              aiNewsletterClient.refineTranslation(originalText, language, refineFields).toMap();
+    try {
+      Map<String, String> refinedById =
+          aiNewsletterClient.refineTranslation(originalText, language, refineFields).toMap();
 
-          Map<String, String> result = new LinkedHashMap<>(papagoTextsById);
-          result.putAll(refinedById); // 검증 결과로 덮어쓰기. 누락된 id는 파파고 번역값 유지.
-          return result;
-      } catch (RuntimeException e) {
-          // 2차 검증 실패 시 파파고 1차 번역 결과로 폴백 (전체 파이프라인은 계속 진행)
-          log.warn("[AiAnalyzer] 2차 검증 실패. 파파고 1차 번역 결과로 대체합니다. error={}", e.getMessage(), e);
-          return papagoTextsById;
-      }
+      Map<String, String> result = new LinkedHashMap<>(papagoTextsById);
+      result.putAll(refinedById); // 검증 결과로 덮어쓰기. 누락된 id는 파파고 번역값 유지.
+      return result;
+    } catch (RuntimeException e) {
+      // 2차 검증 실패 시 파파고 1차 번역 결과로 폴백 (전체 파이프라인은 계속 진행)
+      log.warn("[AiAnalyzer] 2차 검증 실패. 파파고 1차 번역 결과로 대체합니다. error={}", e.getMessage(), e);
+      return papagoTextsById;
+    }
   }
 
-  /**
-   * 1차 분석 응답(한국어)에서 화면 노출 텍스트를 id → 한국어 텍스트 맵으로 수집한다.
-   */
+  /** 1차 분석 응답(한국어)에서 화면 노출 텍스트를 id → 한국어 텍스트 맵으로 수집한다. */
   private Map<String, String> collectKoreanDisplayTexts(
       AnalysisResponse analysisResponse, List<ExtractedItem> items) {
-      Map<String, String> texts = new LinkedHashMap<>();
+    Map<String, String> texts = new LinkedHashMap<>();
 
-      putIfNotBlank(texts, FIELD_ID_TITLE, analysisResponse.title());
-      putIfNotBlank(texts, FIELD_ID_SUMMARY, analysisResponse.summary());
+    putIfNotBlank(texts, FIELD_ID_TITLE, analysisResponse.title());
+    putIfNotBlank(texts, FIELD_ID_SUMMARY, analysisResponse.summary());
 
-      for (int i = 0; i < items.size(); i++) {
-          ExtractedItem item = items.get(i);
-          putIfNotBlank(texts, "item_" + i + "_title", item.title());
+    for (int i = 0; i < items.size(); i++) {
+      ExtractedItem item = items.get(i);
+      putIfNotBlank(texts, "item_" + i + "_title", item.title());
 
-          if (item.checklistItems() == null) {
-              continue;
-          }
-          for (int j = 0; j < item.checklistItems().size(); j++) {
-              AiNewsletterClient.ChecklistItemDto checklistItem = item.checklistItems().get(j);
-              putIfNotBlank(texts, "item_" + i + "_chk_" + j + "_content", checklistItem.content());
-              putIfNotBlank(texts, "item_" + i + "_chk_" + j + "_detail", checklistItem.detail());
-          }
+      if (item.checklistItems() == null) {
+        continue;
       }
-
-      if (analysisResponse.conversationTopics() != null) {
-            for (int k = 0; k < analysisResponse.conversationTopics().size(); k++) {
-                putIfNotBlank(texts, "topic_" + k, analysisResponse.conversationTopics().get(k).topic());
-            }
+      for (int j = 0; j < item.checklistItems().size(); j++) {
+        AiNewsletterClient.ChecklistItemDto checklistItem = item.checklistItems().get(j);
+        putIfNotBlank(texts, "item_" + i + "_chk_" + j + "_content", checklistItem.content());
+        putIfNotBlank(texts, "item_" + i + "_chk_" + j + "_detail", checklistItem.detail());
       }
+    }
 
-      return texts;
+    if (analysisResponse.conversationTopics() != null) {
+      for (int k = 0; k < analysisResponse.conversationTopics().size(); k++) {
+        putIfNotBlank(texts, "topic_" + k, analysisResponse.conversationTopics().get(k).topic());
+      }
+    }
+
+    return texts;
   }
 
   private void putIfNotBlank(Map<String, String> map, String id, String value) {
-      if (value != null && !value.isBlank()) {
-          map.put(id, value);
-      }
+    if (value != null && !value.isBlank()) {
+      map.put(id, value);
+    }
   }
 
   private List<SavedExtractedItem> saveExtractedItems(
@@ -187,14 +188,18 @@ public class NewsletterAiAnalyzer {
       if (item.checklistItems() == null || item.checklistItems().isEmpty()) {
         continue;
       }
-      for (int checklistIndex = 0; checklistIndex < item.checklistItems().size(); checklistIndex++) {
-          AiNewsletterClient.ChecklistItemDto checklistItem = item.checklistItems().get(checklistIndex);
-          if (checklistItem.content() == null || checklistItem.content().isBlank()) {
-              continue; // 빈 content는 저장하지 않음
-          }
-          entitiesToSave.add(
-              toChecklist(newsletterId, userId, checklistItem, itemIndex, checklistIndex, displayTexts));
-          ownerItemIndex.add(itemIndex);
+      for (int checklistIndex = 0;
+          checklistIndex < item.checklistItems().size();
+          checklistIndex++) {
+        AiNewsletterClient.ChecklistItemDto checklistItem =
+            item.checklistItems().get(checklistIndex);
+        if (checklistItem.content() == null || checklistItem.content().isBlank()) {
+          continue; // 빈 content는 저장하지 않음
+        }
+        entitiesToSave.add(
+            toChecklist(
+                newsletterId, userId, checklistItem, itemIndex, checklistIndex, displayTexts));
+        ownerItemIndex.add(itemIndex);
       }
     }
 
@@ -218,27 +223,32 @@ public class NewsletterAiAnalyzer {
         continue;
       }
       List<Checklist> linkedChecklists = checklistsByItemIndex.getOrDefault(itemIndex, List.of());
-      result.add(new SavedExtractedItem(itemIndex,item, linkedChecklists));
+      result.add(new SavedExtractedItem(itemIndex, item, linkedChecklists));
     }
     return result;
   }
 
-  private Checklist toChecklist(Long newsletterId, Long userId, AiNewsletterClient.ChecklistItemDto checklistItem, int itemIndex, int checklistIndex,
-                                Map<String, String> displayTexts) {
-      String contentKey = "item_" + itemIndex + "_chk_" + checklistIndex + "_content";
-      String detailKey = "item_" + itemIndex + "_chk_" + checklistIndex + "_detail";
+  private Checklist toChecklist(
+      Long newsletterId,
+      Long userId,
+      AiNewsletterClient.ChecklistItemDto checklistItem,
+      int itemIndex,
+      int checklistIndex,
+      Map<String, String> displayTexts) {
+    String contentKey = "item_" + itemIndex + "_chk_" + checklistIndex + "_content";
+    String detailKey = "item_" + itemIndex + "_chk_" + checklistIndex + "_detail";
 
-      String contentSource = displayTexts.getOrDefault(contentKey, checklistItem.content());
-      String content = trimToMax(contentSource.trim(), CHECKLIST_TEXT_MAX_LENGTH);
+    String contentSource = displayTexts.getOrDefault(contentKey, checklistItem.content());
+    String content = trimToMax(contentSource.trim(), CHECKLIST_TEXT_MAX_LENGTH);
 
-      String detail = null;
-      String detailSource = displayTexts.get(detailKey);
-      if (detailSource == null) {
-          detailSource = checklistItem.detail();
-      }
-      if (detailSource != null && !detailSource.isBlank()) {
-          detail = trimNullable(detailSource, CHECKLIST_TEXT_MAX_LENGTH);
-      }
+    String detail = null;
+    String detailSource = displayTexts.get(detailKey);
+    if (detailSource == null) {
+      detailSource = checklistItem.detail();
+    }
+    if (detailSource != null && !detailSource.isBlank()) {
+      detail = trimNullable(detailSource, CHECKLIST_TEXT_MAX_LENGTH);
+    }
 
     return Checklist.builder()
         .newsletterId(newsletterId)
@@ -268,38 +278,38 @@ public class NewsletterAiAnalyzer {
 
   private void saveCalendarPreview(
       Long newsletterId, List<SavedExtractedItem> savedItems, Map<String, String> displayTexts) {
-      List<CalendarPreviewEvent> previewEvents = new ArrayList<>();
+    List<CalendarPreviewEvent> previewEvents = new ArrayList<>();
 
-      for (SavedExtractedItem savedItem : savedItems) {
-          ExtractedItem item = savedItem.item();
-          String extractedDate = normalizePreviewDate(item.datetime());
-          if (!"confirmed".equalsIgnoreCase(item.dateStatus()) || extractedDate == null) {
-              continue;
-          }
-
-          String titleSource =
-              displayTexts.getOrDefault("item_" + savedItem.itemIndex() + "_title", item.title());
-
-          previewEvents.add(
-              new CalendarPreviewEvent(
-                  "ai_evt_" + (previewEvents.size() + 1),
-                  trimToMax(titleSource.trim(), CHECKLIST_TEXT_MAX_LENGTH),
-                  trimI18nValues(item.titleI18n(), CHECKLIST_TEXT_MAX_LENGTH),
-                  extractedDate,
-                  true,
-                  checklistIdList(savedItem.checklists())));
+    for (SavedExtractedItem savedItem : savedItems) {
+      ExtractedItem item = savedItem.item();
+      String extractedDate = normalizePreviewDate(item.datetime());
+      if (!"confirmed".equalsIgnoreCase(item.dateStatus()) || extractedDate == null) {
+        continue;
       }
 
-      if (previewEvents.isEmpty()) {
-          // 재분석 결과에 확정 날짜가 없으면 이전 미리보기 데이터가 남아 잘못 등록될 수 있어 비운다.
-          calendarPreviewRedisService.deletePreview(newsletterId);
-          log.debug("[AiAnalyzer] 캘린더 preview 생성 대상 없음. newsletterId={}", newsletterId);
-          return;
-      }
+      String titleSource =
+          displayTexts.getOrDefault("item_" + savedItem.itemIndex() + "_title", item.title());
 
-      calendarPreviewRedisService.savePreview(newsletterId, previewEvents);
-      log.debug(
-          "[AiAnalyzer] 캘린더 preview {}개 저장 완료. newsletterId={}", previewEvents.size(), newsletterId);
+      previewEvents.add(
+          new CalendarPreviewEvent(
+              "ai_evt_" + (previewEvents.size() + 1),
+              trimToMax(titleSource.trim(), CHECKLIST_TEXT_MAX_LENGTH),
+              trimI18nValues(item.titleI18n(), CHECKLIST_TEXT_MAX_LENGTH),
+              extractedDate,
+              true,
+              checklistIdList(savedItem.checklists())));
+    }
+
+    if (previewEvents.isEmpty()) {
+      // 재분석 결과에 확정 날짜가 없으면 이전 미리보기 데이터가 남아 잘못 등록될 수 있어 비운다.
+      calendarPreviewRedisService.deletePreview(newsletterId);
+      log.debug("[AiAnalyzer] 캘린더 preview 생성 대상 없음. newsletterId={}", newsletterId);
+      return;
+    }
+
+    calendarPreviewRedisService.savePreview(newsletterId, previewEvents);
+    log.debug(
+        "[AiAnalyzer] 캘린더 preview {}개 저장 완료. newsletterId={}", previewEvents.size(), newsletterId);
   }
 
   private String normalizePreviewDate(String value) {
@@ -371,7 +381,8 @@ public class NewsletterAiAnalyzer {
     return value.substring(0, maxLength - 3).stripTrailing() + "...";
   }
 
-  private record SavedExtractedItem(int itemIndex, ExtractedItem item, List<Checklist> checklists) {}
+  private record SavedExtractedItem(
+      int itemIndex, ExtractedItem item, List<Checklist> checklists) {}
 
   public record AiAnalysisResult(String title, Map<String, String> titleI18n, String summary) {}
 
@@ -381,28 +392,27 @@ public class NewsletterAiAnalyzer {
       List<AiNewsletterClient.ConversationTopicItem> topicItems,
       Map<String, String> displayTexts) {
 
-      if (topicItems == null || topicItems.isEmpty()) {
-          log.debug("[AiAnalyzer] 대화 주제 없음. newsletterId={}", newsletterId);
-          return;
+    if (topicItems == null || topicItems.isEmpty()) {
+      log.debug("[AiAnalyzer] 대화 주제 없음. newsletterId={}", newsletterId);
+      return;
+    }
+
+    List<com.gachi.be.domain.newsletter.entity.ConversationTopic> entities = new ArrayList<>();
+    for (int k = 0; k < topicItems.size(); k++) {
+      AiNewsletterClient.ConversationTopicItem item = topicItems.get(k);
+      if (item.topic() == null || item.topic().isBlank()) {
+        continue;
       }
+      String topicSource = displayTexts.getOrDefault("topic_" + k, item.topic());
+      entities.add(
+          com.gachi.be.domain.newsletter.entity.ConversationTopic.builder()
+              .newsletterId(newsletterId)
+              .userId(userId)
+              .topic(topicSource.trim())
+              .build());
+    }
 
-      List<com.gachi.be.domain.newsletter.entity.ConversationTopic> entities = new ArrayList<>();
-      for (int k = 0; k < topicItems.size(); k++) {
-          AiNewsletterClient.ConversationTopicItem item = topicItems.get(k);
-          if (item.topic() == null || item.topic().isBlank()) {
-              continue;
-          }
-          String topicSource = displayTexts.getOrDefault("topic_" + k, item.topic());
-          entities.add(
-              com.gachi.be.domain.newsletter.entity.ConversationTopic.builder()
-                  .newsletterId(newsletterId)
-                  .userId(userId)
-                  .topic(topicSource.trim())
-                  .build());
-      }
-
-
-      if (!entities.isEmpty()) {
+    if (!entities.isEmpty()) {
       conversationTopicRepository.saveAll(entities);
       log.debug("[AiAnalyzer] 대화 주제 {}개 저장 완료. newsletterId={}", entities.size(), newsletterId);
     }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -60,7 +60,7 @@ public class NewsletterAiAnalyzer {
         translateAndRefineDisplayTexts(originalText, language, analysisResponse, items);
 
     List<SavedExtractedItem> savedItems =
-        saveExtractedItems(newsletterId, newsletter.getUserId(), items, language);
+        saveExtractedItems(newsletterId, newsletter.getUserId(), items, displayTexts);
 
     try {
       saveCalendarPreview(newsletterId, savedItems, displayTexts);
@@ -71,8 +71,10 @@ public class NewsletterAiAnalyzer {
 
     saveConversationTopics(
         newsletterId, newsletter.getUserId(), analysisResponse.conversationTopics(), displayTexts);
-    String rawTitle = normalizeTitle(analysisResponse.title(), originalText);
-    String summary = normalizeSummary(analysisResponse.summary(), translatedText, originalText);
+    String finalTitle = displayTexts.getOrDefault(FIELD_ID_TITLE, analysisResponse.title());
+    String finalSummary = displayTexts.getOrDefault(FIELD_ID_SUMMARY, analysisResponse.summary());
+    String rawTitle = normalizeTitle(finalTitle, originalText);
+    String summary = normalizeSummary(finalSummary, translatedText, originalText);
     Map<String, String> normalizedTitleI18n =
         trimI18nValues(analysisResponse.titleI18n(), TITLE_MAX_LENGTH);
 
@@ -171,7 +173,7 @@ public class NewsletterAiAnalyzer {
   }
 
   private List<SavedExtractedItem> saveExtractedItems(
-      Long newsletterId, Long userId, List<ExtractedItem> items, String language) {
+      Long newsletterId, Long userId, List<ExtractedItem> items, Map<String, String> displayTexts) {
     if (items == null || items.isEmpty()) {
       log.warn("[AiAnalyzer] AI 서버 항목 추출 결과 없음. newsletterId={}", newsletterId);
       return List.of();
@@ -185,12 +187,14 @@ public class NewsletterAiAnalyzer {
       if (item.checklistItems() == null || item.checklistItems().isEmpty()) {
         continue;
       }
-      for (AiNewsletterClient.ChecklistItemDto checklistItem : item.checklistItems()) {
-        if (checklistItem.content() == null || checklistItem.content().isBlank()) {
-          continue; // 빈 content는 저장하지 않음
-        }
-        entitiesToSave.add(toChecklist(newsletterId, userId, checklistItem, displayTexts));
-        ownerItemIndex.add(itemIndex);
+      for (int checklistIndex = 0; checklistIndex < item.checklistItems().size(); checklistIndex++) {
+          AiNewsletterClient.ChecklistItemDto checklistItem = item.checklistItems().get(checklistIndex);
+          if (checklistItem.content() == null || checklistItem.content().isBlank()) {
+              continue; // 빈 content는 저장하지 않음
+          }
+          entitiesToSave.add(
+              toChecklist(newsletterId, userId, checklistItem, itemIndex, checklistIndex, displayTexts));
+          ownerItemIndex.add(itemIndex);
       }
     }
 

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -8,6 +8,7 @@ import com.gachi.be.domain.checklist.repository.ChecklistRepository;
 import com.gachi.be.domain.newsletter.entity.Newsletter;
 import com.gachi.be.domain.newsletter.pipeline.AiNewsletterClient.AnalysisResponse;
 import com.gachi.be.domain.newsletter.pipeline.AiNewsletterClient.ExtractedItem;
+import com.gachi.be.domain.newsletter.pipeline.AiNewsletterClient.RefineFieldRequest;
 import com.gachi.be.domain.newsletter.repository.ConversationTopicRepository;
 import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
 import java.time.LocalDate;
@@ -36,6 +37,7 @@ public class NewsletterAiAnalyzer {
   private final CalendarPreviewRedisService calendarPreviewRedisService;
   private final NewsletterRepository newsletterRepository;
   private final ConversationTopicRepository conversationTopicRepository;
+  private final PapagoTranslateClient papagoTranslateClient;
 
   public AiAnalysisResult analyze(
       Long newsletterId, String originalText, String translatedText, String language) {
@@ -54,18 +56,21 @@ public class NewsletterAiAnalyzer {
             originalText, translatedText, language, newsletter.getDateCandidates());
     List<ExtractedItem> items = analysisResponse.items();
 
+    Map<String, String> displayTexts =
+        translateAndRefineDisplayTexts(originalText, language, analysisResponse, items);
+
     List<SavedExtractedItem> savedItems =
         saveExtractedItems(newsletterId, newsletter.getUserId(), items, language);
 
     try {
-      saveCalendarPreview(newsletterId, savedItems);
+      saveCalendarPreview(newsletterId, savedItems, displayTexts);
     } catch (RuntimeException e) {
       log.warn(
           "[AiAnalyzer] 캘린더 preview 저장 실패. 분석 결과 저장은 계속 진행합니다. newsletterId={}", newsletterId, e);
     }
 
     saveConversationTopics(
-        newsletterId, newsletter.getUserId(), analysisResponse.conversationTopics());
+        newsletterId, newsletter.getUserId(), analysisResponse.conversationTopics(), displayTexts);
     String rawTitle = normalizeTitle(analysisResponse.title(), originalText);
     String summary = normalizeSummary(analysisResponse.summary(), translatedText, originalText);
     Map<String, String> normalizedTitleI18n =
@@ -74,6 +79,95 @@ public class NewsletterAiAnalyzer {
     log.info(
         "[AiAnalyzer] AI 서버 분석 완료. newsletterId={}, extractedItems={}", newsletterId, items.size());
     return new AiAnalysisResult(rawTitle, normalizedTitleI18n, summary);
+  }
+
+  private static final String FIELD_ID_TITLE = "title";
+  private static final String FIELD_ID_SUMMARY = "summary";
+
+  /**
+     * 1차 분석 응답(한국어)에서 화면에 노출되는 텍스트(title/summary/items[].title/
+     * checklistItems[].content,detail/conversationTopics[].topic)를 모아 id를 부여하고,
+     * KO가 아니면 Papago로 1차 번역 → AI 서버로 2차 검증을 거쳐 최종 텍스트 맵을 반환한다.
+     *
+     * language=KO이거나 번역 대상 텍스트가 없으면 한국어 원본을 그대로 반환한다 (id → 원본 텍스트).
+     */
+  private Map<String, String> translateAndRefineDisplayTexts(
+      String originalText, String language, AnalysisResponse analysisResponse, List<ExtractedItem> items) {
+
+      Map<String, String> koTextsById = collectKoreanDisplayTexts(analysisResponse, items);
+
+      if ("KO".equals(language)) {
+            // KO 사용자는 한국어 원본을 그대로 사용 (번역/검증 불필요)
+          return koTextsById;
+      }
+
+      // 1차: Papago 한국어 → language 번역
+      Map<String, String> papagoTextsById = new LinkedHashMap<>();
+      for (Map.Entry<String, String> entry : koTextsById.entrySet()) {
+          String koText = entry.getValue();
+          String translated = papagoTranslateClient.translate(koText, language);
+          papagoTextsById.put(entry.getKey(), translated != null ? translated : koText);
+      }
+
+        // 2차: AI 서버 검증/교정
+      List<RefineFieldRequest> refineFields = new ArrayList<>();
+      for (Map.Entry<String, String> entry : koTextsById.entrySet()) {
+          refineFields.add(
+              new RefineFieldRequest(
+                  entry.getKey(), entry.getValue(), papagoTextsById.get(entry.getKey())));
+      }
+
+      try {
+          Map<String, String> refinedById =
+              aiNewsletterClient.refineTranslation(originalText, language, refineFields).toMap();
+
+          Map<String, String> result = new LinkedHashMap<>(papagoTextsById);
+          result.putAll(refinedById); // 검증 결과로 덮어쓰기. 누락된 id는 파파고 번역값 유지.
+          return result;
+      } catch (RuntimeException e) {
+          // 2차 검증 실패 시 파파고 1차 번역 결과로 폴백 (전체 파이프라인은 계속 진행)
+          log.warn("[AiAnalyzer] 2차 검증 실패. 파파고 1차 번역 결과로 대체합니다. error={}", e.getMessage(), e);
+          return papagoTextsById;
+      }
+  }
+
+  /**
+   * 1차 분석 응답(한국어)에서 화면 노출 텍스트를 id → 한국어 텍스트 맵으로 수집한다.
+   */
+  private Map<String, String> collectKoreanDisplayTexts(
+      AnalysisResponse analysisResponse, List<ExtractedItem> items) {
+      Map<String, String> texts = new LinkedHashMap<>();
+
+      putIfNotBlank(texts, FIELD_ID_TITLE, analysisResponse.title());
+      putIfNotBlank(texts, FIELD_ID_SUMMARY, analysisResponse.summary());
+
+      for (int i = 0; i < items.size(); i++) {
+          ExtractedItem item = items.get(i);
+          putIfNotBlank(texts, "item_" + i + "_title", item.title());
+
+          if (item.checklistItems() == null) {
+              continue;
+          }
+          for (int j = 0; j < item.checklistItems().size(); j++) {
+              AiNewsletterClient.ChecklistItemDto checklistItem = item.checklistItems().get(j);
+              putIfNotBlank(texts, "item_" + i + "_chk_" + j + "_content", checklistItem.content());
+              putIfNotBlank(texts, "item_" + i + "_chk_" + j + "_detail", checklistItem.detail());
+          }
+      }
+
+      if (analysisResponse.conversationTopics() != null) {
+            for (int k = 0; k < analysisResponse.conversationTopics().size(); k++) {
+                putIfNotBlank(texts, "topic_" + k, analysisResponse.conversationTopics().get(k).topic());
+            }
+      }
+
+      return texts;
+  }
+
+  private void putIfNotBlank(Map<String, String> map, String id, String value) {
+      if (value != null && !value.isBlank()) {
+          map.put(id, value);
+      }
   }
 
   private List<SavedExtractedItem> saveExtractedItems(
@@ -95,7 +189,7 @@ public class NewsletterAiAnalyzer {
         if (checklistItem.content() == null || checklistItem.content().isBlank()) {
           continue; // 빈 content는 저장하지 않음
         }
-        entitiesToSave.add(toChecklist(newsletterId, userId, checklistItem));
+        entitiesToSave.add(toChecklist(newsletterId, userId, checklistItem, displayTexts));
         ownerItemIndex.add(itemIndex);
       }
     }
@@ -120,29 +214,37 @@ public class NewsletterAiAnalyzer {
         continue;
       }
       List<Checklist> linkedChecklists = checklistsByItemIndex.getOrDefault(itemIndex, List.of());
-      result.add(new SavedExtractedItem(item, linkedChecklists));
+      result.add(new SavedExtractedItem(itemIndex,item, linkedChecklists));
     }
     return result;
   }
 
-  private Checklist toChecklist(
-      Long newsletterId, Long userId, AiNewsletterClient.ChecklistItemDto checklistItem) {
-    String content = trimToMax(checklistItem.content().trim(), CHECKLIST_TEXT_MAX_LENGTH);
+  private Checklist toChecklist(Long newsletterId, Long userId, AiNewsletterClient.ChecklistItemDto checklistItem, int itemIndex, int checklistIndex,
+                                Map<String, String> displayTexts) {
+      String contentKey = "item_" + itemIndex + "_chk_" + checklistIndex + "_content";
+      String detailKey = "item_" + itemIndex + "_chk_" + checklistIndex + "_detail";
 
-    String detail = null;
-    if (checklistItem.detail() != null && !checklistItem.detail().isBlank()) {
-      detail = trimNullable(checklistItem.detail(), CHECKLIST_TEXT_MAX_LENGTH);
-    }
+      String contentSource = displayTexts.getOrDefault(contentKey, checklistItem.content());
+      String content = trimToMax(contentSource.trim(), CHECKLIST_TEXT_MAX_LENGTH);
+
+      String detail = null;
+      String detailSource = displayTexts.get(detailKey);
+      if (detailSource == null) {
+          detailSource = checklistItem.detail();
+      }
+      if (detailSource != null && !detailSource.isBlank()) {
+          detail = trimNullable(detailSource, CHECKLIST_TEXT_MAX_LENGTH);
+      }
 
     return Checklist.builder()
         .newsletterId(newsletterId)
         .calendarEventId(null) // 캘린더 등록 시점에 연결됨 (linkChecklistsToEvents)
         .userId(userId)
-        .type(ChecklistType.CHECKLIST) // v7: CHECKLIST만 사용
+        .type(ChecklistType.CHECKLIST) // CHECKLIST만 사용
         .content(content)
         .contentI18n(trimI18nValues(checklistItem.contentI18n(), CHECKLIST_TEXT_MAX_LENGTH))
         .detail(detail)
-        .targetDate(null) // v7: 체크리스트는 날짜를 갖지 않음 (일정의 날짜를 따라감)
+        .targetDate(null) // 체크리스트는 날짜를 갖지 않음 (일정의 날짜를 따라감)
         .targetDateLabel(null)
         .build();
   }
@@ -160,36 +262,40 @@ public class NewsletterAiAnalyzer {
     }
   }
 
-  private void saveCalendarPreview(Long newsletterId, List<SavedExtractedItem> savedItems) {
-    List<CalendarPreviewEvent> previewEvents = new ArrayList<>();
+  private void saveCalendarPreview(
+      Long newsletterId, List<SavedExtractedItem> savedItems, Map<String, String> displayTexts) {
+      List<CalendarPreviewEvent> previewEvents = new ArrayList<>();
 
-    for (SavedExtractedItem savedItem : savedItems) {
-      ExtractedItem item = savedItem.item();
-      String extractedDate = normalizePreviewDate(item.datetime());
-      if (!"confirmed".equalsIgnoreCase(item.dateStatus()) || extractedDate == null) {
-        continue;
+      for (SavedExtractedItem savedItem : savedItems) {
+          ExtractedItem item = savedItem.item();
+          String extractedDate = normalizePreviewDate(item.datetime());
+          if (!"confirmed".equalsIgnoreCase(item.dateStatus()) || extractedDate == null) {
+              continue;
+          }
+
+          String titleSource =
+              displayTexts.getOrDefault("item_" + savedItem.itemIndex() + "_title", item.title());
+
+          previewEvents.add(
+              new CalendarPreviewEvent(
+                  "ai_evt_" + (previewEvents.size() + 1),
+                  trimToMax(titleSource.trim(), CHECKLIST_TEXT_MAX_LENGTH),
+                  trimI18nValues(item.titleI18n(), CHECKLIST_TEXT_MAX_LENGTH),
+                  extractedDate,
+                  true,
+                  checklistIdList(savedItem.checklists())));
       }
 
-      previewEvents.add(
-          new CalendarPreviewEvent(
-              "ai_evt_" + (previewEvents.size() + 1),
-              trimToMax(item.title().trim(), CHECKLIST_TEXT_MAX_LENGTH),
-              trimI18nValues(item.titleI18n(), CHECKLIST_TEXT_MAX_LENGTH),
-              extractedDate,
-              true,
-              checklistIdList(savedItem.checklists())));
-    }
+      if (previewEvents.isEmpty()) {
+          // 재분석 결과에 확정 날짜가 없으면 이전 미리보기 데이터가 남아 잘못 등록될 수 있어 비운다.
+          calendarPreviewRedisService.deletePreview(newsletterId);
+          log.debug("[AiAnalyzer] 캘린더 preview 생성 대상 없음. newsletterId={}", newsletterId);
+          return;
+      }
 
-    if (previewEvents.isEmpty()) {
-      // 재분석 결과에 확정 날짜가 없으면 이전 미리보기 데이터가 남아 잘못 등록될 수 있어 비운다.
-      calendarPreviewRedisService.deletePreview(newsletterId);
-      log.debug("[AiAnalyzer] 캘린더 preview 생성 대상 없음. newsletterId={}", newsletterId);
-      return;
-    }
-
-    calendarPreviewRedisService.savePreview(newsletterId, previewEvents);
-    log.debug(
-        "[AiAnalyzer] 캘린더 preview {}개 저장 완료. newsletterId={}", previewEvents.size(), newsletterId);
+      calendarPreviewRedisService.savePreview(newsletterId, previewEvents);
+      log.debug(
+          "[AiAnalyzer] 캘린더 preview {}개 저장 완료. newsletterId={}", previewEvents.size(), newsletterId);
   }
 
   private String normalizePreviewDate(String value) {
@@ -261,32 +367,38 @@ public class NewsletterAiAnalyzer {
     return value.substring(0, maxLength - 3).stripTrailing() + "...";
   }
 
-  private record SavedExtractedItem(ExtractedItem item, List<Checklist> checklists) {}
+  private record SavedExtractedItem(int itemIndex, ExtractedItem item, List<Checklist> checklists) {}
 
   public record AiAnalysisResult(String title, Map<String, String> titleI18n, String summary) {}
 
   private void saveConversationTopics(
-      Long newsletterId, Long userId, List<AiNewsletterClient.ConversationTopicItem> topicItems) {
+      Long newsletterId,
+      Long userId,
+      List<AiNewsletterClient.ConversationTopicItem> topicItems,
+      Map<String, String> displayTexts) {
 
-    if (topicItems == null || topicItems.isEmpty()) {
-      log.debug("[AiAnalyzer] 대화 주제 없음. newsletterId={}", newsletterId);
-      return;
-    }
+      if (topicItems == null || topicItems.isEmpty()) {
+          log.debug("[AiAnalyzer] 대화 주제 없음. newsletterId={}", newsletterId);
+          return;
+      }
 
-    List<com.gachi.be.domain.newsletter.entity.ConversationTopic> entities =
-        topicItems.stream()
-            .filter(item -> item.topic() != null && !item.topic().isBlank())
-            .map(
-                item -> {
-                  return com.gachi.be.domain.newsletter.entity.ConversationTopic.builder()
-                      .newsletterId(newsletterId)
-                      .userId(userId)
-                      .topic(item.topic().trim())
-                      .build();
-                })
-            .toList();
+      List<com.gachi.be.domain.newsletter.entity.ConversationTopic> entities = new ArrayList<>();
+      for (int k = 0; k < topicItems.size(); k++) {
+          AiNewsletterClient.ConversationTopicItem item = topicItems.get(k);
+          if (item.topic() == null || item.topic().isBlank()) {
+              continue;
+          }
+          String topicSource = displayTexts.getOrDefault("topic_" + k, item.topic());
+          entities.add(
+              com.gachi.be.domain.newsletter.entity.ConversationTopic.builder()
+                  .newsletterId(newsletterId)
+                  .userId(userId)
+                  .topic(topicSource.trim())
+                  .build());
+      }
 
-    if (!entities.isEmpty()) {
+
+      if (!entities.isEmpty()) {
       conversationTopicRepository.saveAll(entities);
       log.debug("[AiAnalyzer] 대화 주제 {}개 저장 완료. newsletterId={}", entities.size(), newsletterId);
     }

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzer.java
@@ -98,10 +98,11 @@ public class NewsletterAiAnalyzer {
       String language,
       AnalysisResponse analysisResponse,
       List<ExtractedItem> items) {
-
+    String normalizedLanguage =
+        (language == null || language.isBlank()) ? "KO" : language.trim().toUpperCase();
     Map<String, String> koTextsById = collectKoreanDisplayTexts(analysisResponse, items);
 
-    if ("KO".equals(language)) {
+    if ("KO".equals(normalizedLanguage)) {
       // KO 사용자는 한국어 원본을 그대로 사용 (번역/검증 불필요)
       return koTextsById;
     }
@@ -110,7 +111,7 @@ public class NewsletterAiAnalyzer {
     Map<String, String> papagoTextsById = new LinkedHashMap<>();
     for (Map.Entry<String, String> entry : koTextsById.entrySet()) {
       String koText = entry.getValue();
-      String translated = papagoTranslateClient.translate(koText, language);
+      String translated = papagoTranslateClient.translate(koText, normalizedLanguage);
       papagoTextsById.put(entry.getKey(), translated != null ? translated : koText);
     }
 
@@ -124,7 +125,9 @@ public class NewsletterAiAnalyzer {
 
     try {
       Map<String, String> refinedById =
-          aiNewsletterClient.refineTranslation(originalText, language, refineFields).toMap();
+          aiNewsletterClient
+              .refineTranslation(originalText, normalizedLanguage, refineFields)
+              .toMap();
 
       Map<String, String> result = new LinkedHashMap<>(papagoTextsById);
       result.putAll(refinedById); // 검증 결과로 덮어쓰기. 누락된 id는 파파고 번역값 유지.

--- a/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzerTest.java
+++ b/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzerTest.java
@@ -38,358 +38,358 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class NewsletterAiAnalyzerTest {
 
-    @Mock private AiNewsletterClient aiNewsletterClient;
-    @Mock private ChecklistRepository checklistRepository;
-    @Mock private CalendarPreviewRedisService calendarPreviewRedisService;
-    @Mock private NewsletterRepository newsletterRepository;
-    @Mock private ConversationTopicRepository conversationTopicRepository;
-    @Mock private PapagoTranslateClient papagoTranslateClient;
+  @Mock private AiNewsletterClient aiNewsletterClient;
+  @Mock private ChecklistRepository checklistRepository;
+  @Mock private CalendarPreviewRedisService calendarPreviewRedisService;
+  @Mock private NewsletterRepository newsletterRepository;
+  @Mock private ConversationTopicRepository conversationTopicRepository;
+  @Mock private PapagoTranslateClient papagoTranslateClient;
 
-    @Captor private ArgumentCaptor<List<Checklist>> checklistsCaptor;
-    @Captor private ArgumentCaptor<List<CalendarPreviewEvent>> previewEventsCaptor;
-    @Captor
-    private ArgumentCaptor<List<com.gachi.be.domain.newsletter.entity.ConversationTopic>>
-        conversationTopicsCaptor;
+  @Captor private ArgumentCaptor<List<Checklist>> checklistsCaptor;
+  @Captor private ArgumentCaptor<List<CalendarPreviewEvent>> previewEventsCaptor;
 
-    @InjectMocks private NewsletterAiAnalyzer newsletterAiAnalyzer;
+  @Captor
+  private ArgumentCaptor<List<com.gachi.be.domain.newsletter.entity.ConversationTopic>>
+      conversationTopicsCaptor;
 
-    @Test
-    void analyzeUsesAiTitleSummaryAndSavesItems() {
-        Long newsletterId = 10L;
-        Newsletter newsletter =
-            Newsletter.builder()
-                .userId(20L)
-                .fileKey("newsletter.pdf")
-                .fileHash("hash")
-                .status(NewsletterStatus.PROCESSING)
-                .language("KO")
-                .build();
+  @InjectMocks private NewsletterAiAnalyzer newsletterAiAnalyzer;
 
-        ExtractedItem item =
-            new ExtractedItem(
-                "reminder",
-                "준비물 확인",
-                null,
-                "2026-05-25",
-                "Asia/Seoul",
-                "체육복을 준비해 주세요.",
-                "confirmed",
-                0.91,
-                false,
-                null,
-                List.of(new AiNewsletterClient.ChecklistItemDto("준비물 확인", "체육복을 준비해 주세요.")));
+  @Test
+  void analyzeUsesAiTitleSummaryAndSavesItems() {
+    Long newsletterId = 10L;
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(20L)
+            .fileKey("newsletter.pdf")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("KO")
+            .build();
 
-        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-        when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
-            .thenReturn(
-                new AnalysisResponse(
-                    "AI 제목",
-                    Map.of(" us ", " AI English title "),
-                    "AI 요약",
-                    List.of(item),
-                    List.of(),
-                    Map.of()));
-        when(checklistRepository.saveAll(anyList()))
-            .thenAnswer(
-                invocation -> {
-                    List<Checklist> checklists = invocation.getArgument(0);
-                    ReflectionTestUtils.setField(checklists.get(0), "id", 501L);
-                    return checklists;
-                });
+    ExtractedItem item =
+        new ExtractedItem(
+            "reminder",
+            "준비물 확인",
+            null,
+            "2026-05-25",
+            "Asia/Seoul",
+            "체육복을 준비해 주세요.",
+            "confirmed",
+            0.91,
+            false,
+            null,
+            List.of(new AiNewsletterClient.ChecklistItemDto("준비물 확인", "체육복을 준비해 주세요.")));
 
-        AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
+    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+    when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
+        .thenReturn(
+            new AnalysisResponse(
+                "AI 제목",
+                Map.of(" us ", " AI English title "),
+                "AI 요약",
+                List.of(item),
+                List.of(),
+                Map.of()));
+    when(checklistRepository.saveAll(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<Checklist> checklists = invocation.getArgument(0);
+              ReflectionTestUtils.setField(checklists.get(0), "id", 501L);
+              return checklists;
+            });
 
-        assertThat(result.title()).isEqualTo("AI 제목");
-        assertThat(result.titleI18n()).containsEntry("US", "AI English title");
-        assertThat(result.summary()).isEqualTo("AI 요약");
+    AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
 
-        verify(checklistRepository).saveAll(checklistsCaptor.capture());
+    assertThat(result.title()).isEqualTo("AI 제목");
+    assertThat(result.titleI18n()).containsEntry("US", "AI English title");
+    assertThat(result.summary()).isEqualTo("AI 요약");
 
-        List<Checklist> savedItems = checklistsCaptor.getValue();
-        assertThat(savedItems).hasSize(1);
-        assertThat(savedItems.get(0).getNewsletterId()).isEqualTo(newsletterId);
-        assertThat(savedItems.get(0).getUserId()).isEqualTo(20L);
-        assertThat(savedItems.get(0).getContent()).isEqualTo("준비물 확인");
-        assertThat(savedItems.get(0).getDetail()).isEqualTo("체육복을 준비해 주세요.");
-        assertThat(savedItems.get(0).getTargetDate()).isNull();
-        assertThat(savedItems.get(0).getTargetDateLabel()).isNull();
-        verify(calendarPreviewRedisService)
-            .savePreview(eq(newsletterId), previewEventsCaptor.capture());
-        List<CalendarPreviewEvent> previewEvents = previewEventsCaptor.getValue();
-        assertThat(previewEvents).hasSize(1);
-        assertThat(previewEvents.get(0).tempEventId()).isEqualTo("ai_evt_1");
-        assertThat(previewEvents.get(0).title()).isEqualTo("준비물 확인");
-        assertThat(previewEvents.get(0).extractedDate()).isEqualTo("2026-05-25");
-        assertThat(previewEvents.get(0).isDateExtracted()).isTrue();
-        assertThat(previewEvents.get(0).checklistIds()).containsExactly(501L);
+    verify(checklistRepository).saveAll(checklistsCaptor.capture());
 
-        verify(papagoTranslateClient, never()).translate(anyString(), anyString());
-        verify(aiNewsletterClient, never()).refineTranslation(anyString(), anyString(), anyList());
-    }
+    List<Checklist> savedItems = checklistsCaptor.getValue();
+    assertThat(savedItems).hasSize(1);
+    assertThat(savedItems.get(0).getNewsletterId()).isEqualTo(newsletterId);
+    assertThat(savedItems.get(0).getUserId()).isEqualTo(20L);
+    assertThat(savedItems.get(0).getContent()).isEqualTo("준비물 확인");
+    assertThat(savedItems.get(0).getDetail()).isEqualTo("체육복을 준비해 주세요.");
+    assertThat(savedItems.get(0).getTargetDate()).isNull();
+    assertThat(savedItems.get(0).getTargetDateLabel()).isNull();
+    verify(calendarPreviewRedisService)
+        .savePreview(eq(newsletterId), previewEventsCaptor.capture());
+    List<CalendarPreviewEvent> previewEvents = previewEventsCaptor.getValue();
+    assertThat(previewEvents).hasSize(1);
+    assertThat(previewEvents.get(0).tempEventId()).isEqualTo("ai_evt_1");
+    assertThat(previewEvents.get(0).title()).isEqualTo("준비물 확인");
+    assertThat(previewEvents.get(0).extractedDate()).isEqualTo("2026-05-25");
+    assertThat(previewEvents.get(0).isDateExtracted()).isTrue();
+    assertThat(previewEvents.get(0).checklistIds()).containsExactly(501L);
 
-    @Test
-    void analyzeSkipsCalendarPreviewWhenDateIsNotConfirmed() {
-        Long newsletterId = 14L;
-        Newsletter newsletter =
-            Newsletter.builder()
-                .userId(24L)
-                .fileKey("newsletter.pdf")
-                .fileHash("hash")
-                .status(NewsletterStatus.PROCESSING)
-                .language("KO")
-                .build();
+    verify(papagoTranslateClient, never()).translate(anyString(), anyString());
+    verify(aiNewsletterClient, never()).refineTranslation(anyString(), anyString(), anyList());
+  }
 
-        ExtractedItem item =
-            new ExtractedItem(
-                "deadline",
-                "신청서 제출",
-                null,
-                "2026-05-25",
-                "Asia/Seoul",
-                "체험학습 3일 전까지 신청서를 제출해 주세요.",
-                "ambiguous",
-                0.7,
-                true,
-                "체험학습 날짜를 확인해 주세요.",
-                List.of());
+  @Test
+  void analyzeSkipsCalendarPreviewWhenDateIsNotConfirmed() {
+    Long newsletterId = 14L;
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(24L)
+            .fileKey("newsletter.pdf")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("KO")
+            .build();
 
-        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-        when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
-            .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(item), List.of(), Map.of()));
-        newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
+    ExtractedItem item =
+        new ExtractedItem(
+            "deadline",
+            "신청서 제출",
+            null,
+            "2026-05-25",
+            "Asia/Seoul",
+            "체험학습 3일 전까지 신청서를 제출해 주세요.",
+            "ambiguous",
+            0.7,
+            true,
+            "체험학습 날짜를 확인해 주세요.",
+            List.of());
 
-        verify(calendarPreviewRedisService).deletePreview(newsletterId);
-    }
+    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+    when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
+        .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(item), List.of(), Map.of()));
+    newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
 
-    @Test
-    void analyzeContinuesWhenCalendarPreviewSaveFails() {
-        Long newsletterId = 15L;
-        Newsletter newsletter =
-            Newsletter.builder()
-                .userId(25L)
-                .fileKey("newsletter.pdf")
-                .fileHash("hash")
-                .status(NewsletterStatus.PROCESSING)
-                .language("KO")
-                .build();
+    verify(calendarPreviewRedisService).deletePreview(newsletterId);
+  }
 
-        ExtractedItem item =
-            new ExtractedItem(
-                "schedule",
-                "현장학습 참석",
-                null,
-                "2026-05-25",
-                "Asia/Seoul",
-                "5월 25일 현장학습에 참석합니다.",
-                "confirmed",
-                0.9,
-                false,
-                null,
-                List.of(new AiNewsletterClient.ChecklistItemDto("도시락 준비하기", "현장학습 당일 도시락을 준비해 주세요.")));
+  @Test
+  void analyzeContinuesWhenCalendarPreviewSaveFails() {
+    Long newsletterId = 15L;
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(25L)
+            .fileKey("newsletter.pdf")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("KO")
+            .build();
 
-        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-        when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
-            .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(item), List.of(), Map.of()));
-        when(checklistRepository.saveAll(anyList()))
-            .thenAnswer(
-                invocation -> {
-                    List<Checklist> checklists = invocation.getArgument(0);
-                    ReflectionTestUtils.setField(checklists.get(0), "id", 502L);
-                    return checklists;
-                });
-        doThrow(new RuntimeException("Redis down"))
-            .when(calendarPreviewRedisService)
-            .savePreview(eq(newsletterId), anyList());
+    ExtractedItem item =
+        new ExtractedItem(
+            "schedule",
+            "현장학습 참석",
+            null,
+            "2026-05-25",
+            "Asia/Seoul",
+            "5월 25일 현장학습에 참석합니다.",
+            "confirmed",
+            0.9,
+            false,
+            null,
+            List.of(new AiNewsletterClient.ChecklistItemDto("도시락 준비하기", "현장학습 당일 도시락을 준비해 주세요.")));
 
-        AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
+    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+    when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
+        .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(item), List.of(), Map.of()));
+    when(checklistRepository.saveAll(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<Checklist> checklists = invocation.getArgument(0);
+              ReflectionTestUtils.setField(checklists.get(0), "id", 502L);
+              return checklists;
+            });
+    doThrow(new RuntimeException("Redis down"))
+        .when(calendarPreviewRedisService)
+        .savePreview(eq(newsletterId), anyList());
 
-        assertThat(result.title()).isEqualTo("AI 제목");
-        assertThat(result.summary()).isEqualTo("AI 요약");
-        verify(checklistRepository).saveAll(anyList());
-    }
+    AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
 
-    @Test
-    void analyzeFallsBackWhenAiTitleSummaryAreBlank() {
-        Long newsletterId = 11L;
-        Newsletter newsletter =
-            Newsletter.builder()
-                .userId(21L)
-                .fileKey("newsletter.pdf")
-                .fileHash("hash")
-                .status(NewsletterStatus.PROCESSING)
-                .language("KO")
-                .build();
+    assertThat(result.title()).isEqualTo("AI 제목");
+    assertThat(result.summary()).isEqualTo("AI 요약");
+    verify(checklistRepository).saveAll(anyList());
+  }
 
-        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-        when(aiNewsletterClient.analyze("가정통신문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
-            .thenReturn(new AnalysisResponse("  ", "  ", List.of(), List.of(), Map.of()));
+  @Test
+  void analyzeFallsBackWhenAiTitleSummaryAreBlank() {
+    Long newsletterId = 11L;
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(21L)
+            .fileKey("newsletter.pdf")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("KO")
+            .build();
 
-        AiAnalysisResult result =
-            newsletterAiAnalyzer.analyze(newsletterId, "가정통신문 제목\n본문입니다.", "번역 요약 대상", "KO");
+    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+    when(aiNewsletterClient.analyze("가정통신문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
+        .thenReturn(new AnalysisResponse("  ", "  ", List.of(), List.of(), Map.of()));
 
-        assertThat(result.title()).isEqualTo("가정통신문 제목");
-        assertThat(result.summary()).isEqualTo("번역 요약 대상");
-        verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
-    }
+    AiAnalysisResult result =
+        newsletterAiAnalyzer.analyze(newsletterId, "가정통신문 제목\n본문입니다.", "번역 요약 대상", "KO");
 
-    @Test
-    void analyzeFallsBackOnlySummaryWhenAiSummaryIsBlank() {
-        Long newsletterId = 12L;
-        Newsletter newsletter =
-            Newsletter.builder()
-                .userId(22L)
-                .fileKey("newsletter.pdf")
-                .fileHash("hash")
-                .status(NewsletterStatus.PROCESSING)
-                .language("KO")
-                .build();
+    assertThat(result.title()).isEqualTo("가정통신문 제목");
+    assertThat(result.summary()).isEqualTo("번역 요약 대상");
+    verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
+  }
 
-        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-        when(aiNewsletterClient.analyze("원문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
-            .thenReturn(new AnalysisResponse("AI 제목", " ", List.of(), List.of(), Map.of()));
+  @Test
+  void analyzeFallsBackOnlySummaryWhenAiSummaryIsBlank() {
+    Long newsletterId = 12L;
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(22L)
+            .fileKey("newsletter.pdf")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("KO")
+            .build();
 
-        AiAnalysisResult result =
-            newsletterAiAnalyzer.analyze(newsletterId, "원문 제목\n본문입니다.", "번역 요약 대상", "KO");
+    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+    when(aiNewsletterClient.analyze("원문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
+        .thenReturn(new AnalysisResponse("AI 제목", " ", List.of(), List.of(), Map.of()));
 
-        assertThat(result.title()).isEqualTo("AI 제목");
-        assertThat(result.summary()).isEqualTo("번역 요약 대상");
-        verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
-    }
+    AiAnalysisResult result =
+        newsletterAiAnalyzer.analyze(newsletterId, "원문 제목\n본문입니다.", "번역 요약 대상", "KO");
 
-    @Test
-    void analyzeFallsBackOnlyTitleWhenAiTitleIsBlank() {
-        Long newsletterId = 13L;
-        Newsletter newsletter =
-            Newsletter.builder()
-                .userId(23L)
-                .fileKey("newsletter.pdf")
-                .fileHash("hash")
-                .status(NewsletterStatus.PROCESSING)
-                .language("KO")
-                .build();
+    assertThat(result.title()).isEqualTo("AI 제목");
+    assertThat(result.summary()).isEqualTo("번역 요약 대상");
+    verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
+  }
 
-        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-        when(aiNewsletterClient.analyze("원문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
-            .thenReturn(new AnalysisResponse("", "AI 요약", List.of(), List.of(), Map.of()));
+  @Test
+  void analyzeFallsBackOnlyTitleWhenAiTitleIsBlank() {
+    Long newsletterId = 13L;
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(23L)
+            .fileKey("newsletter.pdf")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("KO")
+            .build();
 
-        AiAnalysisResult result =
-            newsletterAiAnalyzer.analyze(newsletterId, "원문 제목\n본문입니다.", "번역 요약 대상", "KO");
+    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+    when(aiNewsletterClient.analyze("원문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
+        .thenReturn(new AnalysisResponse("", "AI 요약", List.of(), List.of(), Map.of()));
 
-        assertThat(result.title()).isEqualTo("원문 제목");
-        assertThat(result.summary()).isEqualTo("AI 요약");
-        verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
-    }
+    AiAnalysisResult result =
+        newsletterAiAnalyzer.analyze(newsletterId, "원문 제목\n본문입니다.", "번역 요약 대상", "KO");
 
-    @Test
-    void analyzeTranslatesAndRefinesDisplayTextsForNonKoLanguage() {
-        Long newsletterId = 30L;
-        Newsletter newsletter =
-            Newsletter.builder()
-                .userId(40L)
-                .fileKey("newsletter.pdf")
-                .fileHash("hash")
-                .status(NewsletterStatus.PROCESSING)
-                .language("VI")
-                .build();
+    assertThat(result.title()).isEqualTo("원문 제목");
+    assertThat(result.summary()).isEqualTo("AI 요약");
+    verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
+  }
 
-        ExtractedItem item =
-            new ExtractedItem(
-                "reminder",
-                "준비물 확인", // item_0_title (한국어)
-                null,
-                "2026-05-25",
-                "Asia/Seoul",
-                "체육복을 준비해 주세요.",
-                "confirmed",
-                0.91,
-                false,
-                null,
-                List.of(
-                    new AiNewsletterClient.ChecklistItemDto(
-                        "준비물 확인", // item_0_chk_0_content (한국어)
-                        "체육복을 준비해 주세요." // item_0_chk_0_detail (한국어)
+  @Test
+  void analyzeTranslatesAndRefinesDisplayTextsForNonKoLanguage() {
+    Long newsletterId = 30L;
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(40L)
+            .fileKey("newsletter.pdf")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("VI")
+            .build();
+
+    ExtractedItem item =
+        new ExtractedItem(
+            "reminder",
+            "준비물 확인", // item_0_title (한국어)
+            null,
+            "2026-05-25",
+            "Asia/Seoul",
+            "체육복을 준비해 주세요.",
+            "confirmed",
+            0.91,
+            false,
+            null,
+            List.of(
+                new AiNewsletterClient.ChecklistItemDto(
+                    "준비물 확인", // item_0_chk_0_content (한국어)
+                    "체육복을 준비해 주세요." // item_0_chk_0_detail (한국어)
                     )));
 
-        ConversationTopicItem topic = new ConversationTopicItem("수영장에서 뭐가 제일 기대돼?"); // topic_0 (한국어)
+    ConversationTopicItem topic = new ConversationTopicItem("수영장에서 뭐가 제일 기대돼?"); // topic_0 (한국어)
 
-        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-        when(aiNewsletterClient.analyze("원문", "번역문", "VI", List.of()))
-            .thenReturn(
-                new AnalysisResponse(
-                    "AI 제목", Map.of(), "AI 요약", List.of(item), List.of(topic), Map.of()));
+    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+    when(aiNewsletterClient.analyze("원문", "번역문", "VI", List.of()))
+        .thenReturn(
+            new AnalysisResponse(
+                "AI 제목", Map.of(), "AI 요약", List.of(item), List.of(topic), Map.of()));
 
-        // 파파고 1차 번역: 한국어 → 베트남어 (간단히 "[VI] " 접두사로 표현)
-        when(papagoTranslateClient.translate(org.mockito.ArgumentMatchers.anyString(), eq("VI")))
-            .thenAnswer(invocation -> "[VI] " + invocation.getArgument(0));
+    // 파파고 1차 번역: 한국어 → 베트남어 (간단히 "[VI] " 접두사로 표현)
+    when(papagoTranslateClient.translate(org.mockito.ArgumentMatchers.anyString(), eq("VI")))
+        .thenAnswer(invocation -> "[VI] " + invocation.getArgument(0));
 
-        // AI 서버 2차 검증: title만 교정하고 나머지는 파파고 번역 그대로 통과
-        when(aiNewsletterClient.refineTranslation(
+    // AI 서버 2차 검증: title만 교정하고 나머지는 파파고 번역 그대로 통과
+    when(aiNewsletterClient.refineTranslation(
             eq("원문"), eq("VI"), org.mockito.ArgumentMatchers.anyList()))
-            .thenReturn(
-                new RefineTranslationResponse(
-                    List.of(new RefineFieldResponse("title", "[VI-검증] AI 제목"))));
+        .thenReturn(
+            new RefineTranslationResponse(
+                List.of(new RefineFieldResponse("title", "[VI-검증] AI 제목"))));
 
-        when(checklistRepository.saveAll(anyList()))
-            .thenAnswer(
-                invocation -> {
-                    List<Checklist> checklists = invocation.getArgument(0);
-                    ReflectionTestUtils.setField(checklists.get(0), "id", 601L);
-                    return checklists;
-                });
+    when(checklistRepository.saveAll(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<Checklist> checklists = invocation.getArgument(0);
+              ReflectionTestUtils.setField(checklists.get(0), "id", 601L);
+              return checklists;
+            });
 
-        AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "VI");
+    AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "VI");
 
-        // title은 2차 검증 결과로 교체됨
-        assertThat(result.title()).isEqualTo("[VI-검증] AI 제목");
-        // summary는 2차 검증 응답에 없으므로 파파고 1차 번역 결과를 사용
-        assertThat(result.summary()).isEqualTo("[VI] AI 요약");
+    // title은 2차 검증 결과로 교체됨
+    assertThat(result.title()).isEqualTo("[VI-검증] AI 제목");
+    // summary는 2차 검증 응답에 없으므로 파파고 1차 번역 결과를 사용
+    assertThat(result.summary()).isEqualTo("[VI] AI 요약");
 
-        // 체크리스트 content/detail도 파파고 번역 결과로 저장됨
-        verify(checklistRepository).saveAll(checklistsCaptor.capture());
-        Checklist savedChecklist = checklistsCaptor.getValue().get(0);
-        assertThat(savedChecklist.getContent()).isEqualTo("[VI] 준비물 확인");
-        assertThat(savedChecklist.getDetail()).isEqualTo("[VI] 체육복을 준비해 주세요.");
+    // 체크리스트 content/detail도 파파고 번역 결과로 저장됨
+    verify(checklistRepository).saveAll(checklistsCaptor.capture());
+    Checklist savedChecklist = checklistsCaptor.getValue().get(0);
+    assertThat(savedChecklist.getContent()).isEqualTo("[VI] 준비물 확인");
+    assertThat(savedChecklist.getDetail()).isEqualTo("[VI] 체육복을 준비해 주세요.");
 
-        // 캘린더 preview의 일정 제목도 파파고 번역 결과로 저장됨
-        verify(calendarPreviewRedisService)
-            .savePreview(eq(newsletterId), previewEventsCaptor.capture());
-        assertThat(previewEventsCaptor.getValue().get(0).title()).isEqualTo("[VI] 준비물 확인");
+    // 캘린더 preview의 일정 제목도 파파고 번역 결과로 저장됨
+    verify(calendarPreviewRedisService)
+        .savePreview(eq(newsletterId), previewEventsCaptor.capture());
+    assertThat(previewEventsCaptor.getValue().get(0).title()).isEqualTo("[VI] 준비물 확인");
 
-        // 대화 주제도 파파고 번역 결과로 저장됨
-        verify(conversationTopicRepository).saveAll(conversationTopicsCaptor.capture());
-        assertThat(conversationTopicsCaptor.getValue().get(0).getTopic())
-            .isEqualTo("[VI] 수영장에서 뭐가 제일 기대돼?");
-    }
+    // 대화 주제도 파파고 번역 결과로 저장됨
+    verify(conversationTopicRepository).saveAll(conversationTopicsCaptor.capture());
+    assertThat(conversationTopicsCaptor.getValue().get(0).getTopic())
+        .isEqualTo("[VI] 수영장에서 뭐가 제일 기대돼?");
+  }
 
-    @Test
-    void analyzeFallsBackToPapagoWhenRefineTranslationFails() {
-        Long newsletterId = 31L;
-        Newsletter newsletter =
-            Newsletter.builder()
-                .userId(41L)
-                .fileKey("newsletter.pdf")
-                .fileHash("hash")
-                .status(NewsletterStatus.PROCESSING)
-                .language("VI")
-                .build();
+  @Test
+  void analyzeFallsBackToPapagoWhenRefineTranslationFails() {
+    Long newsletterId = 31L;
+    Newsletter newsletter =
+        Newsletter.builder()
+            .userId(41L)
+            .fileKey("newsletter.pdf")
+            .fileHash("hash")
+            .status(NewsletterStatus.PROCESSING)
+            .language("VI")
+            .build();
 
-        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-        when(aiNewsletterClient.analyze("원문", "번역문", "VI", List.of()))
-            .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(), List.of(), Map.of()));
+    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+    when(aiNewsletterClient.analyze("원문", "번역문", "VI", List.of()))
+        .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(), List.of(), Map.of()));
 
-        when(papagoTranslateClient.translate(org.mockito.ArgumentMatchers.anyString(), eq("VI")))
-            .thenAnswer(invocation -> "[VI] " + invocation.getArgument(0));
+    when(papagoTranslateClient.translate(org.mockito.ArgumentMatchers.anyString(), eq("VI")))
+        .thenAnswer(invocation -> "[VI] " + invocation.getArgument(0));
 
-        // 2차 검증 호출이 실패하는 경우
-        when(aiNewsletterClient.refineTranslation(
+    // 2차 검증 호출이 실패하는 경우
+    when(aiNewsletterClient.refineTranslation(
             eq("원문"), eq("VI"), org.mockito.ArgumentMatchers.anyList()))
-            .thenThrow(new RuntimeException("AI 서버 오류"));
+        .thenThrow(new RuntimeException("AI 서버 오류"));
 
-        AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "VI");
+    AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "VI");
 
-        // 2차 검증 실패 시 파파고 1차 번역 결과를 그대로 사용
-        assertThat(result.title()).isEqualTo("[VI] AI 제목");
-        assertThat(result.summary()).isEqualTo("[VI] AI 요약");
-    }
-
+    // 2차 검증 실패 시 파파고 1차 번역 결과를 그대로 사용
+    assertThat(result.title()).isEqualTo("[VI] AI 제목");
+    assertThat(result.summary()).isEqualTo("[VI] AI 요약");
+  }
 }

--- a/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzerTest.java
+++ b/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterAiAnalyzerTest.java
@@ -2,8 +2,10 @@ package com.gachi.be.domain.newsletter.pipeline;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -14,7 +16,10 @@ import com.gachi.be.domain.checklist.repository.ChecklistRepository;
 import com.gachi.be.domain.newsletter.entity.Newsletter;
 import com.gachi.be.domain.newsletter.entity.enums.NewsletterStatus;
 import com.gachi.be.domain.newsletter.pipeline.AiNewsletterClient.AnalysisResponse;
+import com.gachi.be.domain.newsletter.pipeline.AiNewsletterClient.ConversationTopicItem;
 import com.gachi.be.domain.newsletter.pipeline.AiNewsletterClient.ExtractedItem;
+import com.gachi.be.domain.newsletter.pipeline.AiNewsletterClient.RefineFieldResponse;
+import com.gachi.be.domain.newsletter.pipeline.AiNewsletterClient.RefineTranslationResponse;
 import com.gachi.be.domain.newsletter.pipeline.NewsletterAiAnalyzer.AiAnalysisResult;
 import com.gachi.be.domain.newsletter.repository.ConversationTopicRepository;
 import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
@@ -33,238 +38,358 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class NewsletterAiAnalyzerTest {
 
-  @Mock private AiNewsletterClient aiNewsletterClient;
-  @Mock private ChecklistRepository checklistRepository;
-  @Mock private CalendarPreviewRedisService calendarPreviewRedisService;
-  @Mock private NewsletterRepository newsletterRepository;
-  @Mock private ConversationTopicRepository conversationTopicRepository;
+    @Mock private AiNewsletterClient aiNewsletterClient;
+    @Mock private ChecklistRepository checklistRepository;
+    @Mock private CalendarPreviewRedisService calendarPreviewRedisService;
+    @Mock private NewsletterRepository newsletterRepository;
+    @Mock private ConversationTopicRepository conversationTopicRepository;
+    @Mock private PapagoTranslateClient papagoTranslateClient;
 
-  @Captor private ArgumentCaptor<List<Checklist>> checklistsCaptor;
-  @Captor private ArgumentCaptor<List<CalendarPreviewEvent>> previewEventsCaptor;
+    @Captor private ArgumentCaptor<List<Checklist>> checklistsCaptor;
+    @Captor private ArgumentCaptor<List<CalendarPreviewEvent>> previewEventsCaptor;
+    @Captor
+    private ArgumentCaptor<List<com.gachi.be.domain.newsletter.entity.ConversationTopic>>
+        conversationTopicsCaptor;
 
-  @InjectMocks private NewsletterAiAnalyzer newsletterAiAnalyzer;
+    @InjectMocks private NewsletterAiAnalyzer newsletterAiAnalyzer;
 
-  @Test
-  void analyzeUsesAiTitleSummaryAndSavesItems() {
-    Long newsletterId = 10L;
-    Newsletter newsletter =
-        Newsletter.builder()
-            .userId(20L)
-            .fileKey("newsletter.pdf")
-            .fileHash("hash")
-            .status(NewsletterStatus.PROCESSING)
-            .language("KO")
-            .build();
+    @Test
+    void analyzeUsesAiTitleSummaryAndSavesItems() {
+        Long newsletterId = 10L;
+        Newsletter newsletter =
+            Newsletter.builder()
+                .userId(20L)
+                .fileKey("newsletter.pdf")
+                .fileHash("hash")
+                .status(NewsletterStatus.PROCESSING)
+                .language("KO")
+                .build();
 
-    ExtractedItem item =
-        new ExtractedItem(
-            "reminder",
-            "준비물 확인",
-            null,
-            "2026-05-25",
-            "Asia/Seoul",
-            "체육복을 준비해 주세요.",
-            "confirmed",
-            0.91,
-            false,
-            null,
-            List.of(new AiNewsletterClient.ChecklistItemDto("준비물 확인", "체육복을 준비해 주세요.")));
+        ExtractedItem item =
+            new ExtractedItem(
+                "reminder",
+                "준비물 확인",
+                null,
+                "2026-05-25",
+                "Asia/Seoul",
+                "체육복을 준비해 주세요.",
+                "confirmed",
+                0.91,
+                false,
+                null,
+                List.of(new AiNewsletterClient.ChecklistItemDto("준비물 확인", "체육복을 준비해 주세요.")));
 
-    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-    when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
-        .thenReturn(
-            new AnalysisResponse(
-                "AI 제목",
-                Map.of(" us ", " AI English title "),
-                "AI 요약",
-                List.of(item),
-                List.of(),
-                Map.of()));
-    when(checklistRepository.saveAll(anyList()))
-        .thenAnswer(
-            invocation -> {
-              List<Checklist> checklists = invocation.getArgument(0);
-              ReflectionTestUtils.setField(checklists.get(0), "id", 501L);
-              return checklists;
-            });
+        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+        when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
+            .thenReturn(
+                new AnalysisResponse(
+                    "AI 제목",
+                    Map.of(" us ", " AI English title "),
+                    "AI 요약",
+                    List.of(item),
+                    List.of(),
+                    Map.of()));
+        when(checklistRepository.saveAll(anyList()))
+            .thenAnswer(
+                invocation -> {
+                    List<Checklist> checklists = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(checklists.get(0), "id", 501L);
+                    return checklists;
+                });
 
-    AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
+        AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
 
-    assertThat(result.title()).isEqualTo("AI 제목");
-    assertThat(result.titleI18n()).containsEntry("US", "AI English title");
-    assertThat(result.summary()).isEqualTo("AI 요약");
+        assertThat(result.title()).isEqualTo("AI 제목");
+        assertThat(result.titleI18n()).containsEntry("US", "AI English title");
+        assertThat(result.summary()).isEqualTo("AI 요약");
 
-    verify(checklistRepository).saveAll(checklistsCaptor.capture());
+        verify(checklistRepository).saveAll(checklistsCaptor.capture());
 
-    List<Checklist> savedItems = checklistsCaptor.getValue();
-    assertThat(savedItems).hasSize(1);
-    assertThat(savedItems.get(0).getNewsletterId()).isEqualTo(newsletterId);
-    assertThat(savedItems.get(0).getUserId()).isEqualTo(20L);
-    assertThat(savedItems.get(0).getContent()).isEqualTo("준비물 확인");
-    assertThat(savedItems.get(0).getDetail()).isEqualTo("체육복을 준비해 주세요.");
-    assertThat(savedItems.get(0).getTargetDate()).isNull();
-    assertThat(savedItems.get(0).getTargetDateLabel()).isNull();
-    verify(calendarPreviewRedisService)
-        .savePreview(eq(newsletterId), previewEventsCaptor.capture());
-    List<CalendarPreviewEvent> previewEvents = previewEventsCaptor.getValue();
-    assertThat(previewEvents).hasSize(1);
-    assertThat(previewEvents.get(0).tempEventId()).isEqualTo("ai_evt_1");
-    assertThat(previewEvents.get(0).title()).isEqualTo("준비물 확인");
-    assertThat(previewEvents.get(0).extractedDate()).isEqualTo("2026-05-25");
-    assertThat(previewEvents.get(0).isDateExtracted()).isTrue();
-    assertThat(previewEvents.get(0).checklistIds()).containsExactly(501L);
-  }
+        List<Checklist> savedItems = checklistsCaptor.getValue();
+        assertThat(savedItems).hasSize(1);
+        assertThat(savedItems.get(0).getNewsletterId()).isEqualTo(newsletterId);
+        assertThat(savedItems.get(0).getUserId()).isEqualTo(20L);
+        assertThat(savedItems.get(0).getContent()).isEqualTo("준비물 확인");
+        assertThat(savedItems.get(0).getDetail()).isEqualTo("체육복을 준비해 주세요.");
+        assertThat(savedItems.get(0).getTargetDate()).isNull();
+        assertThat(savedItems.get(0).getTargetDateLabel()).isNull();
+        verify(calendarPreviewRedisService)
+            .savePreview(eq(newsletterId), previewEventsCaptor.capture());
+        List<CalendarPreviewEvent> previewEvents = previewEventsCaptor.getValue();
+        assertThat(previewEvents).hasSize(1);
+        assertThat(previewEvents.get(0).tempEventId()).isEqualTo("ai_evt_1");
+        assertThat(previewEvents.get(0).title()).isEqualTo("준비물 확인");
+        assertThat(previewEvents.get(0).extractedDate()).isEqualTo("2026-05-25");
+        assertThat(previewEvents.get(0).isDateExtracted()).isTrue();
+        assertThat(previewEvents.get(0).checklistIds()).containsExactly(501L);
 
-  @Test
-  void analyzeSkipsCalendarPreviewWhenDateIsNotConfirmed() {
-    Long newsletterId = 14L;
-    Newsletter newsletter =
-        Newsletter.builder()
-            .userId(24L)
-            .fileKey("newsletter.pdf")
-            .fileHash("hash")
-            .status(NewsletterStatus.PROCESSING)
-            .language("KO")
-            .build();
+        verify(papagoTranslateClient, never()).translate(anyString(), anyString());
+        verify(aiNewsletterClient, never()).refineTranslation(anyString(), anyString(), anyList());
+    }
 
-    ExtractedItem item =
-        new ExtractedItem(
-            "deadline",
-            "신청서 제출",
-            null,
-            "2026-05-25",
-            "Asia/Seoul",
-            "체험학습 3일 전까지 신청서를 제출해 주세요.",
-            "ambiguous",
-            0.7,
-            true,
-            "체험학습 날짜를 확인해 주세요.",
-            List.of());
+    @Test
+    void analyzeSkipsCalendarPreviewWhenDateIsNotConfirmed() {
+        Long newsletterId = 14L;
+        Newsletter newsletter =
+            Newsletter.builder()
+                .userId(24L)
+                .fileKey("newsletter.pdf")
+                .fileHash("hash")
+                .status(NewsletterStatus.PROCESSING)
+                .language("KO")
+                .build();
 
-    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-    when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
-        .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(item), List.of(), Map.of()));
-    newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
+        ExtractedItem item =
+            new ExtractedItem(
+                "deadline",
+                "신청서 제출",
+                null,
+                "2026-05-25",
+                "Asia/Seoul",
+                "체험학습 3일 전까지 신청서를 제출해 주세요.",
+                "ambiguous",
+                0.7,
+                true,
+                "체험학습 날짜를 확인해 주세요.",
+                List.of());
 
-    verify(calendarPreviewRedisService).deletePreview(newsletterId);
-  }
+        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+        when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
+            .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(item), List.of(), Map.of()));
+        newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
 
-  @Test
-  void analyzeContinuesWhenCalendarPreviewSaveFails() {
-    Long newsletterId = 15L;
-    Newsletter newsletter =
-        Newsletter.builder()
-            .userId(25L)
-            .fileKey("newsletter.pdf")
-            .fileHash("hash")
-            .status(NewsletterStatus.PROCESSING)
-            .language("KO")
-            .build();
+        verify(calendarPreviewRedisService).deletePreview(newsletterId);
+    }
 
-    ExtractedItem item =
-        new ExtractedItem(
-            "schedule",
-            "현장학습 참석",
-            null,
-            "2026-05-25",
-            "Asia/Seoul",
-            "5월 25일 현장학습에 참석합니다.",
-            "confirmed",
-            0.9,
-            false,
-            null,
-            List.of(new AiNewsletterClient.ChecklistItemDto("도시락 준비하기", "현장학습 당일 도시락을 준비해 주세요.")));
+    @Test
+    void analyzeContinuesWhenCalendarPreviewSaveFails() {
+        Long newsletterId = 15L;
+        Newsletter newsletter =
+            Newsletter.builder()
+                .userId(25L)
+                .fileKey("newsletter.pdf")
+                .fileHash("hash")
+                .status(NewsletterStatus.PROCESSING)
+                .language("KO")
+                .build();
 
-    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-    when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
-        .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(item), List.of(), Map.of()));
-    when(checklistRepository.saveAll(anyList()))
-        .thenAnswer(
-            invocation -> {
-              List<Checklist> checklists = invocation.getArgument(0);
-              ReflectionTestUtils.setField(checklists.get(0), "id", 502L);
-              return checklists;
-            });
-    doThrow(new RuntimeException("Redis down"))
-        .when(calendarPreviewRedisService)
-        .savePreview(eq(newsletterId), anyList());
+        ExtractedItem item =
+            new ExtractedItem(
+                "schedule",
+                "현장학습 참석",
+                null,
+                "2026-05-25",
+                "Asia/Seoul",
+                "5월 25일 현장학습에 참석합니다.",
+                "confirmed",
+                0.9,
+                false,
+                null,
+                List.of(new AiNewsletterClient.ChecklistItemDto("도시락 준비하기", "현장학습 당일 도시락을 준비해 주세요.")));
 
-    AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
+        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+        when(aiNewsletterClient.analyze("원문", "번역문", "KO", List.of()))
+            .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(item), List.of(), Map.of()));
+        when(checklistRepository.saveAll(anyList()))
+            .thenAnswer(
+                invocation -> {
+                    List<Checklist> checklists = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(checklists.get(0), "id", 502L);
+                    return checklists;
+                });
+        doThrow(new RuntimeException("Redis down"))
+            .when(calendarPreviewRedisService)
+            .savePreview(eq(newsletterId), anyList());
 
-    assertThat(result.title()).isEqualTo("AI 제목");
-    assertThat(result.summary()).isEqualTo("AI 요약");
-    verify(checklistRepository).saveAll(anyList());
-  }
+        AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "KO");
 
-  @Test
-  void analyzeFallsBackWhenAiTitleSummaryAreBlank() {
-    Long newsletterId = 11L;
-    Newsletter newsletter =
-        Newsletter.builder()
-            .userId(21L)
-            .fileKey("newsletter.pdf")
-            .fileHash("hash")
-            .status(NewsletterStatus.PROCESSING)
-            .language("KO")
-            .build();
+        assertThat(result.title()).isEqualTo("AI 제목");
+        assertThat(result.summary()).isEqualTo("AI 요약");
+        verify(checklistRepository).saveAll(anyList());
+    }
 
-    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-    when(aiNewsletterClient.analyze("가정통신문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
-        .thenReturn(new AnalysisResponse("  ", "  ", List.of(), List.of(), Map.of()));
+    @Test
+    void analyzeFallsBackWhenAiTitleSummaryAreBlank() {
+        Long newsletterId = 11L;
+        Newsletter newsletter =
+            Newsletter.builder()
+                .userId(21L)
+                .fileKey("newsletter.pdf")
+                .fileHash("hash")
+                .status(NewsletterStatus.PROCESSING)
+                .language("KO")
+                .build();
 
-    AiAnalysisResult result =
-        newsletterAiAnalyzer.analyze(newsletterId, "가정통신문 제목\n본문입니다.", "번역 요약 대상", "KO");
+        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+        when(aiNewsletterClient.analyze("가정통신문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
+            .thenReturn(new AnalysisResponse("  ", "  ", List.of(), List.of(), Map.of()));
 
-    assertThat(result.title()).isEqualTo("가정통신문 제목");
-    assertThat(result.summary()).isEqualTo("번역 요약 대상");
-    verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
-  }
+        AiAnalysisResult result =
+            newsletterAiAnalyzer.analyze(newsletterId, "가정통신문 제목\n본문입니다.", "번역 요약 대상", "KO");
 
-  @Test
-  void analyzeFallsBackOnlySummaryWhenAiSummaryIsBlank() {
-    Long newsletterId = 12L;
-    Newsletter newsletter =
-        Newsletter.builder()
-            .userId(22L)
-            .fileKey("newsletter.pdf")
-            .fileHash("hash")
-            .status(NewsletterStatus.PROCESSING)
-            .language("KO")
-            .build();
+        assertThat(result.title()).isEqualTo("가정통신문 제목");
+        assertThat(result.summary()).isEqualTo("번역 요약 대상");
+        verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
+    }
 
-    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-    when(aiNewsletterClient.analyze("원문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
-        .thenReturn(new AnalysisResponse("AI 제목", " ", List.of(), List.of(), Map.of()));
+    @Test
+    void analyzeFallsBackOnlySummaryWhenAiSummaryIsBlank() {
+        Long newsletterId = 12L;
+        Newsletter newsletter =
+            Newsletter.builder()
+                .userId(22L)
+                .fileKey("newsletter.pdf")
+                .fileHash("hash")
+                .status(NewsletterStatus.PROCESSING)
+                .language("KO")
+                .build();
 
-    AiAnalysisResult result =
-        newsletterAiAnalyzer.analyze(newsletterId, "원문 제목\n본문입니다.", "번역 요약 대상", "KO");
+        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+        when(aiNewsletterClient.analyze("원문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
+            .thenReturn(new AnalysisResponse("AI 제목", " ", List.of(), List.of(), Map.of()));
 
-    assertThat(result.title()).isEqualTo("AI 제목");
-    assertThat(result.summary()).isEqualTo("번역 요약 대상");
-    verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
-  }
+        AiAnalysisResult result =
+            newsletterAiAnalyzer.analyze(newsletterId, "원문 제목\n본문입니다.", "번역 요약 대상", "KO");
 
-  @Test
-  void analyzeFallsBackOnlyTitleWhenAiTitleIsBlank() {
-    Long newsletterId = 13L;
-    Newsletter newsletter =
-        Newsletter.builder()
-            .userId(23L)
-            .fileKey("newsletter.pdf")
-            .fileHash("hash")
-            .status(NewsletterStatus.PROCESSING)
-            .language("KO")
-            .build();
+        assertThat(result.title()).isEqualTo("AI 제목");
+        assertThat(result.summary()).isEqualTo("번역 요약 대상");
+        verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
+    }
 
-    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
-    when(aiNewsletterClient.analyze("원문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
-        .thenReturn(new AnalysisResponse("", "AI 요약", List.of(), List.of(), Map.of()));
+    @Test
+    void analyzeFallsBackOnlyTitleWhenAiTitleIsBlank() {
+        Long newsletterId = 13L;
+        Newsletter newsletter =
+            Newsletter.builder()
+                .userId(23L)
+                .fileKey("newsletter.pdf")
+                .fileHash("hash")
+                .status(NewsletterStatus.PROCESSING)
+                .language("KO")
+                .build();
 
-    AiAnalysisResult result =
-        newsletterAiAnalyzer.analyze(newsletterId, "원문 제목\n본문입니다.", "번역 요약 대상", "KO");
+        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+        when(aiNewsletterClient.analyze("원문 제목\n본문입니다.", "번역 요약 대상", "KO", List.of()))
+            .thenReturn(new AnalysisResponse("", "AI 요약", List.of(), List.of(), Map.of()));
 
-    assertThat(result.title()).isEqualTo("원문 제목");
-    assertThat(result.summary()).isEqualTo("AI 요약");
-    verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
-  }
+        AiAnalysisResult result =
+            newsletterAiAnalyzer.analyze(newsletterId, "원문 제목\n본문입니다.", "번역 요약 대상", "KO");
+
+        assertThat(result.title()).isEqualTo("원문 제목");
+        assertThat(result.summary()).isEqualTo("AI 요약");
+        verify(checklistRepository, org.mockito.Mockito.never()).saveAll(anyList());
+    }
+
+    @Test
+    void analyzeTranslatesAndRefinesDisplayTextsForNonKoLanguage() {
+        Long newsletterId = 30L;
+        Newsletter newsletter =
+            Newsletter.builder()
+                .userId(40L)
+                .fileKey("newsletter.pdf")
+                .fileHash("hash")
+                .status(NewsletterStatus.PROCESSING)
+                .language("VI")
+                .build();
+
+        ExtractedItem item =
+            new ExtractedItem(
+                "reminder",
+                "준비물 확인", // item_0_title (한국어)
+                null,
+                "2026-05-25",
+                "Asia/Seoul",
+                "체육복을 준비해 주세요.",
+                "confirmed",
+                0.91,
+                false,
+                null,
+                List.of(
+                    new AiNewsletterClient.ChecklistItemDto(
+                        "준비물 확인", // item_0_chk_0_content (한국어)
+                        "체육복을 준비해 주세요." // item_0_chk_0_detail (한국어)
+                    )));
+
+        ConversationTopicItem topic = new ConversationTopicItem("수영장에서 뭐가 제일 기대돼?"); // topic_0 (한국어)
+
+        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+        when(aiNewsletterClient.analyze("원문", "번역문", "VI", List.of()))
+            .thenReturn(
+                new AnalysisResponse(
+                    "AI 제목", Map.of(), "AI 요약", List.of(item), List.of(topic), Map.of()));
+
+        // 파파고 1차 번역: 한국어 → 베트남어 (간단히 "[VI] " 접두사로 표현)
+        when(papagoTranslateClient.translate(org.mockito.ArgumentMatchers.anyString(), eq("VI")))
+            .thenAnswer(invocation -> "[VI] " + invocation.getArgument(0));
+
+        // AI 서버 2차 검증: title만 교정하고 나머지는 파파고 번역 그대로 통과
+        when(aiNewsletterClient.refineTranslation(
+            eq("원문"), eq("VI"), org.mockito.ArgumentMatchers.anyList()))
+            .thenReturn(
+                new RefineTranslationResponse(
+                    List.of(new RefineFieldResponse("title", "[VI-검증] AI 제목"))));
+
+        when(checklistRepository.saveAll(anyList()))
+            .thenAnswer(
+                invocation -> {
+                    List<Checklist> checklists = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(checklists.get(0), "id", 601L);
+                    return checklists;
+                });
+
+        AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "VI");
+
+        // title은 2차 검증 결과로 교체됨
+        assertThat(result.title()).isEqualTo("[VI-검증] AI 제목");
+        // summary는 2차 검증 응답에 없으므로 파파고 1차 번역 결과를 사용
+        assertThat(result.summary()).isEqualTo("[VI] AI 요약");
+
+        // 체크리스트 content/detail도 파파고 번역 결과로 저장됨
+        verify(checklistRepository).saveAll(checklistsCaptor.capture());
+        Checklist savedChecklist = checklistsCaptor.getValue().get(0);
+        assertThat(savedChecklist.getContent()).isEqualTo("[VI] 준비물 확인");
+        assertThat(savedChecklist.getDetail()).isEqualTo("[VI] 체육복을 준비해 주세요.");
+
+        // 캘린더 preview의 일정 제목도 파파고 번역 결과로 저장됨
+        verify(calendarPreviewRedisService)
+            .savePreview(eq(newsletterId), previewEventsCaptor.capture());
+        assertThat(previewEventsCaptor.getValue().get(0).title()).isEqualTo("[VI] 준비물 확인");
+
+        // 대화 주제도 파파고 번역 결과로 저장됨
+        verify(conversationTopicRepository).saveAll(conversationTopicsCaptor.capture());
+        assertThat(conversationTopicsCaptor.getValue().get(0).getTopic())
+            .isEqualTo("[VI] 수영장에서 뭐가 제일 기대돼?");
+    }
+
+    @Test
+    void analyzeFallsBackToPapagoWhenRefineTranslationFails() {
+        Long newsletterId = 31L;
+        Newsletter newsletter =
+            Newsletter.builder()
+                .userId(41L)
+                .fileKey("newsletter.pdf")
+                .fileHash("hash")
+                .status(NewsletterStatus.PROCESSING)
+                .language("VI")
+                .build();
+
+        when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+        when(aiNewsletterClient.analyze("원문", "번역문", "VI", List.of()))
+            .thenReturn(new AnalysisResponse("AI 제목", "AI 요약", List.of(), List.of(), Map.of()));
+
+        when(papagoTranslateClient.translate(org.mockito.ArgumentMatchers.anyString(), eq("VI")))
+            .thenAnswer(invocation -> "[VI] " + invocation.getArgument(0));
+
+        // 2차 검증 호출이 실패하는 경우
+        when(aiNewsletterClient.refineTranslation(
+            eq("원문"), eq("VI"), org.mockito.ArgumentMatchers.anyList()))
+            .thenThrow(new RuntimeException("AI 서버 오류"));
+
+        AiAnalysisResult result = newsletterAiAnalyzer.analyze(newsletterId, "원문", "번역문", "VI");
+
+        // 2차 검증 실패 시 파파고 1차 번역 결과를 그대로 사용
+        assertThat(result.title()).isEqualTo("[VI] AI 제목");
+        assertThat(result.summary()).isEqualTo("[VI] AI 요약");
+    }
+
 }


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - AI 서버의 `/ai/newsletters/refine-translation` API를 이용한 2차 번역 보정 추가
  - 요약과 체크리스트 content·detail을 필드 ID로 요청·응답 매핑
  - 빈 필드와 잘못된 응답 필드를 제외하도록 응답 정규화
  - 2차 보정 결과가 있으면 1차 번역 결과를 교체
  - 2차 보정 실패 또는 응답 누락 시 1차 번역 결과 유지
  - 번역 보정 성공·누락·실패 상황에 대한 테스트 추가
- 관련 이슈: closes #152 

## 🌿 브랜치 정보

- **Source**: `fix/#152-translate-correct`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

- 지원 언어별 요약·체크리스트 번역 결과와 2차 보정 fallback 동작 확인
<img width="1141" height="733" alt="스크린샷 2026-06-12 053259" src="https://github.com/user-attachments/assets/a5f0630f-18c1-4208-89e2-7cd18fef0fcb" />
<img width="1167" height="398" alt="스크린샷 2026-06-12 053314" src="https://github.com/user-attachments/assets/3896a868-7e42-4a39-8959-a9299154271e" />
<img width="1144" height="638" alt="스크린샷 2026-06-12 053322" src="https://github.com/user-attachments/assets/a67fc2e7-c895-435e-ab74-78807ac8fc6d" />
<img width="1156" height="736" alt="스크린샷 2026-06-12 053327" src="https://github.com/user-attachments/assets/74830190-04aa-41f1-81dc-3a34281a9baa" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 비한국어 뉴스레터에 AI 기반 2단계 번역 검증 기능 추가
  * 1차 자동 번역 후 AI 서버를 통한 2차 교정으로 번역 품질 향상
  * 번역 검증 실패 시 자동으로 1차 번역 결과로 폴백하여 안정성 강화

* **Tests**
  * 신규 번역 검증 흐름에 대한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->