### PR TITLE
fix: 업로드 용량 제한 및 급식 인원수 파싱 보완

### DIFF
--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -1,6 +1,9 @@
 events {}
 
 http {
+  # 실기기 촬영 이미지는 1MB를 쉽게 넘으므로 백엔드 multipart 한도와 맞춥니다.
+  client_max_body_size 10m;
+
   upstream backend_upstream {
     server backend:8080;
   }

--- a/deploy/nginx/nginx.https.template.conf
+++ b/deploy/nginx/nginx.https.template.conf
@@ -1,6 +1,9 @@
 events {}
 
 http {
+  # 실기기 촬영 이미지는 1MB를 쉽게 넘으므로 백엔드 multipart 한도와 맞춥니다.
+  client_max_body_size 10m;
+
   upstream backend_upstream {
     server backend:8080;
   }

--- a/src/main/java/com/gachi/be/domain/school/client/NeisSchoolMealClient.java
+++ b/src/main/java/com/gachi/be/domain/school/client/NeisSchoolMealClient.java
@@ -7,6 +7,7 @@ import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.config.external.NeisProperties;
 import com.gachi.be.global.exception.ExternalApiException;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -240,7 +241,23 @@ public class NeisSchoolMealClient {
     try {
       return Integer.valueOf(value);
     } catch (NumberFormatException e) {
+      Integer decimalInteger = parseDecimalInteger(value);
+      if (decimalInteger != null) {
+        return decimalInteger;
+      }
       log.warn("[NEIS] 급식 인원수 형식 오류. value={}", value);
+      return null;
+    }
+  }
+
+  private Integer parseDecimalInteger(String value) {
+    try {
+      BigDecimal decimal = new BigDecimal(value).stripTrailingZeros();
+      if (decimal.scale() > 0) {
+        return null;
+      }
+      return decimal.intValueExact();
+    } catch (ArithmeticException | NumberFormatException e) {
       return null;
     }
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     name: GACHI-BE
   profiles:
     default: dev
+  servlet:
+    multipart:
+      max-file-size: ${SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE:10MB}
+      max-request-size: ${SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE:10MB}
   data:
     redis:
       host: ${REDIS_HOST:localhost}

--- a/src/test/java/com/gachi/be/domain/school/client/NeisSchoolMealClientTest.java
+++ b/src/test/java/com/gachi/be/domain/school/client/NeisSchoolMealClientTest.java
@@ -58,7 +58,7 @@ class NeisSchoolMealClientTest {
                         "MMEAL_SC_CODE": "2",
                         "MMEAL_SC_NM": "중식",
                         "MLSV_YMD": "20260302",
-                        "MLSV_FGR": "123",
+                        "MLSV_FGR": "123.0",
                         "DDISH_NM": "현미밥<br/>미역국",
                         "ORPLC_INFO": "쌀 : 국내산",
                         "CAL_INFO": "612.3 Kcal",

--- a/src/test/java/com/gachi/be/domain/school/client/NeisSchoolMealClientTest.java
+++ b/src/test/java/com/gachi/be/domain/school/client/NeisSchoolMealClientTest.java
@@ -117,6 +117,65 @@ class NeisSchoolMealClientTest {
   }
 
   @Test
+  void searchParsesOnlyIntegerLikeDecimalMealPeopleCount() throws IOException {
+    startServer();
+    server.createContext(
+        "/hub/mealServiceDietInfo",
+        exchange ->
+            sendResponse(
+                exchange,
+                200,
+                """
+                {
+                  "mealServiceDietInfo": [
+                    {
+                      "head": [
+                        {"list_total_count": 3},
+                        {"RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."}}
+                      ]
+                    },
+                    {
+                      "row": [
+                        {
+                          "MMEAL_SC_CODE": "2",
+                          "MMEAL_SC_NM": "중식",
+                          "MLSV_YMD": "20260302",
+                          "MLSV_FGR": "123.0",
+                          "DDISH_NM": "현미밥"
+                        },
+                        {
+                          "MMEAL_SC_CODE": "2",
+                          "MMEAL_SC_NM": "중식",
+                          "MLSV_YMD": "20260303",
+                          "MLSV_FGR": "123.5",
+                          "DDISH_NM": "보리밥"
+                        },
+                        {
+                          "MMEAL_SC_CODE": "2",
+                          "MMEAL_SC_NM": "중식",
+                          "MLSV_YMD": "20260304",
+                          "MLSV_FGR": "999999999999.0",
+                          "DDISH_NM": "흑미밥"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """
+                    .getBytes(StandardCharsets.UTF_8)));
+
+    NeisSchoolMealClient client = newClient("meal-key");
+
+    var meals =
+        client.search("B10", "7051173", LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+    assertThat(meals).hasSize(3);
+    assertThat(meals.get(0).mealPeopleCount()).isEqualTo(123);
+    assertThat(meals.get(1).mealPeopleCount()).isNull();
+    assertThat(meals.get(2).mealPeopleCount()).isNull();
+  }
+
+  @Test
   void searchThrowsExternalApiExceptionWhenMealApiKeyIsMissing() {
     NeisSchoolMealClient client = newClient(null);
 


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 운영 Nginx 업로드 요청 본문 제한을 `10m`으로 상향
  - Spring multipart 기본 업로드 제한을 `10MB`로 설정
  - 실기기 촬영 이미지 업로드 시 1MB 초과 요청이 Nginx에서 `413 Request Entity Too Large`로 차단되던 문제 수정
  - NEIS 급식 인원수 값이 `235.0`처럼 정수형 소수 문자열로 내려오는 경우 정수로 안전하게 파싱하도록 보완
  - NEIS 급식 인원수 파싱 테스트에 소수점 포함 응답 케이스 추가 
- 관련 이슈: closes #157 

## 🌿 브랜치 정보

- **Source**: `bugfix/#157-upload-limit-meal-count`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

```powershell
.\gradlew.bat --no-daemon spotlessCheck
.\gradlew.bat --no-daemon test --tests "com.gachi.be.domain.school.client.NeisSchoolMealClientTest"
.\gradlew.bat --no-daemon test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Bug Fixes**
  * 급식 데이터 파싱 안정성을 개선하여 다양한 형식의 수치 입력을 올바르게 처리합니다.

* **Chores**
  * 파일 업로드 크기 제한을 최대 10MB로 설정하여 이미지 등 대용량 파일 업로드를 지원합니다.
  * 서버 설정을 환경변수로 제어 가능하도록 개선합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->