### PR TITLE
feat: 홈 화면 오늘 마감 체크리스트 다국어 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+
+    systemProperty 'http.keepAlive', 'false'
+    systemProperty 'jdk.httpclient.keepalive.timeout', '0'
 }
 
 spotless {

--- a/src/main/java/com/gachi/be/domain/checklist/dto/response/ChecklistTodayItem.java
+++ b/src/main/java/com/gachi/be/domain/checklist/dto/response/ChecklistTodayItem.java
@@ -1,18 +1,21 @@
 package com.gachi.be.domain.checklist.dto.response;
 
 import com.gachi.be.domain.checklist.entity.Checklist;
+import com.gachi.be.global.util.I18nTextResolver;
 
 /** 오늘 마감 미완료 체크리스트 */
 public record ChecklistTodayItem(
     Long checklistId, String content, String detail, String newsletterTitle, String childName) {
 
-  public static ChecklistTodayItem of(
-      Checklist checklist, String newsletterTitle, String childName) {
-    return new ChecklistTodayItem(
-        checklist.getId(),
-        checklist.getContent(),
-        checklist.getDetail(),
-        newsletterTitle,
-        childName);
-  }
+    public static ChecklistTodayItem of(
+        Checklist checklist, String newsletterTitle, String childName, String language) {
+
+        String content =
+            I18nTextResolver.resolve(checklist.getContentI18n(), language, checklist.getContent());
+        String detail =
+            I18nTextResolver.resolve(checklist.getDetailI18n(), language, checklist.getDetail());
+
+        return new ChecklistTodayItem(
+            checklist.getId(), content, detail, newsletterTitle, childName);
+    }
 }

--- a/src/main/java/com/gachi/be/domain/checklist/dto/response/ChecklistTodayItem.java
+++ b/src/main/java/com/gachi/be/domain/checklist/dto/response/ChecklistTodayItem.java
@@ -7,15 +7,14 @@ import com.gachi.be.global.util.I18nTextResolver;
 public record ChecklistTodayItem(
     Long checklistId, String content, String detail, String newsletterTitle, String childName) {
 
-    public static ChecklistTodayItem of(
-        Checklist checklist, String newsletterTitle, String childName, String language) {
+  public static ChecklistTodayItem of(
+      Checklist checklist, String newsletterTitle, String childName, String language) {
 
-        String content =
-            I18nTextResolver.resolve(checklist.getContentI18n(), language, checklist.getContent());
-        String detail =
-            I18nTextResolver.resolve(checklist.getDetailI18n(), language, checklist.getDetail());
+    String content =
+        I18nTextResolver.resolve(checklist.getContentI18n(), language, checklist.getContent());
+    String detail =
+        I18nTextResolver.resolve(checklist.getDetailI18n(), language, checklist.getDetail());
 
-        return new ChecklistTodayItem(
-            checklist.getId(), content, detail, newsletterTitle, childName);
-    }
+    return new ChecklistTodayItem(checklist.getId(), content, detail, newsletterTitle, childName);
+  }
 }

--- a/src/main/java/com/gachi/be/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -151,11 +151,12 @@ public class ChecklistServiceImpl implements ChecklistService {
         checklistId,
         checklist.getType());
   }
-    private String resolveUserLanguage(Long userId) {
-        return userRepository
-            .findById(userId)
-            .map(User::getLanguageCode)
-            .filter(code -> code != null && !code.isBlank())
-            .orElse(I18nTextResolver.DEFAULT_LANGUAGE);
-    }
+
+  private String resolveUserLanguage(Long userId) {
+    return userRepository
+        .findById(userId)
+        .map(User::getLanguageCode)
+        .filter(code -> code != null && !code.isBlank())
+        .orElse(I18nTextResolver.DEFAULT_LANGUAGE);
+  }
 }

