### PR TITLE
fix: 재촬영 가정통신문 중복 업로드 방지

### DIFF
--- a/src/main/java/com/gachi/be/domain/newsletter/entity/Newsletter.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/entity/Newsletter.java
@@ -52,6 +52,9 @@ public class Newsletter {
   @Column(name = "file_hash", nullable = false, length = 64)
   private String fileHash;
 
+  @Column(name = "content_hash", length = 64)
+  private String contentHash;
+
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 20)
   private NewsletterStatus status;
@@ -186,6 +189,11 @@ public class Newsletter {
     this.originalText = originalText;
     this.translatedText = translatedText;
     fail(failureStage, failureReason);
+  }
+
+  /** OCR 결과 기반 본문 해시를 저장합니다. 재촬영처럼 파일 해시가 달라도 같은 문서인지 판단하기 위한 값입니다. */
+  public void updateContentHash(String contentHash) {
+    this.contentHash = contentHash;
   }
 
   /** 실패한 분석을 사용자가 다시 시도할 때 이전 실패 사유를 비우고 대기 상태로 되돌립니다. */

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterContentHasher.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterContentHasher.java
@@ -1,0 +1,40 @@
+package com.gachi.be.domain.newsletter.pipeline;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.Normalizer;
+import java.util.HexFormat;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/** OCR 정제 본문으로 가정통신문 내용 중복 판단용 해시를 생성합니다. */
+@Component
+public class NewsletterContentHasher {
+
+  private static final int MIN_NORMALIZED_LENGTH = 30;
+
+  public Optional<String> hash(String text) {
+    String normalized = normalize(text);
+    if (normalized.length() < MIN_NORMALIZED_LENGTH) {
+      return Optional.empty();
+    }
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hashed = digest.digest(normalized.getBytes(StandardCharsets.UTF_8));
+      return Optional.of(HexFormat.of().formatHex(hashed));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 알고리즘을 사용할 수 없습니다.", e);
+    }
+  }
+
+  private String normalize(String text) {
+    if (text == null || text.isBlank()) {
+      return "";
+    }
+    return Normalizer.normalize(text, Normalizer.Form.NFKC)
+        .toLowerCase(Locale.ROOT)
+        .replaceAll("[^\\p{L}\\p{N}]", "");
+  }
+}

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineService.java
@@ -33,6 +33,7 @@ public class NewsletterPipelineService {
   private final NewsletterAiAnalyzer newsletterAiAnalyzer;
   private final NewsletterDateCandidateService newsletterDateCandidateService;
   private final NewsletterPipelineStatusService newsletterPipelineStatusService;
+  private final NewsletterContentHasher newsletterContentHasher;
 
   @Async
   public void runPipeline(Long newsletterId) {
@@ -89,6 +90,12 @@ public class NewsletterPipelineService {
       failureStage = "TEXT_REFINE";
       log.debug("[Pipeline][STEP5] 텍스트 정제 및 날짜 후보 추출 시작.");
       originalText = ocrTextRefiner.refineText(ocrText);
+      String contentHash = newsletterContentHasher.hash(originalText).orElse(null);
+      if (newsletterPipelineStatusService.markFailedIfContentDuplicated(
+          newsletterId, ocrText, originalText, contentHash)) {
+        log.info("[Pipeline] 본문 중복 가정통신문으로 분석을 중단합니다. newsletterId={}", newsletterId);
+        return;
+      }
       newsletterDateCandidateService.extractAndReplace(newsletterId, originalText);
       log.debug("[Pipeline][STEP5] 정제 완료. length={}chars", originalText.length());
 

--- a/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusService.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusService.java
@@ -2,12 +2,14 @@ package com.gachi.be.domain.newsletter.pipeline;
 
 import com.gachi.be.domain.child.repository.ChildRepository;
 import com.gachi.be.domain.newsletter.entity.Newsletter;
+import com.gachi.be.domain.newsletter.entity.enums.NewsletterStatus;
 import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
 import com.gachi.be.domain.notification.entity.enums.NotificationLevel;
 import com.gachi.be.domain.notification.entity.enums.NotificationType;
 import com.gachi.be.domain.notification.service.NotificationCreateCommand;
 import com.gachi.be.domain.notification.service.NotificationService;
 import com.gachi.be.domain.notification.service.NotificationTemplateKey;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,10 +27,14 @@ import org.springframework.transaction.support.TransactionTemplate;
 @RequiredArgsConstructor
 public class NewsletterPipelineStatusService {
 
+  private static final List<NewsletterStatus> CONTENT_DUPLICATE_TARGET_STATUSES =
+      List.of(NewsletterStatus.PENDING, NewsletterStatus.PROCESSING, NewsletterStatus.COMPLETED);
+
   private final NewsletterRepository newsletterRepository;
   private final NotificationService notificationService;
   private final ChildRepository childRepository;
   private final PlatformTransactionManager transactionManager;
+  private final NewsletterContentHasher newsletterContentHasher;
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void markProcessing(Long newsletterId) {
@@ -39,6 +45,58 @@ public class NewsletterPipelineStatusService {
               newsletter.startProcessing();
               newsletterRepository.save(newsletter);
             });
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public boolean markFailedIfContentDuplicated(
+      Long newsletterId, String ocrText, String originalText, String contentHash) {
+    if (contentHash == null || contentHash.isBlank()) {
+      return false;
+    }
+
+    return newsletterRepository
+        .findById(newsletterId)
+        .map(
+            newsletter -> {
+              boolean duplicated =
+                  hasDuplicateContentHash(newsletterId, newsletter, contentHash)
+                      || hasLegacyDuplicateContentHash(newsletterId, newsletter, contentHash);
+              newsletter.updateContentHash(contentHash);
+              if (duplicated) {
+                newsletter.failWithSnapshot(
+                    ocrText, originalText, null, "CONTENT_DUPLICATE", "동일한 내용의 가정통신문이 이미 존재합니다.");
+              }
+              newsletterRepository.save(newsletter);
+              return duplicated;
+            })
+        .orElse(false);
+  }
+
+  private boolean hasDuplicateContentHash(
+      Long newsletterId, Newsletter newsletter, String contentHash) {
+    return newsletterRepository.existsDuplicateContentHash(
+        newsletterId,
+        newsletter.getUserId(),
+        newsletter.getChildName(),
+        contentHash,
+        CONTENT_DUPLICATE_TARGET_STATUSES);
+  }
+
+  private boolean hasLegacyDuplicateContentHash(
+      Long newsletterId, Newsletter newsletter, String contentHash) {
+    List<Newsletter> candidates =
+        newsletterRepository.findLegacyContentHashCandidates(
+            newsletterId,
+            newsletter.getUserId(),
+            newsletter.getChildName(),
+            CONTENT_DUPLICATE_TARGET_STATUSES);
+    if (candidates == null || candidates.isEmpty()) {
+      return false;
+    }
+    return candidates.stream()
+        .map(Newsletter::getOriginalText)
+        .map(newsletterContentHasher::hash)
+        .anyMatch(candidateHash -> candidateHash.filter(contentHash::equals).isPresent());
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
+++ b/src/main/java/com/gachi/be/domain/newsletter/repository/NewsletterRepository.java
@@ -22,6 +22,46 @@ public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
   /** 자녀 미선택(child_name=NULL) 가정통신문 중 동일 파일 해시 존재 여부 확인 (중복 방지). */
   Optional<Newsletter> findByUserIdAndChildNameIsNullAndFileHash(Long userId, String fileHash);
 
+  @Query(
+      """
+      SELECT COUNT(n) > 0
+      FROM Newsletter n
+      WHERE n.id <> :newsletterId
+        AND n.userId = :userId
+        AND n.contentHash = :contentHash
+        AND n.status IN :statuses
+        AND (
+          (:childName IS NULL AND n.childName IS NULL)
+          OR (:childName IS NOT NULL AND n.childName = :childName)
+        )
+      """)
+  boolean existsDuplicateContentHash(
+      @Param("newsletterId") Long newsletterId,
+      @Param("userId") Long userId,
+      @Param("childName") String childName,
+      @Param("contentHash") String contentHash,
+      @Param("statuses") List<NewsletterStatus> statuses);
+
+  @Query(
+      """
+      SELECT n
+      FROM Newsletter n
+      WHERE n.id <> :newsletterId
+        AND n.userId = :userId
+        AND n.contentHash IS NULL
+        AND n.originalText IS NOT NULL
+        AND n.status IN :statuses
+        AND (
+          (:childName IS NULL AND n.childName IS NULL)
+          OR (:childName IS NOT NULL AND n.childName = :childName)
+        )
+      """)
+  List<Newsletter> findLegacyContentHashCandidates(
+      @Param("newsletterId") Long newsletterId,
+      @Param("userId") Long userId,
+      @Param("childName") String childName,
+      @Param("statuses") List<NewsletterStatus> statuses);
+
   /** 특정 사용자·자녀 이름의 모든 newsletter의 child_color를 일괄 업데이트. */
   @Modifying
   @Query(

--- a/src/main/java/com/gachi/be/global/code/ErrorCode.java
+++ b/src/main/java/com/gachi/be/global/code/ErrorCode.java
@@ -179,7 +179,7 @@ public enum ErrorCode {
       HttpStatus.CONFLICT,
       "NL4091",
       "이미 업로드된 가정통신문입니다.",
-      "동일한 file_hash를 가진 가정통신문이 이미 존재함",
+      "동일한 file_hash 또는 content_hash를 가진 가정통신문이 이미 존재함",
       ErrorLogLevel.WARN),
   NEWSLETTER_FILE_EMPTY(
       HttpStatus.BAD_REQUEST, "NL4001", "파일이 비어있습니다.", "업로드 파일 null 또는 empty", ErrorLogLevel.WARN),

--- a/src/main/resources/db/migration/V23__newsletter_content_hash.sql
+++ b/src/main/resources/db/migration/V23__newsletter_content_hash.sql
@@ -1,0 +1,14 @@
+ALTER TABLE newsletter
+    ADD COLUMN IF NOT EXISTS content_hash VARCHAR(64) NULL;
+
+CREATE INDEX IF NOT EXISTS idx_newsletter_child_content_hash
+    ON newsletter (user_id, child_name, content_hash)
+    WHERE child_name IS NOT NULL
+      AND content_hash IS NOT NULL
+      AND status IN ('PENDING', 'PROCESSING', 'COMPLETED');
+
+CREATE INDEX IF NOT EXISTS idx_newsletter_no_child_content_hash
+    ON newsletter (user_id, content_hash)
+    WHERE child_name IS NULL
+      AND content_hash IS NOT NULL
+      AND status IN ('PENDING', 'PROCESSING', 'COMPLETED');

--- a/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterContentHasherTest.java
+++ b/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterContentHasherTest.java
@@ -1,0 +1,24 @@
+package com.gachi.be.domain.newsletter.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class NewsletterContentHasherTest {
+
+  private final NewsletterContentHasher hasher = new NewsletterContentHasher();
+
+  @Test
+  void hashReturnsSameValueWhenOnlyWhitespaceAndPunctuationDiffer() {
+    String first = "와글와글 베이커리 신청 안내\n제출 기한: 2026.06.20\n준비물: 앞치마";
+    String second = "와글와글 베이커리 신청 안내 - 제출 기한 2026-06-20 / 준비물 앞치마";
+
+    assertThat(hasher.hash(first)).isPresent();
+    assertThat(hasher.hash(first)).isEqualTo(hasher.hash(second));
+  }
+
+  @Test
+  void hashReturnsEmptyWhenTextIsTooShort() {
+    assertThat(hasher.hash("신청 안내")).isEmpty();
+  }
+}

--- a/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusServiceTest.java
+++ b/src/test/java/com/gachi/be/domain/newsletter/pipeline/NewsletterPipelineStatusServiceTest.java
@@ -97,6 +97,69 @@ class NewsletterPipelineStatusServiceTest {
     assertThat(transactionManager.rollbacks).isGreaterThanOrEqualTo(1);
   }
 
+  @Test
+  void markFailedIfContentDuplicatedStoresHashAndStopsPipeline() {
+    Newsletter newsletter = processingNewsletter(90L);
+    when(newsletterRepository.findById(90L)).thenReturn(Optional.of(newsletter));
+    when(newsletterRepository.existsDuplicateContentHash(anyLong(), anyLong(), any(), any(), any()))
+        .thenReturn(true);
+
+    boolean duplicated =
+        newsletterPipelineStatusService.markFailedIfContentDuplicated(
+            90L, "ocr text", "original text", "content-hash");
+
+    assertThat(duplicated).isTrue();
+    assertThat(newsletter.getContentHash()).isEqualTo("content-hash");
+    assertThat(newsletter.getStatus()).isEqualTo(NewsletterStatus.FAILED);
+    assertThat(newsletter.getFailureStage()).isEqualTo("CONTENT_DUPLICATE");
+    assertThat(newsletter.getFailureReason()).contains("동일한 내용");
+    verify(newsletterRepository).save(newsletter);
+  }
+
+  @Test
+  void markFailedIfContentDuplicatedOnlyStoresHashWhenUnique() {
+    Newsletter newsletter = processingNewsletter(91L);
+    when(newsletterRepository.findById(91L)).thenReturn(Optional.of(newsletter));
+    when(newsletterRepository.existsDuplicateContentHash(anyLong(), anyLong(), any(), any(), any()))
+        .thenReturn(false);
+
+    boolean duplicated =
+        newsletterPipelineStatusService.markFailedIfContentDuplicated(
+            91L, "ocr text", "original text", "content-hash");
+
+    assertThat(duplicated).isFalse();
+    assertThat(newsletter.getContentHash()).isEqualTo("content-hash");
+    assertThat(newsletter.getStatus()).isEqualTo(NewsletterStatus.PROCESSING);
+    assertThat(newsletter.getFailureStage()).isNull();
+    verify(newsletterRepository).save(newsletter);
+  }
+
+  @Test
+  void markFailedIfContentDuplicatedComparesLegacyOriginalTextWhenContentHashIsMissing() {
+    Newsletter newsletter = processingNewsletter(92L);
+    Newsletter legacy = processingNewsletter(93L);
+    legacy.complete(
+        "ocr", "와글와글 베이커리 신청 안내\n제출 기한: 2026.06.20\n준비물: 앞치마", null, "와글와글 베이커리", "summary");
+    when(newsletterRepository.findById(92L)).thenReturn(Optional.of(newsletter));
+    when(newsletterRepository.existsDuplicateContentHash(anyLong(), anyLong(), any(), any(), any()))
+        .thenReturn(false);
+    when(newsletterRepository.findLegacyContentHashCandidates(anyLong(), anyLong(), any(), any()))
+        .thenReturn(List.of(legacy));
+
+    String contentHash =
+        new NewsletterContentHasher()
+            .hash("와글와글 베이커리 신청 안내 - 제출 기한 2026-06-20 / 준비물 앞치마")
+            .orElseThrow();
+
+    boolean duplicated =
+        newsletterPipelineStatusService.markFailedIfContentDuplicated(
+            92L, "ocr text", "original text", contentHash);
+
+    assertThat(duplicated).isTrue();
+    assertThat(newsletter.getStatus()).isEqualTo(NewsletterStatus.FAILED);
+    assertThat(newsletter.getFailureStage()).isEqualTo("CONTENT_DUPLICATE");
+  }
+
   private Newsletter processingNewsletter(Long id) {
     Newsletter newsletter =
         Newsletter.builder()
@@ -119,9 +182,14 @@ class NewsletterPipelineStatusServiceTest {
         NewsletterRepository newsletterRepository,
         NotificationService notificationService,
         ChildRepository childRepository,
-        CapturingTransactionManager transactionManager) {
+        CapturingTransactionManager transactionManager,
+        NewsletterContentHasher newsletterContentHasher) {
       return new NewsletterPipelineStatusService(
-          newsletterRepository, notificationService, childRepository, transactionManager);
+          newsletterRepository,
+          notificationService,
+          childRepository,
+          transactionManager,
+          newsletterContentHasher);
     }
 
     @Bean
@@ -142,6 +210,11 @@ class NewsletterPipelineStatusServiceTest {
     @Bean
     CapturingTransactionManager transactionManager() {
       return new CapturingTransactionManager();
+    }
+
+    @Bean
+    NewsletterContentHasher newsletterContentHasher() {
+      return new NewsletterContentHasher();
     }
   }
 


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 재촬영으로 파일 해시가 달라진 동일 가정통신문도 중복으로 감지하도록 OCR 정제 본문 기반 `content_hash` 추가
  - OCR 정제 직후 본문 해시를 계산하고, 같은 사용자/자녀 기준으로 동일 내용 문서가 있으면 파이프라인을 중단하도록 처리
  - 중복 본문으로 판정된 문서는 `FAILED / CONTENT_DUPLICATE` 상태와 실패 사유를 저장하도록 처리
  - 기존 완료 문서 중 `content_hash`가 비어 있는 데이터도 `original_text` 기반 fallback 비교로 중복 감지
  - `newsletter.content_hash` 컬럼 및 조회 인덱스 추가
  - 기존 중복 에러 코드 `NL4091` 설명을 파일 해시 또는 본문 해시 중복으로 갱신
  - 본문 해시 생성 및 중복 판정 단위 테스트 추가
- 관련 이슈: closes #162 

## 🌿 브랜치 정보

- **Source**: `bugfix/#162-newsletter-content-dedup`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

```powershell
.\gradlew.bat --no-daemon test
.\gradlew.bat --no-daemon spotlessCheck
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 콘텐츠 해시 기반 가정통신문 중복 감지 기능 추가
  * 중복 콘텐츠 감지 시 파이프라인 조기 종료로 불필요한 처리 단계 스킵

* **Bug Fixes**
  * 중복 판정 기준 확장: 기존 file_hash뿐만 아니라 content_hash도 검사

* **Chores**
  * 데이터베이스 스키마 업데이트 및 성능 최적화 인덱스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->