--- a/src/main/java/com/gachi/be/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/gachi/be/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -10,8 +10,11 @@ import com.gachi.be.domain.checklist.entity.enums.ChecklistType;
 import com.gachi.be.domain.checklist.repository.ChecklistRepository;
 import com.gachi.be.domain.checklist.service.ChecklistService;
 import com.gachi.be.domain.newsletter.repository.NewsletterRepository;
+import com.gachi.be.domain.user.entity.User;
+import com.gachi.be.domain.user.repository.UserRepository;
 import com.gachi.be.global.code.ErrorCode;
 import com.gachi.be.global.exception.BusinessException;
+import com.gachi.be.global.util.I18nTextResolver;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -32,6 +35,7 @@ public class ChecklistServiceImpl implements ChecklistService {
   private final ChecklistRepository checklistRepository;
   private final CalendarEventRepository calendarEventRepository;
   private final NewsletterRepository newsletterRepository;
+  private final UserRepository userRepository;
   private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
   private static final ZoneOffset KST_OFFSET = ZoneOffset.ofHours(9);
 
@@ -39,6 +43,7 @@ public class ChecklistServiceImpl implements ChecklistService {
   @Override
   @Transactional(readOnly = true)
   public ChecklistTodayResponse getTodayChecklists(Long userId) {
+    String language = resolveUserLanguage(userId);
 
     // KST 오늘 날짜 범위 계산
     LocalDate todayKst = LocalDate.now(KST_ZONE);
@@ -93,7 +98,7 @@ public class ChecklistServiceImpl implements ChecklistService {
                   CalendarEvent linkedEvent = eventMap.get(c.getCalendarEventId());
                   String childName = linkedEvent != null ? linkedEvent.getChildName() : null;
 
-                  return ChecklistTodayItem.of(c, newsletterTitle, childName);
+                  return ChecklistTodayItem.of(c, newsletterTitle, childName, language);
                 })
             .toList();
 
@@ -146,4 +151,11 @@ public class ChecklistServiceImpl implements ChecklistService {
         checklistId,
         checklist.getType());
   }
+    private String resolveUserLanguage(Long userId) {
+        return userRepository
+            .findById(userId)
+            .map(User::getLanguageCode)
+            .filter(code -> code != null && !code.isBlank())
+            .orElse(I18nTextResolver.DEFAULT_LANGUAGE);
+    }
 }


### PR DESCRIPTION
## 📌 작업 요약

- 요약:
  - 홈 화면의 오늘 마감 미완료 체크리스트 조회에 사용자 언어 설정 적용
  - 체크리스트 content와 detail을 사용자 언어에 맞게 반환
  - 요청 언어 번역이 없으면 KO 번역값 또는 기존 원문으로 fallback

- 부수 변경:
  - 테스트 실행 시 HTTP 연결이 남아 종료가 지연되는 것을 방지하도록 test task에서 HTTP keep-alive 비활성화

- 관련 이슈: closes #166 

## 🌿 브랜치 정보

- **Source**: `feat/#166-home-translate`
- **Target**: `develop`

## ✅ 체크리스트

- [x] 브랜치 컨벤션 준수 (`feat/refac/hotfix/chore/design/bugfix`)
- [x] 커밋 컨벤션 준수 (`feat/fix/refactor/docs/style/chore`)
- [x] self-review 완료
- [x] 테스트 및 로컬 실행 확인 완료

## 🧪 테스트 결과

- 사용자 언어 설정에 따라 오늘 마감 체크리스트의 content와 detail이 번역되어 반환되는 것을 확인
<img width="1156" height="716" alt="스크린샷 2026-06-13 182047" src="https://github.com/user-attachments/assets/342d05ab-366a-4976-b09f-733b38e7bd47" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 프로필의 언어 설정에 따라 오늘 마감인 체크리스트 항목의 제목과 상세 설명이 자동으로 해당 언어로 표시됩니다. 언어 설정이 없는 경우 기본 언어가 적용됩니다.

* **Chores**
  * 테스트 실행 후 HTTP 연결로 인한 종료 지연을 방지하도록 test task의 keep-alive 설정을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->